### PR TITLE
Add missing numeric header.

### DIFF
--- a/src/wrappers.hpp
+++ b/src/wrappers.hpp
@@ -20,10 +20,11 @@
 #define WRAPPERS_H
 
 #include <algorithm>
-#include <complex>
 #include <cmath>
+#include <complex>
 #include <functional>
 #include <limits>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
Also sort alphabetically std headers.

This header is required to std::accumulate.