### PR TITLE
Fix some outstanding issues with CXXDiagrams.

### DIFF
--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -343,6 +343,22 @@ VertexFunctionBodyForFieldsImpl[fields_List, vertexList_List] :=
     ]
   ]
 
+DeclareIndices[indexedFields_List, arrayName_String] :=
+    Module[{p, total = 0, fieldIndexList, decl = ""},
+           DeclareIndex[idx_, num_Integer, an_String] := (
+               "const int " <> CConversion`ToValidCSymbolString[idx] <>
+               " = " <> an <> "[" <> ToString[num] <> "];\n");
+           For[p = 1, p <= Length[indexedFields], p++,
+               fieldIndexList = Vertices`FieldIndexList[indexedFields[[p]]];
+               decl = decl <> StringJoin[DeclareIndex[#, total++, arrayName]& /@ fieldIndexList];
+              ];
+           Assert[total == Total[Length[Vertices`FieldIndexList[#]]& /@ indexedFields]];
+           decl
+          ]
+
+GetComplexScalarCType[] :=
+    CConversion`CreateCType[CConversion`ScalarType[CConversion`complexScalarCType]]
+
 (* Get a mathematical expression of the requested vertex
    in terms of its canonically ordered vertex. *)
 CanonicalizeCoupling[

--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -215,7 +215,7 @@ CreateVertex[fields_List] :=
 
     "template<> inline\n" <> 
     functionClassName <> "::vertex_type\n" <>
-    functionClassName <> "::evaluate(const indices_type& indices, const EvaluationContext& context)\n" <>
+    functionClassName <> "::evaluate(const indices_type& indices, const ContextBase& context)\n" <>
     "{\n" <>
     TextFormatting`IndentText @ VertexFunctionBodyForFields[fields] <> "\n" <>
     "}"
@@ -382,7 +382,7 @@ CreateMassFunctions[] :=
              numberOfIndices = Length @ fieldInfo[[5]];
                                    
              "template<> inline\n" <>
-             "double EvaluationContext::mass_impl<" <>
+             "double ContextBase::mass_impl<" <>
                CXXNameOfField[#, prefixNamespace -> "fields"] <>
              ">(const std::array<int, " <> ToString @ numberOfIndices <>
              ">& indices) const\n" <>
@@ -401,7 +401,7 @@ CreateUnitCharge[] :=
          numberOfElectronIndices = NumberOfFieldIndices[electron];
          numberOfPhotonIndices = NumberOfFieldIndices[photon];
 
-         "static ChiralVertex unit_charge(const EvaluationContext& context)\n" <>
+         "static ChiralVertex unit_charge(const ContextBase& context)\n" <>
          "{\n" <>
          TextFormatting`IndentText["using vertex_type = ChiralVertex;"] <> "\n\n" <>
          TextFormatting`IndentText @ 

--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -533,6 +533,3 @@ FieldInfo[field_,OptionsPattern[{includeLorentzIndices -> False}]] :=
 
 End[];
 EndPackage[];
-
-
-

--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -1,3 +1,5 @@
+(* ::Package:: *)
+
 (* :Copyright:
 
    ====================================================================
@@ -24,7 +26,12 @@ BeginPackage["CXXDiagrams`", {"SARAH`", "TextFormatting`", "TreeMasses`", "Verti
 
 (* This module generates c++ code intended to be used similarly to SARAH's fields and Vertex[] function *)
 
-CXXDiagramsInitialize::usage="";
+(* Vertex types *)
+ScalarVertex::usage="";
+ChiralVertex::usage="";
+MomentumDifferenceVertex::usage="";
+InverseMetricVertex::usage="";
+
 VertexTypes::usage="";
 CXXNameOfField::usage="";
 LorentzConjugateOperation::usage="";
@@ -38,19 +45,17 @@ VertexRulesForVertices::usage="";
 CreateMassFunctions::usage="";
 CreateUnitCharge::usage="";
 NumberOfFieldIndices::usage="";
+FieldInfo::usage="";
+includeLorentzIndices::usage="";
 
 Begin["`Private`"];
 
-CXXDiagramsInitialize[] := LoadVerticesIfNecessary[]
-
-(* The supported vertex types.
- They have the same names as their c++ counterparts. *)
-vertexTypes = {
-    SingleComponentedVertex,
-    LeftAndRightComponentedVertex
+VertexTypes[] := {
+    ScalarVertex,
+    ChiralVertex,
+    MomentumDifferenceVertex,
+    InverseMetricVertex
 };
-
-VertexTypes[] := vertexTypes
 
 (* Return a string corresponding to the c++ class name of the field.
  Note that "bar" and "conj" get turned into bar<...>::type and
@@ -71,15 +76,27 @@ LorentzConjugate[field_] := SARAH`AntiField[field]
 AtomHead[x_] := If[AtomQ[x], x, AtomHead[Head[x]]]
 
 CreateFields[] :=
-  Module[{fields},
+  Module[{fields, scalars, fermions, vectors, ghosts},
        fields = TreeMasses`GetParticles[];
+       scalars = Select[fields, TreeMasses`IsScalar];
+       fermions = Select[fields, TreeMasses`IsFermion];
+       vectors = Select[fields, TreeMasses`IsVector];
+       ghosts = Select[fields, TreeMasses`IsGhost];
        
        StringJoin @ Riffle[
          ("struct " <> CXXNameOfField[#] <> " {\n" <>
             TextFormatting`IndentText[
+              "using index_bounds = boost::mpl::pair<\n" <>
+              "  boost::mpl::vector_c<int" <>
+                   StringJoin[", " <> ToString[#] & /@ 
+                     (IndexBoundsForField[#][[1]] - 1)] <> ">,\n" <>
+              "  boost::mpl::vector_c<int" <>
+                   StringJoin[", " <> ToString[#] & /@
+                     IndexBoundsForField[#][[2]]] <> ">\n" <>
+              ">;\n" <>
               "static constexpr int numberOfGenerations = " <>
                    ToString @ TreeMasses`GetDimension[#] <> ";\n" <>
-                     "using smFlags = boost::mpl::vector_c<bool, " <>
+                     "using sm_flags = boost::mpl::vector_c<bool, " <>
                         If[TreeMasses`GetDimension[#] === 1,
                            CXXBoolValue @ TreeMasses`IsSMParticle[#],
                            StringJoin @ Riffle[CXXBoolValue /@
@@ -103,7 +120,16 @@ CreateFields[] :=
          ("template<> struct " <> LorentzConjugateOperation[#] <> "<" <> CXXNameOfField[#] <> ">" <>
             " { using type = " <> CXXNameOfField[#] <> "; };"
             &) /@ Select[fields, (# == LorentzConjugate[#] &)],
-          "\n"] <> "\n"
+          "\n"] <> "\n\n" <>
+
+       "using scalars = boost::mpl::vector<" <>
+         StringJoin[Riffle[CXXNameOfField /@ scalars, ", "]] <> ">;\n" <>
+       "using fermions = boost::mpl::vector<" <>
+         StringJoin[Riffle[CXXNameOfField /@ fermions, ", "]] <> ">;\n" <>
+       "using vectors = boost::mpl::vector<" <>
+         StringJoin[Riffle[CXXNameOfField /@ vectors, ", "]] <> ">;\n" <>
+       "using ghosts = boost::mpl::vector<" <>
+         StringJoin[Riffle[CXXNameOfField /@ ghosts, ", "]] <> ">;"
   ]
 
 (* adjacencyMatrix must be undirected (i.e symmetric) *)
@@ -152,69 +178,174 @@ FeynmanDiagramsOfType[adjacencyMatrix_List,externalFields_List] :=
 
 VerticesForDiagram[diagram_] := Select[diagram,Length[#] > 1 &]
 
-VertexRulesForVertices[vertices_List, massMatrices_, OptionsPattern[{sortCouplings -> True}]] := 
-  Module[{nPointFunctions,sortCommand},
-    nPointFunctions = CXXDiagrams`NPointFunctions[IndexFields /@ vertices];
-    sortCommand = If[OptionValue[sortCouplings],Vertices`SortCps,Identity];
-    Vertices`VertexRules[sortCommand @ nPointFunctions, massMatrices]
-    ]
-
-NPointFunctions[vertices_List] :=
-  Module[{nPointFunctions},
-    nPointFunctions = Flatten[(Null[Null, #] &) /@ (CouplingsForFields /@ vertices)];
-    nPointFunctions = Cases[nPointFunctions,Except[Null[Null,{}]]]; (* Remove unknown vertices *)
-    DeleteDuplicates[nPointFunctions]
-  ]
-
-CreateVertexData[fields_List,vertexRules_List] := 
-  Module[{dataClassName,indexBounds,parsedVertex,fieldIndexStartF,fieldIndexStart},
-    parsedVertex = ParseVertex[fields, vertexRules];
-    indexBounds = IndexBounds[parsedVertex];
-    
-    fieldIndexStartF[1] = 0;
-    fieldIndexStartF[pIndex_] := fieldIndexStartF[pIndex-1] + NumberOfIndices[parsedVertex, pIndex-1];
-    fieldIndexStartF[Length[fields]+1] = NumberOfIndices[parsedVertex];
-           
-    fieldIndexStart = Table[fieldIndexStartF[i], {i, 1, Length[fields] + 1}];
-    
-    dataClassName = "VertexData<" <> StringJoin @ Riffle[CXXNameOfField /@ fields, ", "] <> ">";
+CreateVertexData[fields_List] := 
+  Module[{dataClassName},
+    dataClassName = "VertexData<" <> StringJoin[Riffle[
+      CXXNameOfField /@ fields,
+    ", "]] <> ">";
     
     "template<> struct " <> dataClassName <> "\n" <>
     "{\n" <>
     TextFormatting`IndentText[
-      "static constexpr impl::IndexBounds<" <> ToString @ NumberOfIndices[parsedVertex] <>
-        "> index_bounds" <>
-        If[NumberOfIndices[parsedVertex] =!= 0,
-           " = { " <>
-             "{ " <> StringJoin @ Riffle[ToString /@ indexBounds[[1]], ", "] <> " }, " <>
-             "{ " <> StringJoin @ Riffle[ToString /@ indexBounds[[2]], ", "] <> " } }",
-           "{}"
-        ] <> ";\n" <>
-      "static constexpr int fieldIndexStart[" <> ToString @ Length[fieldIndexStart] <>
-         "] = { " <> StringJoin @ Riffle[ToString /@ fieldIndexStart, ", "] <> " };\n" <>
-      "using vertex_type = " <> VertexClassName[parsedVertex] <> ";"] <> "\n" <>
+      "using vertex_type = " <> SymbolName[VertexTypeForFields[fields]] <>
+         ";"] <> "\n" <>
     "};"
   ]
 
 (* Returns the necessary c++ code corresponding to the vertices that need to be calculated.
  The returned value is a list {prototypes, definitions}. *)
-CreateVertices[vertices_List,vertexRules_List] :=
-  StringJoin @\[NonBreakingSpace]Riffle[CreateVertex[#, vertexRules] & /@ DeleteDuplicates[vertices],
-                      "\n\n"]
+CreateVertices[vertices_List] :=
+  StringJoin @ Riffle[CreateVertex /@ DeleteDuplicates[vertices], "\n\n"]
 
 (* Creates the actual c++ code for a vertex with given fields.
  You should never need to change this code! *)
-CreateVertex[fields_List, vertexRules_List] :=
-  Module[{parsedVertex, functionClassName},
-         parsedVertex = ParseVertex[fields, vertexRules];
-         functionClassName = "Vertex<" <> StringJoin @ Riffle[CXXNameOfField /@ fields, ", "] <> ">";
+CreateVertex[fields_List] :=
+  Module[{functionClassName},
+    LoadVerticesIfNecessary[];
+    functionClassName = "Vertex<" <> StringJoin @ Riffle[
+    CXXNameOfField /@ fields, ", "] <> ">";
+
+    "template<> inline\n" <> 
+    functionClassName <> "::vertex_type\n" <>
+    functionClassName <> "::evaluate(const indices_type& indices, const EvaluationContext& context)\n" <>
+    "{\n" <>
+    TextFormatting`IndentText @ VertexFunctionBodyForFields[fields] <> "\n" <>
+    "}"
+  ]
+
+VertexFunctionBodyForFields[fields_List] := 
+  Switch[Length[fields],
+         3, VertexFunctionBodyForFieldsImpl[fields, SARAH`VertexList3],
+         4, VertexFunctionBodyForFieldsImpl[fields, SARAH`VertexList4],
+         _, "non-(3,4)-point vertex"]
+
+VertexFunctionBodyForFieldsImpl[fields_List, vertexList_List] :=
+  Module[{sortedFields, sortedIndexedFields, indexedFields,
+          fieldsOrdering, sortedFieldsOrdering, inverseFOrdering,
+          fOrderingWRTSortedF, vertex, vExpression, vertexIsZero = False,
+          vertexType = VertexTypeForFields[fields], expr, exprL, exprR,
+          vertexRules, incomingScalar, outgoingScalar},
+    sortedFields = Vertices`SortFieldsInCp[fields];
+    
+    vertex = Select[vertexList, StripFieldIndices[#[[1]]] === sortedFields &, 1];
+    If[vertex === {}, vertexIsZero = True, vertex = vertex[[1]]];
+
+    If[vertexIsZero,
+       Return[Switch[vertexType,
+         ScalarVertex,
+         "return vertex_type(0);",
          
-         "template<> inline\n" <> 
-         functionClassName <> "::vertex_type\n" <>
-         functionClassName <> "::evaluate(const indices_type& indices, const EvaluationContext& context)\n" <>
-         "{\n" <>
-         TextFormatting`IndentText @ VertexFunctionBody[parsedVertex] <> "\n" <>
-         "}"
+         ChiralVertex,
+         "return vertex_type(0, 0);",
+         
+         MomentumDifferenceVertex,
+         "return vertex_type(0, " <> StringJoin[Riffle[
+            ToString /@ Flatten[Position[fields,
+               field_ /; TreeMasses`IsScalar[field] || TreeMasses`IsGhost[field],
+               {1}, Heads -> False] - 1],
+            ", "]] <> ");",
+         
+         InverseMetricVertex,
+         "return vertex_type(0);"]]];
+
+    sortedIndexedFields = vertex[[1]];
+    
+    (* Mathematica 7 does not know about permutations... :'-( *)
+    fieldsOrdering = Ordering[fields];
+    sortedFieldsOrdering = Ordering[sortedFields];
+
+    inverseFOrdering = Ordering[fieldsOrdering];
+    fOrderingWRTSortedF = sortedFieldsOrdering[[inverseFOrdering]];
+
+    indexedFields = sortedIndexedFields[[fOrderingWRTSortedF]];
+
+    Switch[vertexType,
+      ScalarVertex,
+      vertexRules = {(SARAH`Cp @@ sortedIndexedFields) ->
+        Vertices`FindVertexWithLorentzStructure[Rest[vertex], 1][[1]]};
+      
+      expr = CanonicalizeCoupling[SARAH`Cp @@ fields,
+        sortedFields, sortedIndexedFields] /. vertexRules;
+      
+      expr = Vertices`SarahToFSVertexConventions[sortedFields, expr];
+      expr = TreeMasses`ReplaceDependenciesReverse[expr];
+      DeclareIndices[StripLorentzIndices /@ indexedFields, "indices"] <>
+      Parameters`CreateLocalConstRefs[expr] <> "\n" <>
+      "const " <> GetComplexScalarCType[] <> " result = " <>
+      Parameters`ExpressionToString[expr] <> ";\n\n" <>
+      "return vertex_type(result);",
+      
+      ChiralVertex,
+      vertexRules = {
+        (SARAH`Cp @@ sortedIndexedFields)[SARAH`PL] ->
+          Vertices`FindVertexWithLorentzStructure[Rest[vertex], SARAH`PL][[1]],
+        (SARAH`Cp @@ sortedIndexedFields)[SARAH`PR] ->
+          Vertices`FindVertexWithLorentzStructure[Rest[vertex], SARAH`PR][[1]]};
+
+      exprL = CanonicalizeCoupling[(SARAH`Cp @@ fields)[SARAH`PL],
+        sortedFields, sortedIndexedFields] /. vertexRules;
+      exprR = CanonicalizeCoupling[(SARAH`Cp @@ fields)[SARAH`PR],
+        sortedFields, sortedIndexedFields] /. vertexRules;
+
+      exprL = Vertices`SarahToFSVertexConventions[sortedFields, exprL];
+      exprR = Vertices`SarahToFSVertexConventions[sortedFields, exprR];
+      exprL = TreeMasses`ReplaceDependenciesReverse[exprL];
+      exprR = TreeMasses`ReplaceDependenciesReverse[exprR];
+      DeclareIndices[StripLorentzIndices /@ indexedFields, "indices"] <>
+      Parameters`CreateLocalConstRefs[exprL + exprR] <> "\n" <>
+      "const " <> GetComplexScalarCType[] <> " left = " <>
+      Parameters`ExpressionToString[exprL] <> ";\n\n" <>
+      "const " <> GetComplexScalarCType[] <> " right = " <>
+      Parameters`ExpressionToString[exprR] <> ";\n\n" <>
+      "return vertex_type(left, right);",
+
+      MomentumDifferenceVertex,
+      {incomingScalar, outgoingScalar} = Replace[vertex[[2,2]],
+        SARAH`Mom[is_,_] - SARAH`Mom[os_,_] :> {is, os}];
+      vertexRules = {(SARAH`Cp @@ sortedIndexedFields) -> vertex[[2,1]]};
+      
+      expr = CanonicalizeCoupling[SARAH`Cp @@ fields,
+        sortedFields, sortedIndexedFields] /. vertexRules;
+      
+      expr = Vertices`SarahToFSVertexConventions[sortedFields, expr];
+      expr = TreeMasses`ReplaceDependenciesReverse[expr];
+      "int minuend_index = " <> 
+        ToString[Position[indexedFields, incomingScalar][[1,1]] - 1] <> ";\n" <>
+      "int subtrahend_index = " <>
+        ToString[Position[indexedFields, outgoingScalar][[1,1]] - 1] <> ";\n\n" <>
+      DeclareIndices[StripLorentzIndices /@ indexedFields, "indices"] <>
+      Parameters`CreateLocalConstRefs[expr] <> "\n" <>
+      "const " <> GetComplexScalarCType[] <> " result = " <>
+      Parameters`ExpressionToString[expr] <> ";\n\n" <>
+      "return vertex_type(result, minuend_index, subtrahend_index);",
+
+      InverseMetricVertex,
+      vertexRules = {(SARAH`Cp @@ sortedIndexedFields) -> vertex[[2,1]]};
+      
+      expr = CanonicalizeCoupling[SARAH`Cp @@ fields,
+        sortedFields, sortedIndexedFields] /. vertexRules;
+      
+      expr = Vertices`SarahToFSVertexConventions[sortedFields, expr];
+      expr = TreeMasses`ReplaceDependenciesReverse[expr];
+      DeclareIndices[StripLorentzIndices /@ indexedFields, "indices"] <>
+      Parameters`CreateLocalConstRefs[expr] <> "\n" <>
+      "const " <> GetComplexScalarCType[] <> " result = " <>
+      Parameters`ExpressionToString[expr] <> ";\n\n" <>
+      "return vertex_type(result);"
+    ]
+  ]
+
+(* Get a mathematical expression of the requested vertex
+   in terms of its canonically ordered vertex. *)
+CanonicalizeCoupling[
+    coupling_, sortedFields_List, sortedIndexedFields_List] :=
+  Module[{expr},
+    (* Note: Cannot use indexed fields, because their internal
+    SARAH ordering is different... *)
+    expr = Vertices`SortCp[coupling];
+    
+    (* Index the fields *)
+    expr = expr /. {SARAH`Cp @@ sortedFields -> SARAH`Cp @@ sortedIndexedFields}
   ]
   
 CreateMassFunctions[] :=
@@ -233,21 +364,19 @@ CreateMassFunctions[] :=
             ] & /@ massiveFields, "\n\n"]
         ]
 
-CreateUnitCharge[massMatrices_] :=
-  Module[{electron,photon,vertex,
-          vertexRules,parsedVertex,
+CreateUnitCharge[] :=
+  Module[{electron,photon,vertex,vertexBody,
           numberOfElectronIndices,numberOfPhotonIndices},
          electron = AtomHead @ TreeMasses`GetSMElectronLepton[];
          photon = SARAH`Photon;
-         vertex = {photon, electron, SARAH`bar[electron]};
-         vertexRules = VertexRulesForVertices[{vertex}, massMatrices, sortCouplings -> False];
-         parsedVertex = ParseVertex[vertex, vertexRules, sortCouplings -> False];
+         vertex = {SARAH`bar[electron], electron, photon};
+         vertexBody = VertexFunctionBodyForFields[vertex];
          numberOfElectronIndices = NumberOfFieldIndices[electron];
          numberOfPhotonIndices = NumberOfFieldIndices[photon];
 
-         "static LeftAndRightComponentedVertex unit_charge(const EvaluationContext& context)\n" <>
+         "static ChiralVertex unit_charge(const EvaluationContext& context)\n" <>
          "{\n" <>
-         TextFormatting`IndentText["using vertex_type = LeftAndRightComponentedVertex;"] <> "\n\n" <>
+         TextFormatting`IndentText["using vertex_type = ChiralVertex;"] <> "\n\n" <>
          TextFormatting`IndentText @ 
            ("std::array<int, " <> ToString @ numberOfElectronIndices <> "> electron_indices = {" <>
               If[TreeMasses`GetDimension[electron] =!= 1,
@@ -273,132 +402,36 @@ CreateUnitCharge[massMatrices_] :=
                 ] <>
             "};\n") <>
          TextFormatting`IndentText @ 
-           ("std::array<int, " <> ToString @ NumberOfIndices[parsedVertex] <> "> indices = " <>
-              "concatenate(concatenate(photon_indices, electron_indices), electron_indices);\n\n") <>
+           ("std::array<int, " <> ToString[
+              Total[NumberOfFieldIndices /@ {photon,electron,electron}]] <>
+            "> indices = " <>
+              "concatenate(photon_indices, electron_indices, electron_indices);\n\n") <>
            
-         TextFormatting`IndentText @ VertexFunctionBody[parsedVertex] <> "\n" <>
+         TextFormatting`IndentText @ vertexBody <> "\n" <>
          "}"
   ]
 
 NumberOfFieldIndices[field_] := Length @ FieldInfo[field][[5]]
 
+IndexBoundsForField[field_] :=
+  Module[{fieldInfo = FieldInfo[field]},
+    If[NumberOfFieldIndices[field] === 0,
+       Return[{{},{}}]];
+    If[Length @ Cases[fieldInfo[[5]],{SARAH`generation,_}] === 0,
+       Transpose[{1,#[[2]]} & /@ fieldInfo[[5]]],
+       Transpose[Prepend[
+         {1,#[[2]]} & /@ DeleteCases[fieldInfo[[5]],{SARAH`generation,_}],
+         {fieldInfo[[2]],fieldInfo[[3]]}]]]]
+
 LoadVerticesIfNecessary[] :=
-   If[SARAH`VertexList3 =!= List || Length[SARAH`VertexList3] === 0,
+   If[Head[SARAH`VertexList3] === Symbol || Length[SARAH`VertexList3] === 0,
         SA`CurrentStates = FlexibleSUSY`FSEigenstates; 
         SARAH`InitVertexCalculation[FlexibleSUSY`FSEigenstates, False];
+        SARAH`partDefinition = ParticleDefinitions[FlexibleSUSY`FSEigenstates];
+        SARAH`Particles[SARAH`Current] = SARAH`Particles[FlexibleSUSY`FSEigenstates];
         SARAH`ReadVertexList[FlexibleSUSY`FSEigenstates, False, False, True];
         SARAH`MakeCouplingLists;
    ]
-
-(* ParsedVertex structure:
- ParsedVertex[
-              {numP1Indices, numP2Indices, ...},
-              {{minIndex1, minIndex2, ...}, {maxIndex1+1, maxIndex2+1, ...}},
-              VertexClassName,
-              VertexFunctionBody
-              ]
-
- Getters are available! Given below ParseVertex[]
- *)
- 
-(* The heart of the algorithm! From the field content, determine all
- necessary information. *)
-ParseVertex[fields_List, vertexRules_List, OptionsPattern[{sortCouplings -> True}]] :=
-    Module[{indexedFields, numberOfIndices, declareIndices,
-        parsedVertex, vertexClassName, vertexFunctionBody,
-        fieldInfo, trIndexBounds, indexBounds,
-        expr, exprL, exprR, sortCommand},
-           indexedFields = IndexFields[fields];
-           
-           numberOfIndices = ((Length @ Vertices`FieldIndexList[#] &) /@ indexedFields);
-           declareIndices = DeclareIndices[indexedFields, "indices"];
-
-           vertexClassName = SymbolName[VertexTypeForFields[fields]];
-
-           sortCommand = If[OptionValue[sortCouplings],Vertices`SortCp,Identity];
-           vertexFunctionBody = Switch[vertexClassName,
-                                       "SingleComponentedVertex",
-                                       expr = sortCommand[SARAH`Cp @@ indexedFields] /. vertexRules;
-                                       expr = TreeMasses`ReplaceDependenciesReverse[expr];
-                                       declareIndices <>
-                                       Parameters`CreateLocalConstRefs[expr] <> "\n" <>
-                                       "const " <> GetComplexScalarCType[] <> " result = " <>
-                                       Parameters`ExpressionToString[expr] <> ";\n\n" <>
-                                       "return vertex_type(result);",
-                                       
-                                       "LeftAndRightComponentedVertex",
-                                       exprL = sortCommand @ SARAH`Cp[Sequence @@ indexedFields][SARAH`PL] /. vertexRules;
-                                       exprR = sortCommand @ SARAH`Cp[Sequence @@ indexedFields][SARAH`PR] /. vertexRules;
-                                       exprL = TreeMasses`ReplaceDependenciesReverse[exprL];
-                                       exprR = TreeMasses`ReplaceDependenciesReverse[exprR];
-                                       declareIndices <>
-                                       Parameters`CreateLocalConstRefs[{exprL, exprR}] <> "\n" <>
-                                       "const " <> GetComplexScalarCType[] <> " left = " <>
-                                       Parameters`ExpressionToString[exprL] <> ";\n\n" <>
-                                       "const " <> GetComplexScalarCType[] <> " right = " <>
-                                       Parameters`ExpressionToString[exprR] <> ";\n\n" <>
-                                       "return vertex_type(left, right);"];
-
-           fieldInfo = FieldInfo /@ fields;
-
-           trIndexBounds = Cases[Flatten[(With[{fieldIndex = #},
-                                             (If[#[[1]] === SARAH`generation,
-                                                 {fieldInfo[[fieldIndex, 2]]-1, fieldInfo[[fieldIndex, 3]]},
-                                                 {0, #[[2]]}]
-                                              &) /@ fieldInfo[[fieldIndex, 5]]]
-                                        &) /@ Table[i, {i, Length[fields]}],
-                                       1],
-                                 Except[{}]];
-           
-           If[trIndexBounds === {},
-              indexBounds = {{},{}},
-              indexBounds = Transpose @ trIndexBounds];
-
-           parsedVertex = ParsedVertex[numberOfIndices,
-                                       indexBounds,
-                                       vertexClassName,
-                                       vertexFunctionBody];
-
-           parsedVertex
-           ];
-
-IndexFields[fields_List] :=
-    MapIndexed[
-	Module[{field = #1,
-		index = #2[[1]]},
-	       StripLorentzIndices[
-		   SARAH`getFull[field] /. SARAH`subGC[index] /.
-		   SARAH`subIndFinal[index,index]]
-               ] &, fields];
-
-(* Creates local declarations of field indices, whose values are taken
-   from the elements of `arrayName'.
- *)
-DeclareIndices[indexedFields_List, arrayName_String] :=
-    Module[{p, total = 0, fieldIndexList, decl = ""},
-           DeclareIndex[idx_, num_Integer, an_String] := (
-               "const int " <> CConversion`ToValidCSymbolString[idx] <>
-               " = " <> an <> "[" <> ToString[num] <> "];\n");
-           For[p = 1, p <= Length[indexedFields], p++,
-               fieldIndexList = Vertices`FieldIndexList[indexedFields[[p]]];
-               decl = decl <> StringJoin[DeclareIndex[#, total++, arrayName]& /@ fieldIndexList];
-              ];
-           Assert[total == Total[Length[Vertices`FieldIndexList[#]]& /@ indexedFields]];
-           decl
-          ];
-
-GetComplexScalarCType[] :=
-    CConversion`CreateCType[CConversion`ScalarType[CConversion`complexScalarCType]];
-
-(** Getters to the ParsedVertex structure **)
-NumberOfIndices[parsedVertex_ParsedVertex] := Total @ parsedVertex[[1]];
-NumberOfIndices[parsedVertex_ParsedVertex, pIndex_Integer] := parsedVertex[[1, pIndex]];
-
-IndexBounds[parsedVertex_ParsedVertex] := parsedVertex[[2]];
-
-VertexClassName[parsedVertex_ParsedVertex] := parsedVertex[[3]];
-VertexFunctionBody[parsedVertex_ParsedVertex] := parsedVertex[[4]];
-(** End getters **)
 
 (* Returns the vertex type for a vertex with a given list of fields *)
 VertexTypeForFields[fields_List] :=
@@ -431,6 +464,26 @@ CouplingsForFields[fields_List] :=
              "UnknownVertexType",{}]
    ]
 
+(* Returns the vertex type for a vertex with a given list of fields *)
+VertexTypeForFields[fields_List] :=
+  Module[{scalarCount, vectorCount, fermionCount, ghostCount},
+    scalarCount = Length @ Select[fields, TreeMasses`IsScalar];
+    vectorCount = Length @ Select[fields, TreeMasses`IsVector];
+    fermionCount = Length @ Select[fields, TreeMasses`IsFermion];
+    ghostCount = Length @ Select[fields, TreeMasses`IsGhost];
+    
+    Switch[{fermionCount, scalarCount, vectorCount, ghostCount},
+      {0, 3, 0, 0}, ScalarVertex,
+      {0, 1, 0, 2}, ScalarVertex,
+      {0, 4, 0, 0}, ScalarVertex,
+      {2, 1, 0, 0}, ChiralVertex,
+      {2, 0, 1, 0}, ChiralVertex,
+      {0, 2, 1, 0}, MomentumDifferenceVertex,
+      {0, 1, 2, 0}, InverseMetricVertex,
+      {0, 2, 2, 0}, InverseMetricVertex,
+      _, "(UnknownVertexType: " <> ToString[fields] <> ")"]
+  ]
+
 IsLorentzIndex[index_] := StringMatchQ[ToString @ index, "lt" ~~ __];
 
 StripLorentzIndices[p_Symbol] := p;
@@ -441,6 +494,18 @@ StripLorentzIndices[p_] := Module[{remainingIndices},
                                   If[Length[remainingIndices] === 0, Head[p],
                                      Head[p][remainingIndices]]
                                   ];
-        
+
+FieldInfo[field_,OptionsPattern[{includeLorentzIndices -> False}]] := 
+    Module[{fieldInfo = Cases[SARAH`Particles[FlexibleSUSY`FSEigenstates],
+                                {SARAH`getParticleName @ field, ___}][[1]]},
+            fieldInfo = DeleteCases[fieldInfo, {SARAH`generation, 1}, {2}];
+            If[!OptionValue[includeLorentzIndices],
+               DeleteCases[fieldInfo, {SARAH`lorentz, _}, {2}],
+               fieldInfo]
+          ]
+
 End[];
 EndPackage[];
+
+
+

--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -215,7 +215,7 @@ CreateVertex[fields_List] :=
 
     "template<> inline\n" <> 
     functionClassName <> "::vertex_type\n" <>
-    functionClassName <> "::evaluate(const indices_type& indices, const ContextBase& context)\n" <>
+    functionClassName <> "::evaluate(const indices_type& indices, const context_base& context)\n" <>
     "{\n" <>
     TextFormatting`IndentText @ VertexFunctionBodyForFields[fields] <> "\n" <>
     "}"
@@ -382,7 +382,7 @@ CreateMassFunctions[] :=
              numberOfIndices = Length @ fieldInfo[[5]];
                                    
              "template<> inline\n" <>
-             "double ContextBase::mass_impl<" <>
+             "double context_base::mass_impl<" <>
                CXXNameOfField[#, prefixNamespace -> "fields"] <>
              ">(const std::array<int, " <> ToString @ numberOfIndices <>
              ">& indices) const\n" <>
@@ -401,7 +401,7 @@ CreateUnitCharge[] :=
          numberOfElectronIndices = NumberOfFieldIndices[electron];
          numberOfPhotonIndices = NumberOfFieldIndices[photon];
 
-         "static ChiralVertex unit_charge(const ContextBase& context)\n" <>
+         "static ChiralVertex unit_charge(const context_base& context)\n" <>
          "{\n" <>
          TextFormatting`IndentText["using vertex_type = ChiralVertex;"] <> "\n\n" <>
          TextFormatting`IndentText @ 

--- a/meta/EDM.m
+++ b/meta/EDM.m
@@ -87,7 +87,7 @@ EDMCreateInterfaceFunctionForField[field_,gTaggedDiagrams_List] :=
                  "{\n" <>
                  IndentText[
                    FlexibleSUSY`FSModelName <> "_mass_eigenstates model_ = model;\n" <>
-                   "EvaluationContext context{ model_ };\n" <>
+                   "ContextBase context{ model_ };\n" <>
                    "std::array<int, " <> ToString @ numberOfIndices <>
                      "> indices = {" <>
                        If[TreeMasses`GetDimension[field] =!= 1,

--- a/meta/EDM.m
+++ b/meta/EDM.m
@@ -1,3 +1,5 @@
+(* ::Package:: *)
+
 (* :Copyright:
 
    ====================================================================
@@ -99,6 +101,8 @@ EDMCreateInterfaceFunctionForField[field_,gTaggedDiagrams_List] :=
                          ] <> "};\n\n" <>
                                  
                    "double val = 0.0;\n\n" <>
+                   
+                   "using namespace @ModelName@_cxx_diagrams::fields;\n\n" <>
                    
                    StringJoin @ Riffle[("val += " <> ToString @ # <> "::value(indices, context);") & /@ 
                      Flatten[CXXEvaluatorsForFieldAndDiagramsFromGraph[field,#[[2]],#[[1]]] & /@ gTaggedDiagrams],

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -1,3 +1,5 @@
+(* ::Package:: *)
+
 (* :Copyright:
 
    ====================================================================
@@ -1927,17 +1929,15 @@ WriteObservables[extraSLHAOutputBlocks_, files_List] :=
            ];
            
 (* Write the CXXDiagrams c++ files *)
-WriteCXXDiagramClass[vertices_List,massMatrices_,files_List] :=
-  Module[{fields, nPointFunctions, vertexRules, vertexData, cxxVertices, massFunctions, unitCharge},
-    vertexRules = CXXDiagrams`VertexRulesForVertices[vertices,massMatrices];
-
+WriteCXXDiagramClass[vertices_List,files_List] :=
+  Module[{fields, nPointFunctions, vertexData, cxxVertices, massFunctions, unitCharge},
     fields = CXXDiagrams`CreateFields[];
-    vertexData = StringJoin @ Riffle[CXXDiagrams`CreateVertexData[#,vertexRules] &
+    vertexData = StringJoin @ Riffle[CXXDiagrams`CreateVertexData
                                      /@ DeleteDuplicates[vertices],
                                      "\n\n"];
-    cxxVertices = CXXDiagrams`CreateVertices[vertices,vertexRules];
+    cxxVertices = CXXDiagrams`CreateVertices[vertices];
     massFunctions = CXXDiagrams`CreateMassFunctions[];
-    unitCharge = CXXDiagrams`CreateUnitCharge[massMatrices];
+    unitCharge = CXXDiagrams`CreateUnitCharge[];
     
     WriteOut`ReplaceInFiles[files,
                             {"@CXXDiagrams_Fields@"          -> fields,
@@ -4009,9 +4009,6 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
                               FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_observables.cpp"}]}}];
                       
                       
-           Print["Setting up CXXDiagrams..."];
-           CXXDiagrams`CXXDiagramsInitialize[];
-           
            Print["Creating EDM class..."];
            edmFields = DeleteDuplicates @ Cases[Observables`GetRequestedObservables[extraSLHAOutputBlocks],
                                                 FlexibleSUSYObservable`EDM[p_[__]|p_] :> p];
@@ -4029,7 +4026,7 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
                               {FileNameJoin[{$flexiblesusyTemplateDir, "a_muon.cpp.in"}],
                                FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_a_muon.cpp"}]}}];
            
-           WriteCXXDiagramClass[Join[edmVertices,aMuonVertices],Lat$massMatrices,
+           WriteCXXDiagramClass[Join[edmVertices,aMuonVertices],
                                 {{FileNameJoin[{$flexiblesusyTemplateDir, "cxx_diagrams.hpp.in"}],
                                  FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_cxx_diagrams.hpp"}]}}];
 

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -3141,6 +3141,7 @@ Options[MakeFlexibleSUSY] :=
 MakeFlexibleSUSY[OptionsPattern[]] :=
     Module[{nPointFunctions, runInputFile, initialGuesserInputFile,
             edmVertices, aMuonVertices, edmFields,
+            cxxQFTTemplateDir, cxxQFTOutputDir, cxxQFTFiles,
             susyBetaFunctions, susyBreakingBetaFunctions,
             numberOfSusyParameters, anomDim,
             inputParameters (* list of 3-component lists of the form {name, block, type} *),
@@ -4025,10 +4026,21 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
                                FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_a_muon.hpp"}]},
                               {FileNameJoin[{$flexiblesusyTemplateDir, "a_muon.cpp.in"}],
                                FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_a_muon.cpp"}]}}];
+
+           Print["Creating C++ QFT class..."];
+           cxxQFTTemplateDir = FileNameJoin[{$flexiblesusyTemplateDir, "cxx_qft"}];
+           cxxQFTOutputDir = FileNameJoin[{FSOutputDir, "cxx_qft"}];
+           cxxQFTFiles = {{FileNameJoin[{cxxQFTTemplateDir, "qft.hpp.in"}],
+                           FileNameJoin[{cxxQFTOutputDir, FlexibleSUSY`FSModelName <> "_qft.hpp"}]},
+                          {FileNameJoin[{cxxQFTTemplateDir, "fields.hpp.in"}],
+                           FileNameJoin[{cxxQFTOutputDir, FlexibleSUSY`FSModelName <> "_fields.hpp"}]},
+                          {FileNameJoin[{cxxQFTTemplateDir, "vertices.hpp.in"}],
+                           FileNameJoin[{cxxQFTOutputDir, FlexibleSUSY`FSModelName <> "_vertices.hpp"}]}};
+
+           If[DirectoryQ[cxxQFTOutputDir] === False,
+              CreateDirectory[cxxQFTOutputDir]];
            
-           WriteCXXDiagramClass[Join[edmVertices,aMuonVertices],
-                                {{FileNameJoin[{$flexiblesusyTemplateDir, "cxx_diagrams.hpp.in"}],
-                                 FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_cxx_diagrams.hpp"}]}}];
+           WriteCXXDiagramClass[Join[edmVertices,aMuonVertices],cxxQFTFiles];
 
            PrintHeadline["Creating Mathematica interface"];
            Print["Creating LibraryLink ", FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> ".mx"}], " ..."];

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -4035,7 +4035,9 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
                           {FileNameJoin[{cxxQFTTemplateDir, "fields.hpp.in"}],
                            FileNameJoin[{cxxQFTOutputDir, FlexibleSUSY`FSModelName <> "_fields.hpp"}]},
                           {FileNameJoin[{cxxQFTTemplateDir, "vertices.hpp.in"}],
-                           FileNameJoin[{cxxQFTOutputDir, FlexibleSUSY`FSModelName <> "_vertices.hpp"}]}};
+                           FileNameJoin[{cxxQFTOutputDir, FlexibleSUSY`FSModelName <> "_vertices.hpp"}]},
+                          {FileNameJoin[{cxxQFTTemplateDir, "context_base.hpp.in"}],
+                           FileNameJoin[{cxxQFTOutputDir, FlexibleSUSY`FSModelName <> "_context_base.hpp"}]}};
 
            If[DirectoryQ[cxxQFTOutputDir] === False,
               CreateDirectory[cxxQFTOutputDir]];

--- a/meta/SelfEnergies.m
+++ b/meta/SelfEnergies.m
@@ -1,3 +1,5 @@
+(* ::Package:: *)
+
 (* :Copyright:
 
    ====================================================================
@@ -85,6 +87,8 @@ definitions for three-loop Higgs self-energies in split-SUSY";
 
 SelfEnergyIsSymmetric::usage = "";
 CreateCouplingSymbol::usage = "";
+
+ReplaceGhosts::usage="";
 
 Begin["`Private`"];
 
@@ -1568,3 +1572,6 @@ CreateThreeLoopSelfEnergiesSplit[particles_List] :=
 End[];
 
 EndPackage[];
+
+
+

--- a/meta/SelfEnergies.m
+++ b/meta/SelfEnergies.m
@@ -1572,6 +1572,3 @@ CreateThreeLoopSelfEnergiesSplit[particles_List] :=
 End[];
 
 EndPackage[];
-
-
-

--- a/meta/Vertices.m
+++ b/meta/Vertices.m
@@ -44,7 +44,9 @@ ReplaceUnrotatedFields::usage;
 StripGroupStructure::usage="Removes group generators and Kronecker deltas.";
 StripFieldIndices::usage;
 
+FindVertexWithLorentzStructure::usage="";
 SarahToFSVertexConventions::usage="";
+SortFieldsInCp::usage="";
 
 Begin["`Private`"]
 

--- a/meta/Vertices.m
+++ b/meta/Vertices.m
@@ -699,6 +699,3 @@ ReplaceUnrotatedFields[SARAH`Cp[p__][lorentz_]] :=
 End[] (* `Private` *)
 
 EndPackage[]
-
-
-

--- a/meta/Vertices.m
+++ b/meta/Vertices.m
@@ -1,3 +1,5 @@
+(* ::Package:: *)
+
 (* :Copyright:
 
    ====================================================================
@@ -697,3 +699,6 @@ ReplaceUnrotatedFields[SARAH`Cp[p__][lorentz_]] :=
 End[] (* `Private` *)
 
 EndPackage[]
+
+
+

--- a/meta/Vertices.m
+++ b/meta/Vertices.m
@@ -44,6 +44,8 @@ ReplaceUnrotatedFields::usage;
 StripGroupStructure::usage="Removes group generators and Kronecker deltas.";
 StripFieldIndices::usage;
 
+SarahToFSVertexConventions::usage="";
+
 Begin["`Private`"]
 
 (* There is a sign ambiguity when SARAH`Vertex[] factors an SSV-type
@@ -309,6 +311,20 @@ VertexExp[cpPattern_, nPointFunctions_, massMatrices_] := Module[{
     -I factor TreeMasses`ReplaceDependencies[contraction] /.
 	Parameters`ApplyGUTNormalization[]
 ];
+
+SarahToFSVertexConventions[sortedFields_List, expr_] :=
+  Module[{contraction},
+    StripGroupStructure[expr, {}];
+    contraction = Block[{
+	    SARAH`sum
+	    (* corrupts a polynomial (monomial + monomial + ...) summand *)
+	},
+	ExpandSarahSum @ SimplifyContraction @ expr];
+    (* see SPhenoCouplingList[] in SARAH/Package/SPheno/SPhenoCoupling.m
+       for the following sign factor *)
+    -I TreeMasses`ReplaceDependencies[contraction] /.
+	Parameters`ApplyGUTNormalization[]
+  ]
 
 SARAHVertex[fieldsInRotatedCp_List] := Module[{
 	sarahVertex = SARAH`Vertex @ StripFieldIndices[fieldsInRotatedCp],

--- a/src/concatenate.hpp
+++ b/src/concatenate.hpp
@@ -21,89 +21,78 @@
 
 #include <type_traits>
 
-namespace flexiblesusy {
+namespace flexiblesusy
+{
 namespace detail
 {
-template<class T> 
-struct value_type
-{
-  using type = typename T::value_type;
+template <class T>
+struct value_type {
+   using type = typename T::value_type;
 };
 
-template<class ...Args>
-struct common_value_type
-{
-  using type = typename std::common_type<
-    typename value_type<Args>::type...
-  >::type;
+template <class... Args>
+struct common_value_type {
+   using type =
+      typename std::common_type<typename value_type<Args>::type...>::type;
 };
 
-template<int ...Args> struct sum;
+template <int... Args>
+struct sum;
 
-template<int V1, int ...Tail>
-struct sum<V1, Tail...>
-{
-  static constexpr int value = V1 + sum<Tail...>::value;
+template <int V1, int... Tail>
+struct sum<V1, Tail...> {
+   static constexpr int value = V1 + sum<Tail...>::value;
 };
 
-template<> struct sum<>
-{
-  static constexpr int value = 0;
+template <>
+struct sum<> {
+   static constexpr int value = 0;
 };
 
 namespace result_of
 {
-template<class ...Args>
-struct concatenate
-{
-  using type = std::array<
-    typename common_value_type<
-      typename std::decay<Args>::type...
-    >::type,
-    sum<std::tuple_size<
-      typename std::decay<Args>::type
-    >::value...>::value
-  >;
+template <class... Args>
+struct concatenate {
+   using type = std::array<
+      typename common_value_type<typename std::decay<Args>::type...>::type,
+      sum<std::tuple_size<typename std::decay<Args>::type>::value...>::value>;
 };
-}
+} // namespace result_of
 
-template<class ...Args>
+template <class... Args>
 struct concatenate_impl;
 
-template<class T, class ...Args>
-struct concatenate_impl<T, Args...>
-{
-  template<class OutputIterator>
-  void operator()( OutputIterator it, T &&t, Args &&...args )
-  {
-    auto next = std::copy( t.begin(), t.end(), it );
-    concatenate_impl<Args...>{}( next, std::forward<Args>( args )... );
-  }
+template <class T, class... Args>
+struct concatenate_impl<T, Args...> {
+   template <class OutputIterator>
+   void operator()(OutputIterator it, T&& t, Args&&... args)
+   {
+      auto next = std::copy(t.begin(), t.end(), it);
+      concatenate_impl<Args...>{}(next, std::forward<Args>(args)...);
+   }
 };
 
-template<>
-struct concatenate_impl<>
-{
-  template<class OutputIterator>
-  void operator()( OutputIterator it )
-  {}
+template <>
+struct concatenate_impl<> {
+   template <class OutputIterator>
+   void operator()(OutputIterator it)
+   {
+   }
 };
-}
+} // namespace detail
 
-template<class ...Args>
+template <class... Args>
 typename detail::result_of::concatenate<Args...>::type
-concatenate( Args &&...args )
+concatenate(Args&&... args)
 {
-  using result_type =
-    typename detail::result_of::concatenate<Args...>::type;
-  result_type result;  
+   using result_type = typename detail::result_of::concatenate<Args...>::type;
+   result_type result;
 
-  detail::concatenate_impl<Args...>{}( result.begin(),
-    std::forward<Args>( args )... );
+   detail::concatenate_impl<Args...>{}(result.begin(),
+                                       std::forward<Args>(args)...);
 
-  return result;
+   return result;
 }
-}
+} // namespace flexiblesusy
 
 #endif
-

--- a/src/concatenate.hpp
+++ b/src/concatenate.hpp
@@ -1,0 +1,89 @@
+#ifndef H_FS_CONCATENATE
+#define H_FS_CONCATENATE
+
+#include <type_traits>
+
+namespace detail
+{
+template<class T> 
+struct value_type
+{
+  using type = typename T::value_type;
+};
+
+template<class ...Args>
+struct common_value_type
+{
+  using type = typename std::common_type<
+    typename value_type<Args>::type...
+  >::type;
+};
+
+template<int ...Args> struct sum;
+
+template<int V1, int ...Tail>
+struct sum<V1, Tail...>
+{
+  static constexpr int value = V1 + sum<Tail...>::value;
+};
+
+template<> struct sum<>
+{
+  static constexpr int value = 0;
+};
+
+namespace result_of
+{
+template<class ...Args>
+struct concatenate
+{
+  using type = std::array<
+    typename common_value_type<
+      typename std::decay<Args>::type...
+    >::type,
+    sum<std::tuple_size<
+      typename std::decay<Args>::type
+    >::value...>::value
+  >;
+};
+}
+
+template<class ...Args>
+struct concatenate_impl;
+
+template<class T, class ...Args>
+struct concatenate_impl<T, Args...>
+{
+  template<class OutputIterator>
+  void operator()( OutputIterator it, T &&t, Args &&...args )
+  {
+    auto next = std::copy( t.begin(), t.end(), it );
+    concatenate_impl<Args...>{}( next, std::forward<Args>( args )... );
+  }
+};
+
+template<>
+struct concatenate_impl<>
+{
+  template<class OutputIterator>
+  void operator()( OutputIterator it )
+  {}
+};
+}
+
+template<class ...Args>
+typename detail::result_of::concatenate<Args...>::type
+concatenate( Args &&...args )
+{
+  using result_type =
+    typename detail::result_of::concatenate<Args...>::type;
+  result_type result;  
+
+  detail::concatenate_impl<Args...>{}( result.begin(),
+    std::forward<Args>( args )... );
+
+  return result;
+}
+
+#endif
+

--- a/src/concatenate.hpp
+++ b/src/concatenate.hpp
@@ -1,3 +1,21 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
 #ifndef H_FS_CONCATENATE
 #define H_FS_CONCATENATE
 

--- a/src/concatenate.hpp
+++ b/src/concatenate.hpp
@@ -3,6 +3,7 @@
 
 #include <type_traits>
 
+namespace flexiblesusy {
 namespace detail
 {
 template<class T> 
@@ -83,6 +84,7 @@ concatenate( Args &&...args )
     std::forward<Args>( args )... );
 
   return result;
+}
 }
 
 #endif

--- a/src/find_if.hpp
+++ b/src/find_if.hpp
@@ -8,6 +8,7 @@
 #include <boost/mpl/deref.hpp>
 #include <boost/mpl/begin_end.hpp>
 
+namespace flexiblesusy {
 namespace meta {
 namespace detail
 {
@@ -61,7 +62,7 @@ template<
        typename boost::mpl::end<Sequence>::type
      >::type{} );
 }
-
+}
 }
 
 #endif

--- a/src/find_if.hpp
+++ b/src/find_if.hpp
@@ -1,3 +1,21 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
 #ifndef H_FS_FIND_IF
 #define H_FS_FIND_IF
 

--- a/src/find_if.hpp
+++ b/src/find_if.hpp
@@ -1,0 +1,68 @@
+#ifndef H_FS_FIND_IF
+#define H_FS_FIND_IF
+
+#include <type_traits>
+#include <utility>
+
+#include <boost/mpl/next.hpp>
+#include <boost/mpl/deref.hpp>
+#include <boost/mpl/begin_end.hpp>
+
+namespace meta {
+namespace detail
+{
+template<
+  class Iterator,
+  class End,
+  template<typename> class Predicate,
+  template<typename> class F,
+  class State
+> bool find_if_impl( State &&state, std::true_type )
+{ return false; }
+
+template<
+  class Iterator,
+  class End,
+  template<typename> class Predicate,
+  template<typename> class F,
+  class State
+> bool find_if_impl( State &&state, std::false_type )
+{
+  if( Predicate<typename boost::mpl::deref<Iterator>::type>{}(
+        state ) )
+  {
+    F<typename boost::mpl::deref<Iterator>::type>{}( state );
+    return true;
+  }
+
+  using NextIterator = typename boost::mpl::next<Iterator>::type;
+
+  return find_if_impl<
+    NextIterator, End, Predicate, F
+  >( std::forward<State>( state ),
+     typename std::is_same<NextIterator, End>::type{} );
+}
+}
+
+template<
+  class Sequence,
+  template<typename> class Predicate,
+  template<typename> class F,
+  class State
+> bool find_if( State &&state )
+{
+  return detail::find_if_impl<
+    typename boost::mpl::begin<Sequence>::type,
+    typename boost::mpl::end<Sequence>::type,
+    Predicate, F
+  >( std::forward<State>( state ),
+     typename std::is_same<
+       typename boost::mpl::begin<Sequence>::type,
+       typename boost::mpl::end<Sequence>::type
+     >::type{} );
+}
+
+}
+
+#endif
+

--- a/src/find_if.hpp
+++ b/src/find_if.hpp
@@ -22,66 +22,52 @@
 #include <type_traits>
 #include <utility>
 
-#include <boost/mpl/next.hpp>
-#include <boost/mpl/deref.hpp>
 #include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/deref.hpp>
+#include <boost/mpl/next.hpp>
 
-namespace flexiblesusy {
-namespace meta {
+namespace flexiblesusy
+{
+namespace meta
+{
 namespace detail
 {
-template<
-  class Iterator,
-  class End,
-  template<typename> class Predicate,
-  template<typename> class F,
-  class State
-> bool find_if_impl( State &&state, std::true_type )
-{ return false; }
-
-template<
-  class Iterator,
-  class End,
-  template<typename> class Predicate,
-  template<typename> class F,
-  class State
-> bool find_if_impl( State &&state, std::false_type )
+template <class Iterator, class End, template <typename> class Predicate,
+          template <typename> class F, class State>
+bool find_if_impl(State&& state, std::true_type)
 {
-  if( Predicate<typename boost::mpl::deref<Iterator>::type>{}(
-        state ) )
-  {
-    F<typename boost::mpl::deref<Iterator>::type>{}( state );
-    return true;
-  }
-
-  using NextIterator = typename boost::mpl::next<Iterator>::type;
-
-  return find_if_impl<
-    NextIterator, End, Predicate, F
-  >( std::forward<State>( state ),
-     typename std::is_same<NextIterator, End>::type{} );
-}
+   return false;
 }
 
-template<
-  class Sequence,
-  template<typename> class Predicate,
-  template<typename> class F,
-  class State
-> bool find_if( State &&state )
+template <class Iterator, class End, template <typename> class Predicate,
+          template <typename> class F, class State>
+bool find_if_impl(State&& state, std::false_type)
 {
-  return detail::find_if_impl<
-    typename boost::mpl::begin<Sequence>::type,
-    typename boost::mpl::end<Sequence>::type,
-    Predicate, F
-  >( std::forward<State>( state ),
-     typename std::is_same<
-       typename boost::mpl::begin<Sequence>::type,
-       typename boost::mpl::end<Sequence>::type
-     >::type{} );
+   if (Predicate<typename boost::mpl::deref<Iterator>::type>{}(state)) {
+      F<typename boost::mpl::deref<Iterator>::type>{}(state);
+      return true;
+   }
+
+   using NextIterator = typename boost::mpl::next<Iterator>::type;
+
+   return find_if_impl<NextIterator, End, Predicate, F>(
+      std::forward<State>(state),
+      typename std::is_same<NextIterator, End>::type{});
 }
+} // namespace detail
+
+template <class Sequence, template <typename> class Predicate,
+          template <typename> class F, class State>
+bool find_if(State&& state)
+{
+   return detail::find_if_impl<typename boost::mpl::begin<Sequence>::type,
+                               typename boost::mpl::end<Sequence>::type,
+                               Predicate, F>(
+      std::forward<State>(state),
+      typename std::is_same<typename boost::mpl::begin<Sequence>::type,
+                            typename boost::mpl::end<Sequence>::type>::type{});
 }
-}
+} // namespace meta
+} // namespace flexiblesusy
 
 #endif
-

--- a/src/multiindex.hpp
+++ b/src/multiindex.hpp
@@ -1,3 +1,21 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
 #ifndef H_FS_MULTIINDEX
 #define H_FS_MULTIINDEX
 

--- a/src/multiindex.hpp
+++ b/src/multiindex.hpp
@@ -27,61 +27,53 @@
 #include <boost/array.hpp>
 
 #include <boost/mpl/at.hpp>
-#include <boost/mpl/size.hpp>
 #include <boost/mpl/range_c.hpp>
+#include <boost/mpl/size.hpp>
 
 #include <boost/range/iterator_range.hpp>
 
+#include <boost/fusion/adapted/boost_array.hpp>
 #include <boost/fusion/adapted/mpl.hpp>
 #include <boost/fusion/include/copy.hpp>
-#include <boost/fusion/adapted/boost_array.hpp>
 
 namespace flexiblesusy
 {
 namespace detail
 {
-template<class End, class Location>
-struct can_increment_multiindex
-{
-  template<class Indices>
-  bool operator()( const Indices &indices )
-  {
-    return (indices[Location::value] !=
-      boost::mpl::at<End, Location>::type::value - 1);
-  }
+template <class End, class Location>
+struct can_increment_multiindex {
+   template <class Indices>
+   bool operator()(const Indices& indices)
+   {
+      return (indices[Location::value] !=
+              boost::mpl::at<End, Location>::type::value - 1);
+   }
 };
 
-template<class End>
-struct increment_checker
-{
-  template<class Location>
-  using type = can_increment_multiindex<End, Location>;
+template <class End>
+struct increment_checker {
+   template <class Location>
+   using type = can_increment_multiindex<End, Location>;
 };
 
-template<class Begin>
-struct increment_multiindex
-{
-  template<class Location>
-  struct type
-  {
-    template<class Indices>
-    void operator()( Indices &indices )
-    {
-      boost::array<
-        int,
-        std::tuple_size<Indices>::value
-      > boost_temp;
-      boost::fusion::copy( Begin(), boost_temp );
-      std::copy( boost_temp.begin(),
-        boost_temp.begin() + Location::value,
-        indices.begin() );
+template <class Begin>
+struct increment_multiindex {
+   template <class Location>
+   struct type {
+      template <class Indices>
+      void operator()(Indices& indices)
+      {
+         boost::array<int, std::tuple_size<Indices>::value> boost_temp;
+         boost::fusion::copy(Begin(), boost_temp);
+         std::copy(boost_temp.begin(), boost_temp.begin() + Location::value,
+                   indices.begin());
 
-      ++(indices[Location::value]);
-    }
-  };
+         ++(indices[Location::value]);
+      }
+   };
 };
 
-template<class Begin, class End, bool>
+template <class Begin, class End, bool>
 class multiindex_impl;
 
 /* FIXME: This copying back and forth
@@ -90,198 +82,182 @@ class multiindex_impl;
           is stupid...
           Using boost::hana would be the
           way to go! */
-template<class Begin, class End>
+template <class Begin, class End>
 class multiindex_impl<Begin, End, false>
 {
-  static constexpr auto NumIndices = boost::mpl::size<Begin>::value;
-  using data_type = std::array<int, NumIndices>;
-    
-  data_type data;
+   static constexpr auto NumIndices = boost::mpl::size<Begin>::value;
+   using data_type = std::array<int, NumIndices>;
 
-  multiindex_impl( data_type &&d )
-  : data( std::move( d ) ) {}
+   data_type data;
+
+   multiindex_impl(data_type&& d) : data(std::move(d)) {}
+
 public:
-  static multiindex_impl begin()
-  {
-    boost::array<int, NumIndices> boost_temp;
-    std::array<int, NumIndices> std_temp;
-
-    boost::fusion::copy( Begin(), boost_temp );
-    std::copy( boost_temp.begin(), boost_temp.end(), std_temp.begin() );
-
-    return multiindex_impl{ std::move( std_temp ) };
-  }
-
-  static multiindex_impl end()
-  {
-    boost::array<int, NumIndices> boost_temp;
-    std::array<int, NumIndices> std_temp;
-
-    boost::fusion::copy( End(), boost_temp );
-    std::copy( boost_temp.begin(), boost_temp.end(), std_temp.begin() );
-
-    return multiindex_impl{ std::move( std_temp ) };
-  }
-  
-  multiindex_impl &operator++()
-  {
-    using locations = boost::mpl::range_c<int, 0, NumIndices>;
-
-    if( meta::find_if<
-          locations,
-          detail::increment_checker<End>::template type,
-          detail::increment_multiindex<Begin>::template type
-        >( data ) == false )
-    {
+   static multiindex_impl begin()
+   {
       boost::array<int, NumIndices> boost_temp;
-      boost::fusion::copy( End(), boost_temp );
+      std::array<int, NumIndices> std_temp;
 
-      std::copy( boost_temp.begin(), boost_temp.end(), data.begin() );
-    }
-    
-    return *this;
-  }
+      boost::fusion::copy(Begin(), boost_temp);
+      std::copy(boost_temp.begin(), boost_temp.end(), std_temp.begin());
 
-  multiindex_impl operator++( int )
-  {
-     multiindex_impl copy( *this );
-     operator++();
-     return copy;
-  }
+      return multiindex_impl{std::move(std_temp)};
+   }
 
-  const data_type &operator*( void ) const
-  { return data; }
+   static multiindex_impl end()
+   {
+      boost::array<int, NumIndices> boost_temp;
+      std::array<int, NumIndices> std_temp;
 
-  const data_type *operator->( void ) const
-  { return &data; }
+      boost::fusion::copy(End(), boost_temp);
+      std::copy(boost_temp.begin(), boost_temp.end(), std_temp.begin());
 
-  bool operator==( const multiindex_impl &other ) const
-  { return data == other.data; }
+      return multiindex_impl{std::move(std_temp)};
+   }
 
-  bool operator!=( const multiindex_impl &other ) const
-  { return !(*this == other); }
+   multiindex_impl& operator++()
+   {
+      using locations = boost::mpl::range_c<int, 0, NumIndices>;
+
+      if (meta::find_if<locations,
+                        detail::increment_checker<End>::template type,
+                        detail::increment_multiindex<Begin>::template type>(
+             data) == false) {
+         boost::array<int, NumIndices> boost_temp;
+         boost::fusion::copy(End(), boost_temp);
+
+         std::copy(boost_temp.begin(), boost_temp.end(), data.begin());
+      }
+
+      return *this;
+   }
+
+   multiindex_impl operator++(int)
+   {
+      multiindex_impl copy(*this);
+      operator++();
+      return copy;
+   }
+
+   const data_type& operator*(void)const { return data; }
+
+   const data_type* operator->(void)const { return &data; }
+
+   bool operator==(const multiindex_impl& other) const
+   {
+      return data == other.data;
+   }
+
+   bool operator!=(const multiindex_impl& other) const
+   {
+      return !(*this == other);
+   }
 };
 
-template<class Begin, class End>
+template <class Begin, class End>
 class multiindex_impl<Begin, End, true>
 {
-  using data_type = std::array<int, 0>;
-  bool is_incremented;
+   using data_type = std::array<int, 0>;
+   bool is_incremented;
 
-  data_type data;
+   data_type data;
 
-  multiindex_impl( bool is_inc )
-  : is_incremented( is_inc ) {}
+   multiindex_impl(bool is_inc) : is_incremented(is_inc) {}
+
 public:
-  static multiindex_impl begin()
-  { return multiindex_impl{ false }; }
+   static multiindex_impl begin() { return multiindex_impl{false}; }
 
-  static multiindex_impl end()
-  { return multiindex_impl{ true }; }
-  
-  multiindex_impl &operator++()
-  {
-    is_incremented = true;
-    return *this;
-  }
+   static multiindex_impl end() { return multiindex_impl{true}; }
 
-  multiindex_impl operator++( int )
-  {
-     multiindex_impl copy( *this );
-     operator++();
-     return copy;
-  }
+   multiindex_impl& operator++()
+   {
+      is_incremented = true;
+      return *this;
+   }
 
-  const data_type &operator*( void ) const
-  { return data; }
+   multiindex_impl operator++(int)
+   {
+      multiindex_impl copy(*this);
+      operator++();
+      return copy;
+   }
 
-  const data_type *operator->( void ) const
-  { return &data; }
+   const data_type& operator*(void)const { return data; }
 
-  bool operator==( const multiindex_impl &other ) const
-  { return is_incremented == other.is_incremented; }
+   const data_type* operator->(void)const { return &data; }
 
-  bool operator!=( const multiindex_impl &other ) const
-  { return !(*this == other); }
+   bool operator==(const multiindex_impl& other) const
+   {
+      return is_incremented == other.is_incremented;
+   }
+
+   bool operator!=(const multiindex_impl& other) const
+   {
+      return !(*this == other);
+   }
 };
-}
+} // namespace detail
 
-template<class Begin, class End>
+template <class Begin, class End>
 class multiindex
-: public detail::multiindex_impl<
-    Begin,
-    End,
-    std::is_same<Begin, End>::type::value
->
+   : public detail::multiindex_impl<Begin, End,
+                                    std::is_same<Begin, End>::type::value>
 {
-  using impl = detail::multiindex_impl<
-    Begin,
-    End,
-    std::is_same<Begin, End>::type::value
-  >;
+   using impl = detail::multiindex_impl<Begin, End,
+                                        std::is_same<Begin, End>::type::value>;
 
-  multiindex( impl &&index )
-  : impl( std::move( index ) ) {}
+   multiindex(impl&& index) : impl(std::move(index)) {}
+
 public:
-  static multiindex begin()
-  { return impl::begin(); }
+   static multiindex begin() { return impl::begin(); }
 
-  static multiindex end()
-  { return impl::end(); }
+   static multiindex end() { return impl::end(); }
 };
-}
+} // namespace flexiblesusy
 
 namespace std
 {
-  template<class Begin, class End>
-  struct iterator_traits<flexiblesusy::multiindex<Begin, End>>
-  {
-    using difference_type = std::ptrdiff_t;
-    using value_type = typename std::decay<decltype(
-      *std::declval<flexiblesusy::multiindex<Begin, End>>() )
-    >::type;
-    using pointer = const value_type *;
-    using reference = const value_type &;
-    using iterator_category = std::forward_iterator_tag;
-  };
-}
-
-namespace flexiblesusy {
-namespace meta {
-template<class ObjectWithIndexBounds>
-struct index_bounds
-{
-  using type = typename ObjectWithIndexBounds::index_bounds;
+template <class Begin, class End>
+struct iterator_traits<flexiblesusy::multiindex<Begin, End>> {
+   using difference_type = std::ptrdiff_t;
+   using value_type = typename std::decay<decltype(
+      *std::declval<flexiblesusy::multiindex<Begin, End>>())>::type;
+   using pointer = const value_type*;
+   using reference = const value_type&;
+   using iterator_category = std::forward_iterator_tag;
 };
-}
+} // namespace std
 
-template<class ObjectWithIndexBounds>
-static decltype(
-  boost::make_iterator_range(
-    multiindex<
-      typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
-      typename meta::index_bounds<ObjectWithIndexBounds>::type::second
-    >::begin(),
-    multiindex<
-      typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
-      typename meta::index_bounds<ObjectWithIndexBounds>::type::second
-    >::end()
-  )
-)
-index_range( void )
+namespace flexiblesusy
 {
-  return boost::make_iterator_range(
-    multiindex<
+namespace meta
+{
+template <class ObjectWithIndexBounds>
+struct index_bounds {
+   using type = typename ObjectWithIndexBounds::index_bounds;
+};
+} // namespace meta
+
+template <class ObjectWithIndexBounds>
+static decltype(boost::make_iterator_range(
+   multiindex<typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
+              typename meta::index_bounds<
+                 ObjectWithIndexBounds>::type::second>::begin(),
+   multiindex<
       typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
-      typename meta::index_bounds<ObjectWithIndexBounds>::type::second
-    >::begin(),
-    multiindex<
-      typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
-      typename meta::index_bounds<ObjectWithIndexBounds>::type::second
-    >::end()
-  );
+      typename meta::index_bounds<ObjectWithIndexBounds>::type::second>::end()))
+index_range(void)
+{
+   return boost::make_iterator_range(
+      multiindex<
+         typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
+         typename meta::index_bounds<ObjectWithIndexBounds>::type::second>::
+         begin(),
+      multiindex<
+         typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
+         typename meta::index_bounds<ObjectWithIndexBounds>::type::second>::
+         end());
 }
-}
+} // namespace flexiblesusy
 
 #endif
-

--- a/src/multiindex.hpp
+++ b/src/multiindex.hpp
@@ -1,0 +1,229 @@
+#ifndef H_FS_MULTIINDEX
+#define H_FS_MULTIINDEX
+
+#include "find_if.hpp"
+
+#include <array>
+#include <iterator>
+
+#include <boost/array.hpp>
+
+#include <boost/mpl/at.hpp>
+#include <boost/mpl/size.hpp>
+#include <boost/mpl/range_c.hpp>
+
+#include <boost/range/iterator_range.hpp>
+
+#include <boost/fusion/adapted/mpl.hpp>
+#include <boost/fusion/include/copy.hpp>
+#include <boost/fusion/adapted/boost_array.hpp>
+
+namespace detail
+{
+template<class End, class Location>
+struct can_increment_multiindex
+{
+  template<class Indices>
+  bool operator()( const Indices &indices )
+  {
+    return (indices[Location::value] !=
+      boost::mpl::at<End, Location>::type::value - 1);
+  }
+};
+
+template<class End>
+struct increment_checker
+{
+  template<class Location>
+  using type = can_increment_multiindex<End, Location>;
+};
+
+template<class Begin>
+struct increment_multiindex
+{
+  template<class Location>
+  struct type
+  {
+    template<class Indices>
+    void operator()( Indices &indices )
+    {
+      boost::array<
+        int,
+        std::tuple_size<Indices>::value
+      > boost_temp;
+      boost::fusion::copy( Begin(), boost_temp );
+      std::copy( boost_temp.begin(),
+        boost_temp.begin() + Location::value,
+        indices.begin() );
+
+      ++(indices[Location::value]);
+    }
+  };
+};
+
+template<class Begin, class End, bool>
+class multiindex_impl;
+
+/* FIXME: This copying back and forth
+          using boost::array<> between
+          boost::mpl and std::array<>
+          is stupid...
+          Using boost::hana would be the
+          way to go! */
+template<class Begin, class End>
+class multiindex_impl<Begin, End, false>
+{
+  static constexpr auto NumIndices = boost::mpl::size<Begin>::value;
+  using data_type = std::array<int, NumIndices>;
+    
+  data_type data;
+
+  multiindex_impl( data_type &&d )
+  : data( std::move( d ) ) {}
+public:
+  static multiindex_impl begin()
+  {
+    boost::array<int, NumIndices> boost_temp;
+    std::array<int, NumIndices> std_temp;
+
+    boost::fusion::copy( Begin(), boost_temp );
+    std::copy( boost_temp.begin(), boost_temp.end(), std_temp.begin() );
+
+    return multiindex_impl{ std::move( std_temp ) };
+  }
+
+  static multiindex_impl end()
+  {
+    boost::array<int, NumIndices> boost_temp;
+    std::array<int, NumIndices> std_temp;
+
+    boost::fusion::copy( End(), boost_temp );
+    std::copy( boost_temp.begin(), boost_temp.end(), std_temp.begin() );
+
+    return multiindex_impl{ std::move( std_temp ) };
+  }
+  
+  multiindex_impl &operator++()
+  {
+    using locations = boost::mpl::range_c<int, 0, NumIndices>;
+
+    if( meta::find_if<
+          locations,
+          detail::increment_checker<End>::template type,
+          detail::increment_multiindex<Begin>::template type
+        >( data ) == false )
+    {
+      boost::array<int, NumIndices> boost_temp;
+      boost::fusion::copy( End(), boost_temp );
+
+      std::copy( boost_temp.begin(), boost_temp.end(), data.begin() );
+    }
+    
+    return *this;
+  }
+
+  multiindex_impl operator++( int )
+  {
+     multiindex_impl copy( *this );
+     operator++();
+     return copy;
+  }
+
+  const data_type &operator*( void ) const
+  { return data; }
+
+  const data_type *operator->( void ) const
+  { return &data; }
+
+  bool operator==( const multiindex_impl &other ) const
+  { return data == other.data; }
+
+  bool operator!=( const multiindex_impl &other ) const
+  { return !(*this == other); }
+};
+
+template<class Begin, class End>
+class multiindex_impl<Begin, End, true>
+{
+  using data_type = std::array<int, 0>;
+  bool is_incremented;
+
+  data_type data;
+
+  multiindex_impl( bool is_inc )
+  : is_incremented( is_inc ) {}
+public:
+  static multiindex_impl begin()
+  { return multiindex_impl{ false }; }
+
+  static multiindex_impl end()
+  { return multiindex_impl{ true }; }
+  
+  multiindex_impl &operator++()
+  {
+    is_incremented = true;
+    return *this;
+  }
+
+  multiindex_impl operator++( int )
+  {
+     multiindex_impl copy( *this );
+     operator++();
+     return copy;
+  }
+
+  const data_type &operator*( void ) const
+  { return data; }
+
+  const data_type *operator->( void ) const
+  { return &data; }
+
+  bool operator==( const multiindex_impl &other ) const
+  { return is_incremented == other.is_incremented; }
+
+  bool operator!=( const multiindex_impl &other ) const
+  { return !(*this == other); }
+};
+}
+
+template<class Begin, class End>
+class multiindex
+: public detail::multiindex_impl<
+    Begin,
+    End,
+    std::is_same<Begin, End>::type::value
+>
+{
+  using impl = detail::multiindex_impl<
+    Begin,
+    End,
+    std::is_same<Begin, End>::type::value
+  >;
+
+  multiindex( impl &&index )
+  : impl( std::move( index ) ) {}
+public:
+  static multiindex begin()
+  { return impl::begin(); }
+
+  static multiindex end()
+  { return impl::end(); }
+};
+
+namespace std
+{
+  template<class Begin, class End>
+  struct iterator_traits<multiindex<Begin, End>>
+  {
+    using difference_type = std::ptrdiff_t;
+    using value_type = typename std::decay<decltype(
+      *std::declval<multiindex<Begin, End>>() )
+    >::type;
+    using pointer = const value_type *;
+    using reference = const value_type &;
+    using iterator_category = std::forward_iterator_tag;
+  };
+}
+
+#endif
+

--- a/src/multiindex.hpp
+++ b/src/multiindex.hpp
@@ -18,6 +18,8 @@
 #include <boost/fusion/include/copy.hpp>
 #include <boost/fusion/adapted/boost_array.hpp>
 
+namespace flexiblesusy
+{
 namespace detail
 {
 template<class End, class Location>
@@ -209,20 +211,58 @@ public:
   static multiindex end()
   { return impl::end(); }
 };
+}
 
 namespace std
 {
   template<class Begin, class End>
-  struct iterator_traits<multiindex<Begin, End>>
+  struct iterator_traits<flexiblesusy::multiindex<Begin, End>>
   {
     using difference_type = std::ptrdiff_t;
     using value_type = typename std::decay<decltype(
-      *std::declval<multiindex<Begin, End>>() )
+      *std::declval<flexiblesusy::multiindex<Begin, End>>() )
     >::type;
     using pointer = const value_type *;
     using reference = const value_type &;
     using iterator_category = std::forward_iterator_tag;
   };
+}
+
+namespace flexiblesusy {
+namespace meta {
+template<class ObjectWithIndexBounds>
+struct index_bounds
+{
+  using type = typename ObjectWithIndexBounds::index_bounds;
+};
+}
+
+template<class ObjectWithIndexBounds>
+static decltype(
+  boost::make_iterator_range(
+    multiindex<
+      typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
+      typename meta::index_bounds<ObjectWithIndexBounds>::type::second
+    >::begin(),
+    multiindex<
+      typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
+      typename meta::index_bounds<ObjectWithIndexBounds>::type::second
+    >::end()
+  )
+)
+index_range( void )
+{
+  return boost::make_iterator_range(
+    multiindex<
+      typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
+      typename meta::index_bounds<ObjectWithIndexBounds>::type::second
+    >::begin(),
+    multiindex<
+      typename meta::index_bounds<ObjectWithIndexBounds>::type::first,
+      typename meta::index_bounds<ObjectWithIndexBounds>::type::second
+    >::end()
+  );
+}
 }
 
 #endif

--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -51,7 +51,7 @@ double OneLoopFunctionF2C(double);
 double OneLoopFunctionF1N(double);
 double OneLoopFunctionF2N(double);
 
-double get_QED_2L(ContextBase&);
+double get_QED_2L(context_base&);
 
 /**
  * @class AMuonVertexCorrectionSF
@@ -72,7 +72,7 @@ double get_QED_2L(ContextBase&);
 template<class PhotonEmitter, class ExchangeParticle>
 struct AMuonVertexCorrectionSF {
    static double value(const typename field_indices<Muon>::type& indices,
-                       const ContextBase& context);
+                       const context_base& context);
 };
 
 /**
@@ -94,7 +94,7 @@ struct AMuonVertexCorrectionSF {
 template<class PhotonEmitter, class ExchangeParticle>
 struct AMuonVertexCorrectionFS {
    static double value(const typename field_indices<Muon>::type& indices,
-                       const ContextBase& context);
+                       const context_base& context);
 };
 
 /**
@@ -261,7 +261,7 @@ double calculate_a_muon_impl(@ModelName@_mass_eigenstates& model)
 {
    VERBOSE_MSG("@ModelName@_a_muon: calculating a_mu at Q = " << model.get_scale());
 
-   ContextBase context{ model };
+   context_base context{ model };
    double val = 0.0;
    
    using namespace @ModelName@_cxx_diagrams::fields;
@@ -321,7 +321,7 @@ std::pair<double,double> vary_scale(const @ModelName@_mass_eigenstates& model)
    return std::make_pair(*(minmax.first), *(minmax.second));
 }
 
-double muonPhysicalMass(const ContextBase& context)
+double muonPhysicalMass(const context_base& context)
 {
 @AMuon_MuonPhysicalMass@
 }
@@ -342,7 +342,7 @@ double @ModelName@_a_muon::calculate_a_muon(const @ModelName@_mass_eigenstates& 
       return std::numeric_limits<double>::quiet_NaN();
    }
 
-   double m_muon_pole = muonPhysicalMass(ContextBase{model});
+   double m_muon_pole = muonPhysicalMass(context_base{model});
 
    if (m_muon_pole == 0.0) {
       model.solve_ewsb();
@@ -373,7 +373,7 @@ double @ModelName@_a_muon::calculate_a_muon_uncertainty(const @ModelName@_mass_e
 }
 
 namespace {
-double get_QED_2L(ContextBase& context)
+double get_QED_2L(context_base& context)
 {
    const double MSUSY = Abs(get_MSUSY(context.model));
    const double m_muon = muonPhysicalMass(context);
@@ -386,7 +386,7 @@ double get_QED_2L(ContextBase& context)
 template<class PhotonEmitter, class ExchangeField>
 double AMuonVertexCorrectionFS<
 PhotonEmitter, ExchangeField
->::value(const typename field_indices<Muon>::type& indices, const ContextBase& context)
+>::value(const typename field_indices<Muon>::type& indices, const context_base& context)
 {
    double res = 0.0;
 
@@ -444,7 +444,7 @@ PhotonEmitter, ExchangeField
 template<class PhotonEmitter, class ExchangeField>
 double AMuonVertexCorrectionSF<
 PhotonEmitter, ExchangeField
->::value(const typename field_indices<Muon>::type& indices, const ContextBase& context)
+>::value(const typename field_indices<Muon>::type& indices, const context_base& context)
 {
    double res = 0.0;
 

--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -391,16 +391,14 @@ PhotonEmitter, ExchangeField
                       PhotonEmitter
                       >;
 
-   constexpr auto indexBounds = MuonVertex::index_bounds;
-
-   for (const auto& index: indexBounds) {
-      const auto muonIndices = MuonVertex::template fieldIndices<0>(index);
+   for (const auto& index: index_range<MuonVertex>()) {
+      const auto muonIndices = MuonVertex::template field_indices<0>(index);
 
       if (muonIndices != indices)
          continue;
 
-      const auto photonEmitterIndices = MuonVertex::template fieldIndices<2>(index);
-      const auto exchangeFieldIndices = MuonVertex::template fieldIndices<1>(index);
+      const auto photonEmitterIndices = MuonVertex::template field_indices<2>(index);
+      const auto exchangeFieldIndices = MuonVertex::template field_indices<1>(index);
 
       if (isSMField<PhotonEmitter>(photonEmitterIndices) &&
           isSMField<ExchangeField>(exchangeFieldIndices))
@@ -451,16 +449,14 @@ PhotonEmitter, ExchangeField
                       PhotonEmitter
                       >;
 
-   constexpr auto indexBounds = MuonVertex::index_bounds;
-
-   for (const auto& index: indexBounds) {
-      const auto muonIndices = MuonVertex::template fieldIndices<0>(index);
+   for (const auto& index: index_range<MuonVertex>()) {
+      const auto muonIndices = MuonVertex::template field_indices<0>(index);
 
       if (muonIndices != indices)
          continue;
 
-      const auto photonEmitterIndices = MuonVertex::template fieldIndices<2>(index);
-      const auto exchangeFieldIndices = MuonVertex::template fieldIndices<1>(index);
+      const auto photonEmitterIndices = MuonVertex::template field_indices<2>(index);
+      const auto exchangeFieldIndices = MuonVertex::template field_indices<1>(index);
 
       if (isSMField<PhotonEmitter>(photonEmitterIndices) &&
           isSMField<ExchangeField>(exchangeFieldIndices))

--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -51,7 +51,7 @@ double OneLoopFunctionF2C(double);
 double OneLoopFunctionF1N(double);
 double OneLoopFunctionF2N(double);
 
-double get_QED_2L(EvaluationContext&);
+double get_QED_2L(ContextBase&);
 
 /**
  * @class AMuonVertexCorrectionSF
@@ -72,7 +72,7 @@ double get_QED_2L(EvaluationContext&);
 template<class PhotonEmitter, class ExchangeParticle>
 struct AMuonVertexCorrectionSF {
    static double value(const typename field_indices<Muon>::type& indices,
-                       const EvaluationContext& context);
+                       const ContextBase& context);
 };
 
 /**
@@ -94,7 +94,7 @@ struct AMuonVertexCorrectionSF {
 template<class PhotonEmitter, class ExchangeParticle>
 struct AMuonVertexCorrectionFS {
    static double value(const typename field_indices<Muon>::type& indices,
-                       const EvaluationContext& context);
+                       const ContextBase& context);
 };
 
 /**
@@ -261,7 +261,7 @@ double calculate_a_muon_impl(@ModelName@_mass_eigenstates& model)
 {
    VERBOSE_MSG("@ModelName@_a_muon: calculating a_mu at Q = " << model.get_scale());
 
-   EvaluationContext context{ model };
+   ContextBase context{ model };
    double val = 0.0;
    
    using namespace @ModelName@_cxx_diagrams::fields;
@@ -321,7 +321,7 @@ std::pair<double,double> vary_scale(const @ModelName@_mass_eigenstates& model)
    return std::make_pair(*(minmax.first), *(minmax.second));
 }
 
-double muonPhysicalMass(const EvaluationContext& context)
+double muonPhysicalMass(const ContextBase& context)
 {
 @AMuon_MuonPhysicalMass@
 }
@@ -342,7 +342,7 @@ double @ModelName@_a_muon::calculate_a_muon(const @ModelName@_mass_eigenstates& 
       return std::numeric_limits<double>::quiet_NaN();
    }
 
-   double m_muon_pole = muonPhysicalMass(EvaluationContext{model});
+   double m_muon_pole = muonPhysicalMass(ContextBase{model});
 
    if (m_muon_pole == 0.0) {
       model.solve_ewsb();
@@ -373,7 +373,7 @@ double @ModelName@_a_muon::calculate_a_muon_uncertainty(const @ModelName@_mass_e
 }
 
 namespace {
-double get_QED_2L(EvaluationContext& context)
+double get_QED_2L(ContextBase& context)
 {
    const double MSUSY = Abs(get_MSUSY(context.model));
    const double m_muon = muonPhysicalMass(context);
@@ -386,7 +386,7 @@ double get_QED_2L(EvaluationContext& context)
 template<class PhotonEmitter, class ExchangeField>
 double AMuonVertexCorrectionFS<
 PhotonEmitter, ExchangeField
->::value(const typename field_indices<Muon>::type& indices, const EvaluationContext& context)
+>::value(const typename field_indices<Muon>::type& indices, const ContextBase& context)
 {
    double res = 0.0;
 
@@ -444,7 +444,7 @@ PhotonEmitter, ExchangeField
 template<class PhotonEmitter, class ExchangeField>
 double AMuonVertexCorrectionSF<
 PhotonEmitter, ExchangeField
->::value(const typename field_indices<Muon>::type& indices, const EvaluationContext& context)
+>::value(const typename field_indices<Muon>::type& indices, const ContextBase& context)
 {
    double res = 0.0;
 

--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -28,7 +28,10 @@
 #include "@ModelName@_a_muon.hpp"
 #include "@ModelName@_mass_eigenstates.hpp"
 
-#include "@ModelName@_cxx_diagrams.hpp"
+#include "cxx_qft/@ModelName@_qft.hpp"
+
+#include "wrappers.hpp"
+#include "numerics2.hpp"
 
 #define INPUTPARAMETER(p) context.model.get_input().p
 #define MODELPARAMETER(p) context.model.get_##p()
@@ -36,9 +39,9 @@
 #define PHASE(p) context.model.get_##p()
 
 using namespace flexiblesusy;
-using namespace cxx_diagrams;
+using namespace @ModelName@_cxx_diagrams;
 
-using Muon = @AMuon_MuonField@;
+using Muon = fields::@AMuon_MuonField@;
 
 namespace {
 static constexpr double oneOver16PiSquared = 0.0063325739776461107152;
@@ -260,6 +263,8 @@ double calculate_a_muon_impl(@ModelName@_mass_eigenstates& model)
 
    EvaluationContext context{ model };
    double val = 0.0;
+   
+   using namespace @ModelName@_cxx_diagrams::fields;
 
 @AMuon_Calculation@
 

--- a/templates/cxx_diagrams.hpp.in
+++ b/templates/cxx_diagrams.hpp.in
@@ -30,16 +30,22 @@
 
 #include "numerics2.hpp"
 #include "wrappers.hpp"
+#include "multiindex.hpp"
+#include "concatenate.hpp"
 
 #include <array>
+
+#include <boost/array.hpp>
+#include <boost/version.hpp>
 #include <boost/range/join.hpp>
+
+#include <boost/mpl/erase.hpp>
 #include <boost/mpl/vector_c.hpp>
+#include <boost/mpl/joint_view.hpp>
+
 #include <boost/fusion/adapted/mpl.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/adapted/boost_array.hpp>
-#include <boost/array.hpp>
-
-#include <boost/version.hpp>
 
 #if BOOST_VERSION >= 105800
 #include <boost/fusion/include/move.hpp>
@@ -54,258 +60,61 @@
 
 namespace flexiblesusy {
 namespace cxx_diagrams {
-namespace impl {
-/** \brief Helper template for make_array
- */
-template<class ForwardIterator, std::size_t N, class T>
-struct make_array_it {
-   using decayed_type = typename std::decay<
-                        typename std::iterator_traits<ForwardIterator>::value_type
-                        >::type;
-   static constexpr bool use_cast = !std::is_same<decayed_type, T>::value;
 
-   template<class... Args>
-   static auto iterate(ForwardIterator begin, Args &&...args)
-   -> typename std::enable_if<
-   !use_cast,
-   std::array<T, N + sizeof...(Args)>
-   >::type {
-      ForwardIterator copy(begin);
-      return make_array_it<ForwardIterator, N-1, T>::iterate(++begin,
-            std::forward<Args>(args)..., *copy);
-   }
-
-   template<class... Args>
-   static auto iterate(ForwardIterator begin, Args &&...args)
-   -> typename std::enable_if<
-   use_cast,
-   std::array<T, N + sizeof...(Args)>
-   >::type {
-      ForwardIterator copy(begin);
-      return make_array_it<ForwardIterator, N-1, T>::iterate(++begin,
-            std::forward<Args>(args)..., T(*copy));
-   }
+// Declare a type that can hold the field indices for any given field
+template<class Field> struct field_indices {
+   using type = std::array<int, Field::numberOfFieldIndices>;
 };
 
-/** \brief Specialized helper template for make_array */
-template<class ForwardIterator, class T>
-struct make_array_it<ForwardIterator, 0, T> {
-   template<class... Args>
-   static auto iterate(ForwardIterator /* begin */, Args &&...args)
-   -> std::array<T, sizeof...(Args)> {
-      return std::array<T, sizeof...(Args)>{ std::forward<Args>(args)... };
-   }
-};
-
-/** \class make_array
- * \brief Facility for easy construction of \a std::array
- *        objects.
- * \tparam N The size of the to be constructed array
- * \tparam T The type of the objects the array should hold
- *           or void (by default) if the type should be
- *           inferred.
- */
-template<std::size_t N, class T = void>
-struct make_array {
-   /** \brief Construct a \a std::array by copying values
-    *         from a range.
-    * \tparam ForwardIterator The iterator type (usually inferred)
-    * \param[in] begin The iterator marking the beginning of
-    *                  the range to be copied.
-    * \returns A \a std::array holding the desired objects.
-    * \warning \a begin must be incrementable sufficiently
-    *          often (\a N times) otherwise the behaviour
-    *          is undefined.
-    */
-   template<class ForwardIterator>
-   static auto iterate(ForwardIterator begin)
-   -> std::array<typename std::conditional<
-   std::is_void<T>::value,
-       typename std::iterator_traits<ForwardIterator>::value_type,
-       T
-   >::type, N> {
-      using value_type = typename std::conditional<
-      std::is_void<T>::value,
-      typename std::iterator_traits<ForwardIterator>::value_type,
-      T
-      >::type;
-
-      return make_array_it<ForwardIterator, N, value_type>::iterate(begin);
-   }
-};
-
-template<class Array1, class Array2>
-auto concatenate(const Array1& a1, const Array2& a2)
--> std::array<
-typename std::common_type<
-typename Array1::value_type,
-         typename Array1::value_type
-         >::type,
-         std::tuple_size<Array1>::value + std::tuple_size<Array2>::value>
-         {
-            using value_type = typename std::common_type<
-                               typename Array1::value_type,
-            typename Array1::value_type
-            >::type;
-            constexpr auto size = std::tuple_size<Array1>::value + std::tuple_size<Array2>::value;
-
-            auto range1 = boost::make_iterator_range(boost::begin(a1),
-                          boost::end(a1));
-            auto range2 = boost::make_iterator_range(boost::begin(a2),
-                          boost::end(a2));
-            auto joined = boost::join(range1, range2);
-
-            return make_array<size, value_type>::iterate(boost::begin(joined));
-         }
-
-         /**
-          * @class IndexBounds<N>
-          * @brief A class representing multiple (N) index ranges.
-          *
-          * N is a non-negative integer.
-          * The ranges are specified the c++ way; The range begins are inclusive
-          * and the range ends are exclusive. Misspecified ranges result in
-          * undefined behaviour!
-          * The intended use is to iterate over an IndexBounds<N> using the normal
-          * begin()/end() syntax, which will iterate over every possible combination
-          * of the indices within their respective ranges.
-          * The ranges are const! Once they are initialized they cannot be changed.
-          * Initialization is done like = {{ beg1, beg2, ... }, { end1, end2, ... }}
-          */
-         template<int N> struct IndexBounds;
-
-/**
- * @class IndexIterator<N>
- * @brief The iterator class used by IndexBounds<N>.
- *
- * It only fulfils the input iterator requirements!
- * The value_type is a const std::array<int, N>
- * containing the current indices.
- * Incrementing the iterator results in a new index combination.
- */
-template<int N> struct IndexIterator {
-   using difference_type = typename std::array<int, N>::difference_type;
-   using value_type = int;
-   using pointer = int*;
-   using reference = int&;
-   using iterator_category = std::input_iterator_tag;
-
-   friend class IndexBounds<N>;
-private:
-   const IndexBounds<N>& bounds;
-   std::array<int, N> indices;
-
-   IndexIterator(const IndexBounds<N>& b, std::array<int, N>&& i)
-      : bounds(b), indices(std::move(i)) {}
-public:
-   const std::array<int, N>& operator*() const
-   {
-      return indices;
-   }
-
-   const std::array<int, N>* operator->() const
-   {
-      return &indices;
-   }
-
-   IndexIterator& operator++()
-   {
-      for (int i = 0; i != N; i++) {
-         indices[i]++;
-         if (indices[i] == bounds.indexEnd[i]) {
-            indices[i] = bounds.indexBegin[i];
-            continue;
-         }
-
-         return *this;
-      }
-
-      indices = make_array<N>::iterate(bounds.indexEnd);
-      return *this;
-   }
-
-   IndexIterator operator++(int)
-   {
-      IndexIterator it(*this);
-      this->operator++();
-      return it;
-   }
-
-   template<int M>
-   friend bool operator==(const IndexIterator<M>& it1, const IndexIterator<M>& it2);
-};
-
-template<int N>
-bool operator==(const IndexIterator<N>& it1, const IndexIterator<N>& it2)
+namespace detail
 {
-   return it1.indices == it2.indices;
+  template<class Field>
+  struct number_of_field_indices
+  {
+    static constexpr int value =
+      std::tuple_size<typename field_indices<Field>::type>::value;
+    using type = boost::mpl::int_<value>;
+  };
+
+  template<class Sequence>
+  struct total_number_of_field_indices
+  {
+    using type = typename boost::mpl::fold<
+      Sequence,
+      boost::mpl::int_<0>,
+      boost::mpl::plus<
+        boost::mpl::_1,
+        number_of_field_indices<
+          boost::mpl::_2
+        >
+      >
+    >::type;
+    static constexpr int value = type::value;
+  };
 }
 
-template<int N>
-bool operator!=(const IndexIterator<N>& it1, const IndexIterator<N>& it2)
+template<class Field> struct bar
 {
-   return !(it1 == it2);
-}
+  using index_bounds = typename Field::index_bounds;
+  static constexpr int numberOfGenerations = Field::numberOfGenerations;
+  using sm_flags = typename Field::sm_flags;
+  static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
+  static constexpr double electric_charge = Field::electric_charge;
+  using lorentz_conjugate = Field;
 
-template<int N> struct IndexBounds {
-   typedef const std::array<int, N> indices_type;
-
-   int indexBegin[N];
-   int indexEnd[N];
-
-   typedef IndexIterator<N> const_iterator;
-
-   const_iterator begin() const
-   {
-      return const_iterator(*this, make_array<N>::iterate(indexBegin));
-   }
-
-   const_iterator end() const
-   {
-      return const_iterator(*this, make_array<N>::iterate(indexEnd));
-   }
+  using type = bar<Field>;
 };
 
-template<> struct IndexBounds<0> {
-   using indices_type = const std::array<int, 0>;
-   using const_iterator = indices_type*;
+template<class Field> struct conj
+{
+  using index_bounds = typename Field::index_bounds;
+  static constexpr int numberOfGenerations = Field::numberOfGenerations;
+  using sm_flags = typename Field::sm_flags;
+  static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
+  static constexpr double electric_charge = Field::electric_charge;
+  using lorentz_conjugate = Field;
 
-   const indices_type dummyIndex = {};
-
-   const_iterator begin() const
-   {
-      return &dummyIndex;
-   }
-   const_iterator end() const
-   {
-      return (begin()+1);
-   }
-};
-
-} // namespace impl
-
-// Lorentz conjugate fermions
-template<class Field> struct bar {
-   static constexpr int numberOfGenerations = Field::numberOfGenerations;
-   static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
-   using smFlags = typename Field::smFlags;
-
-   static constexpr double electric_charge = - Field::electric_charge;
-
-   using type = bar<Field>;
-   using lorentz_conjugate = Field;
-};
-
-// Lorentz conjugate bosons
-template<class Field> struct conj {
-   static constexpr int numberOfGenerations = Field::numberOfGenerations;
-   static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
-   using smFlags = typename Field::smFlags;
-
-   static constexpr double electric_charge = - Field::electric_charge;
-
-   using type = conj<Field>;
-   using lorentz_conjugate = Field;
+  using type = conj<Field>;
 };
 
 // Double Lorentz conjugation
@@ -330,105 +139,163 @@ template<class Field> struct remove_lorentz_conjugation<conj<Field>> {
 };
 
 
-// Declare a type that can hold the field indices for any given field
-template<class Field> struct field_indices {
-   using type = std::array<int, Field::numberOfFieldIndices>;
-};
-
 template<class Field>
-typename std::enable_if<Field::numberOfGenerations != 1, bool>::type
+typename std::enable_if<
+  Field::numberOfGenerations != 1,
+  bool
+>::type
 isSMField(const typename field_indices<Field>::type& indices)
 {
-   boost::array<bool,Field::numberOfGenerations> smFlags;
+  boost::array<bool, Field::numberOfGenerations> sm_flags;
 
 #if BOOST_VERSION >= 105800
-   boost::fusion::move(typename Field::smFlags(), smFlags);
+  boost::fusion::move(typename Field::sm_flags(), sm_flags);
 #else
-   boost::fusion::copy(typename Field::smFlags(), smFlags);
+  boost::fusion::copy(typename Field::sm_flags(), sm_flags);
 #endif
 
-   return smFlags[indices[0]];
+  return sm_flags[indices.front()];
 }
 
 template<class Field>
-typename std::enable_if<Field::numberOfGenerations == 1, bool>::type
-isSMField(const typename field_indices<Field>::type& /* indices */)
+typename std::enable_if<
+  Field::numberOfGenerations == 1,
+  bool
+>::type
+isSMField(const typename field_indices<Field>::type &)
 {
-   return boost::mpl::at_c<typename Field::smFlags,0>::type::value;
+  return boost::mpl::at_c<
+    typename Field::sm_flags,
+    0
+  >::type::value;
+}
+
+namespace detail
+{
+template<class Begin, class End>
+decltype(
+  boost::make_iterator_range(
+    multiindex<Begin, End>::begin(),
+    multiindex<Begin, End>::end()
+  )
+)
+make_index_range( void )
+{
+  using index = multiindex<Begin, End>;
+
+  return boost::make_iterator_range(
+    index::begin(), index::end()
+  );
+}
+}
+
+template<class ObjectWithIndexBounds>
+struct index_bounds_of
+{
+  using type = typename ObjectWithIndexBounds::index_bounds;
+};
+
+template<class ObjectWithIndexBounds>
+decltype(detail::make_index_range<
+  typename index_bounds_of<ObjectWithIndexBounds>::type::first,
+  typename index_bounds_of<ObjectWithIndexBounds>::type::second
+>())
+index_range( void )
+{
+  return detail::make_index_range<
+    typename index_bounds_of<ObjectWithIndexBounds>::type::first,
+    typename index_bounds_of<ObjectWithIndexBounds>::type::second
+  >();
 }
 
 @CXXDiagrams_Fields@
 
-
-/**
-* @class SingleComponentedVertex
-* @brief A vertex whose value can be represented by a single complex number
-*/
-class SingleComponentedVertex {
+class ScalarVertex {
 private:
-   std::complex<double> val; ///< The value
+  std::complex<double> val;
 public:
-   SingleComponentedVertex(std::complex<double> v)
-      : val(v) {}
+  ScalarVertex(std::complex<double> v)
+  : val(v) {}
 
-   /**
-   * @fn value
-   * @brief Returns the value of the vertex.
-   */
-   std::complex<double> value() const
-   {
-      return val;
-   }
+  std::complex<double> value() const
+  {
+     return val;
+  }
 
-   /**
-   * @fn isZero
-   * @brief Tests whether the value is numerically significant
-   */
-   bool isZero() const
-   {
-      return (is_zero(val.real()) && is_zero(val.imag()));
-   }
+  bool isZero() const
+  {
+    return (is_zero(val.real()) && is_zero(val.imag()));
+  }
 };
 
-/**
-* @class LeftAndRightComponentedVertex
-* @brief A vertex whose value can be represented by two complex numbers
-*/
-class LeftAndRightComponentedVertex {
+class ChiralVertex {
 private:
-   std::pair<std::complex<double>, std::complex<double>> value;  ///< The values
+  std::pair<std::complex<double>, std::complex<double>> value;
 public:
-   LeftAndRightComponentedVertex(const std::complex<double>& left,
-                                 const std::complex<double>& right)
-      : value(left, right) {}
+  ChiralVertex(const std::complex<double>& left,
+               const std::complex<double>& right)
+  : value(left, right) {}
 
-   /**
-   * @fn left
-   * @brief Returns the left component of the vertex.
-   */
-   std::complex<double> left() const
-   {
-      return value.first;
-   }
+  std::complex<double> left() const
+  {
+     return value.first;
+  }
 
-   /**
-   * @fn right
-   * @brief Returns the left component of the vertex.
-   */
-   std::complex<double> right() const
-   {
-      return value.second;
-   }
+  std::complex<double> right() const
+  {
+     return value.second;
+  }
 
-   /**
-   * @fn isZero
-   * @brief Tests whether the values are numerically significant
-   */
-   bool isZero() const
-   {
-      return (is_zero(value.first.real()) && is_zero(value.first.imag()) &&
-              is_zero(value.second.real()) && is_zero(value.second.imag()));
-   }
+  bool isZero() const
+  {
+    return (is_zero(value.first.real()) && is_zero(value.first.imag()) &&
+            is_zero(value.second.real()) && is_zero(value.second.imag()));
+  }
+};
+
+class MomentumDifferenceVertex {
+private:
+  std::complex<double> val;
+  int minuendIndex;
+  int subtrahendIndex;
+public:
+  MomentumDifferenceVertex(std::complex<double> v, int mi, int si )
+  : val(v), minuendIndex(mi), subtrahendIndex(si) {}
+
+  std::complex<double> value(int mi, int si) const
+  {
+    if( mi == minuendIndex && si == subtrahendIndex )
+      return val;
+    if( mi == subtrahendIndex && si == minuendIndex )
+      return -val;
+
+    throw std::invalid_argument(
+       "MomentumDifferenceVertex: Wrong index combination" );
+    return 0.0;
+  }
+
+  bool isZero() const
+  {
+    return (is_zero(val.real()) && is_zero(val.imag()));
+  }
+};
+
+class InverseMetricVertex {
+private:
+  std::complex<double> val;
+public:
+  InverseMetricVertex(std::complex<double> v)
+  : val(v) {}
+
+  std::complex<double> value() const
+  {
+    return val;
+  }
+
+  bool isZero() const
+  {
+    return (is_zero(val.real()) && is_zero(val.imag()));
+  }
 };
 
 /**
@@ -439,50 +306,77 @@ template<class ...Fields> struct VertexData;
 
 struct EvaluationContext;
 
-/**
- * @class Vertex<F...>
- * @brief A template that represents a vertex with open field indices.
- *
- * All elements in F... have to be publicly derived from Field.
- * To obtain a conrete value, use the static member function evaluate()
- * along with the desired field indices.
- */
-template<class ...F> class Vertex {
-   using Data = VertexData<F...>;
-   using bounds_type = typename std::decay<decltype(Data::index_bounds)>::type;
+template<class ...Fields> class Vertex {
+  using Data = VertexData<Fields...>;
 public:
-   using vertex_type = typename Data::vertex_type;
-   using indices_type = typename decltype(Data::index_bounds)::indices_type;
+  using index_bounds = typename boost::mpl::fold<
+    boost::mpl::vector<Fields...>,
+    boost::mpl::pair<
+      boost::mpl::vector<>,
+      boost::mpl::vector<>
+    >,
+    boost::mpl::pair<
+      boost::mpl::joint_view<
+        boost::mpl::first<boost::mpl::_1>,
+        boost::mpl::first<
+          index_bounds_of<boost::mpl::_2>
+        >
+      >,
+      boost::mpl::joint_view<
+        boost::mpl::second<boost::mpl::_1>,
+        boost::mpl::second<
+          index_bounds_of<boost::mpl::_2>
+        >
+      >
+    >
+  >::type;
+  using indices_type = std::array<
+    int,
+    detail::total_number_of_field_indices<
+      boost::mpl::vector<Fields...>
+    >::value
+  >;
+  using vertex_type = typename Data::vertex_type;
 
-   static constexpr bounds_type index_bounds = Data::index_bounds;
+  template<int FieldIndex>
+  static typename field_indices<
+    typename boost::mpl::at_c<
+      boost::mpl::vector<Fields...>,
+      FieldIndex
+    >::type
+  >::type 
+  field_indices(const indices_type& indices)
+  {
+    using namespace boost::mpl;
+    using fields = vector<Fields...>;
 
-   /**
-    * @fn fieldIndices
-    * @brief Returns the subset of indices belonging to
-    *        a field at a given index.
-    * @param indices The complete set of indices for all fields
-    *
-    * The field indexing is in the same order as the template arguments
-    * and starts at 0.
-    */
-   template<int fieldIndex>
-   static
-   std::array<int, Data::fieldIndexStart[fieldIndex+1] - Data::fieldIndexStart[fieldIndex]>
-   fieldIndices(const indices_type& indices)
-   {
-      constexpr auto length = Data::fieldIndexStart[fieldIndex+1] - Data::fieldIndexStart[fieldIndex];
-      constexpr auto offset = Data::fieldIndexStart[fieldIndex];
-      auto begin = indices.begin() + offset;
-      return impl::make_array<length>::iterate(begin);
-   }
+    using result_type = typename field_indices<
+      typename boost::mpl::at_c<fields, FieldIndex>::type
+    >::type;
 
-   /**
-    * @fn vertex
-    * @brief Calculates the vertex for a given set of field indices.
-    * @param indices The field indices
-    * @param context The evaluation context
-    */
-   static vertex_type evaluate(const indices_type& indices, const EvaluationContext& context);
+    using preceeding_fields = typename erase<
+      fields,
+      typename advance<
+        typename begin<fields>::type,
+        int_<FieldIndex>
+      >::type,
+      typename end<fields>::type
+    >::type;
+
+    constexpr int offset = detail::total_number_of_field_indices<
+      preceeding_fields
+    >::value;
+    constexpr int length = std::tuple_size<result_type>::value;
+
+    result_type result_indices;
+    std::copy( indices.begin() + offset,
+               indices.begin() + offset + length,
+               result_indices.begin() );
+    return result_indices;
+  }
+
+  static vertex_type evaluate(const indices_type& indices,
+    const EvaluationContext& context);
 };
 
 
@@ -524,7 +418,7 @@ namespace impl {
 
 static double unit_charge(const EvaluationContext& context)
 {
-   return impl::unit_charge(context).left().real() / Electron::electric_charge;
+   return -impl::unit_charge(context).left().real() / Electron::electric_charge;
 }
 
 } // namespace cxx_diagrams

--- a/templates/cxx_diagrams.hpp.in
+++ b/templates/cxx_diagrams.hpp.in
@@ -99,7 +99,7 @@ template<class Field> struct bar
   static constexpr int numberOfGenerations = Field::numberOfGenerations;
   using sm_flags = typename Field::sm_flags;
   static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
-  static constexpr double electric_charge = Field::electric_charge;
+  static constexpr double electric_charge = - Field::electric_charge;
   using lorentz_conjugate = Field;
 
   using type = bar<Field>;
@@ -111,7 +111,7 @@ template<class Field> struct conj
   static constexpr int numberOfGenerations = Field::numberOfGenerations;
   using sm_flags = typename Field::sm_flags;
   static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
-  static constexpr double electric_charge = Field::electric_charge;
+  static constexpr double electric_charge = - Field::electric_charge;
   using lorentz_conjugate = Field;
 
   using type = conj<Field>;

--- a/templates/cxx_qft/context_base.hpp.in
+++ b/templates/cxx_qft/context_base.hpp.in
@@ -32,7 +32,7 @@
 
 namespace flexiblesusy {
 namespace @ModelName@_cxx_diagrams {
-struct ContextBase
+struct context_base
 {
   @ModelName@_mass_eigenstates& model; ///< The model object.
  
@@ -45,14 +45,14 @@ struct ContextBase
     return mass_impl<CleanField>(indices);
   }
 
-  ContextBase( @ModelName@_mass_eigenstates &m ) : model( m ) {}
-  ContextBase( const ContextBase & ) = default;
-  ContextBase( ContextBase && ) = default;
+  context_base( @ModelName@_mass_eigenstates &m ) : model( m ) {}
+  context_base( const context_base & ) = default;
+  context_base( context_base && ) = default;
   
-  ContextBase &operator=( const ContextBase & ) = default;
-  ContextBase &operator=( ContextBase && ) = default;
+  context_base &operator=( const context_base & ) = default;
+  context_base &operator=( context_base && ) = default;
   
-  virtual ~ContextBase( void ) = default;
+  virtual ~context_base( void ) = default;
 private:
   template<class Field>
   double mass_impl(const typename field_indices<Field>::type& indices) const;

--- a/templates/cxx_qft/context_base.hpp.in
+++ b/templates/cxx_qft/context_base.hpp.in
@@ -19,19 +19,50 @@
 // File generated at @DateAndTime@
 
 /**
- * @file cxx_qft/@ModelName@_qft.hpp
+ * @file cxx_qft/@ModelName@_context_base.hpp
  *
  * This file was generated at @DateAndTime@ with FlexibleSUSY
  * @FlexibleSUSYVersion@ and SARAH @SARAHVersion@ .
  */
 
-#ifndef @ModelName@_CXXQFT_QFT_H
-#define @ModelName@_CXXQFT_QFT_H
-
-#include "multiindex.hpp"
+#ifndef @ModelName@_CXXQFT_CONTEXT_BASE_H
+#define @ModelName@_CXXQFT_CONTEXT_BASE_H
 
 #include "@ModelName@_fields.hpp"
-#include "@ModelName@_context_base.hpp"
+
+namespace flexiblesusy {
+namespace @ModelName@_cxx_diagrams {
+struct ContextBase
+{
+  @ModelName@_mass_eigenstates& model; ///< The model object.
+ 
+  template<class Field>
+  double mass(const typename field_indices<Field>::type& indices) const
+  {
+    using CleanField = typename fields::remove_lorentz_conjugation<
+      Field
+    >::type;
+    return mass_impl<CleanField>(indices);
+  }
+
+  ContextBase( @ModelName@_mass_eigenstates &m ) : model( m ) {}
+  ContextBase( const ContextBase & ) = default;
+  ContextBase( ContextBase && ) = default;
+  
+  ContextBase &operator=( const ContextBase & ) = default;
+  ContextBase &operator=( ContextBase && ) = default;
+  
+  virtual ~ContextBase( void ) = default;
+private:
+  template<class Field>
+  double mass_impl(const typename field_indices<Field>::type& indices) const;
+};
+
+@CXXDiagrams_MassFunctions@
+
+} // namespace cxx_diagrams
+} // namespace flexiblesusy
+
 #include "@ModelName@_vertices.hpp"
 
 #endif

--- a/templates/cxx_qft/context_base.hpp.in
+++ b/templates/cxx_qft/context_base.hpp.in
@@ -30,37 +30,39 @@
 
 #include "@ModelName@_fields.hpp"
 
-namespace flexiblesusy {
-namespace @ModelName@_cxx_diagrams {
-struct context_base
+namespace flexiblesusy
 {
-  @ModelName@_mass_eigenstates& model; ///< The model object.
- 
-  template<class Field>
-  double mass(const typename field_indices<Field>::type& indices) const
-  {
-    using CleanField = typename fields::remove_lorentz_conjugation<
-      Field
-    >::type;
-    return mass_impl<CleanField>(indices);
-  }
+namespace @ModelName@_cxx_diagrams
+{
+   struct context_base {
+      @ModelName@_mass_eigenstates& model; ///< The model object.
 
-  context_base( @ModelName@_mass_eigenstates &m ) : model( m ) {}
-  context_base( const context_base & ) = default;
-  context_base( context_base && ) = default;
-  
-  context_base &operator=( const context_base & ) = default;
-  context_base &operator=( context_base && ) = default;
-  
-  virtual ~context_base( void ) = default;
-private:
-  template<class Field>
-  double mass_impl(const typename field_indices<Field>::type& indices) const;
-};
+      template <class Field>
+      double mass(const typename field_indices<Field>::type& indices) const
+      {
+         using CleanField =
+            typename fields::remove_lorentz_conjugation<Field>::type;
+         return mass_impl<CleanField>(indices);
+      }
 
-@CXXDiagrams_MassFunctions@
+      context_base(@ModelName@_mass_eigenstates& m) : model(m) {}
+      context_base(const context_base&) = default;
+      context_base(context_base&&) = default;
 
-} // namespace cxx_diagrams
+      context_base& operator=(const context_base&) = default;
+      context_base& operator=(context_base&&) = default;
+
+      virtual ~context_base(void) = default;
+
+   private:
+      template <class Field>
+      double
+      mass_impl(const typename field_indices<Field>::type& indices) const;
+   };
+
+   @CXXDiagrams_MassFunctions@
+
+} // namespace @ModelName@_cxx_diagrams
 } // namespace flexiblesusy
 
 #include "@ModelName@_vertices.hpp"

--- a/templates/cxx_qft/fields.hpp.in
+++ b/templates/cxx_qft/fields.hpp.in
@@ -1,0 +1,172 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+// File generated at @DateAndTime@
+
+/**
+ * @file cxx_qft/@ModelName@_fields.hpp
+ *
+ * This file was generated at @DateAndTime@ with FlexibleSUSY
+ * @FlexibleSUSYVersion@ and SARAH @SARAHVersion@ .
+ */
+
+#ifndef @ModelName@_CXXQFT_FIELDS_H
+#define @ModelName@_CXXQFT_FIELDS_H
+
+#include <array>
+
+#include <boost/array.hpp>
+#include <boost/version.hpp>
+
+#include <boost/mpl/pair.hpp>
+#include <boost/mpl/erase.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/vector_c.hpp>
+#include <boost/mpl/joint_view.hpp>
+
+#include <boost/fusion/adapted/mpl.hpp>
+#include <boost/fusion/adapted/boost_array.hpp>
+
+#if BOOST_VERSION >= 105800
+#include <boost/fusion/include/move.hpp>
+#else
+#include <boost/fusion/include/copy.hpp>
+#endif
+
+namespace flexiblesusy {
+namespace @ModelName@_cxx_diagrams {
+// Declare a type that can hold the field indices for any given field
+template<class Field> struct field_indices {
+   using type = std::array<int, Field::numberOfFieldIndices>;
+};
+
+namespace detail
+{
+template<class Field>
+struct number_of_field_indices
+{
+  static constexpr int value =
+    std::tuple_size<typename field_indices<Field>::type>::value;
+  using type = boost::mpl::int_<value>;
+};
+
+template<class FieldSequence>
+struct total_number_of_field_indices
+{
+  using type = typename boost::mpl::fold<
+    FieldSequence,
+    boost::mpl::int_<0>,
+    boost::mpl::plus<
+      boost::mpl::_1,
+      number_of_field_indices<
+        boost::mpl::_2
+      >
+    >
+  >::type;
+  static constexpr int value = type::value;
+};
+}
+
+template<class Field>
+typename std::enable_if<
+  Field::numberOfGenerations != 1,
+  bool
+>::type
+isSMField(const typename field_indices<Field>::type& indices)
+{
+  boost::array<bool, Field::numberOfGenerations> sm_flags;
+
+#if BOOST_VERSION >= 105800
+  boost::fusion::move(typename Field::sm_flags(), sm_flags);
+#else
+  boost::fusion::copy(typename Field::sm_flags(), sm_flags);
+#endif
+
+  return sm_flags[indices.front()];
+}
+
+template<class Field>
+typename std::enable_if<
+  Field::numberOfGenerations == 1,
+  bool
+>::type
+isSMField(const typename field_indices<Field>::type &)
+{
+  return boost::mpl::at_c<
+    typename Field::sm_flags,
+    0
+  >::type::value;
+}
+
+namespace fields
+{
+template<class Field> struct bar
+{
+  using index_bounds = typename Field::index_bounds;
+  static constexpr int numberOfGenerations = Field::numberOfGenerations;
+  using sm_flags = typename Field::sm_flags;
+  static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
+  static constexpr double electric_charge = - Field::electric_charge;
+  using lorentz_conjugate = Field;
+
+  using type = bar<Field>;
+};
+
+template<class Field> struct conj
+{
+  using index_bounds = typename Field::index_bounds;
+  static constexpr int numberOfGenerations = Field::numberOfGenerations;
+  using sm_flags = typename Field::sm_flags;
+  static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
+  static constexpr double electric_charge = - Field::electric_charge;
+  using lorentz_conjugate = Field;
+
+  using type = conj<Field>;
+};
+
+// Double Lorentz conjugation
+template<class Field> struct bar<bar<Field>> {
+   using type = Field;
+};
+template<class Field> struct conj<conj<Field>> {
+   using type = Field;
+};
+
+// Remove Lorentz conjugation
+template<class Field> struct remove_lorentz_conjugation {
+   using type = Field;
+};
+
+template<class Field> struct remove_lorentz_conjugation<bar<Field>> {
+   using type = Field;
+};
+
+template<class Field> struct remove_lorentz_conjugation<conj<Field>> {
+   using type = Field;
+};
+
+@CXXDiagrams_Fields@
+}
+
+using fields::bar;
+using fields::conj;
+using fields::remove_lorentz_conjugation;
+}
+}
+
+#endif

--- a/templates/cxx_qft/fields.hpp.in
+++ b/templates/cxx_qft/fields.hpp.in
@@ -33,14 +33,14 @@
 #include <boost/array.hpp>
 #include <boost/version.hpp>
 
-#include <boost/mpl/pair.hpp>
 #include <boost/mpl/erase.hpp>
+#include <boost/mpl/joint_view.hpp>
+#include <boost/mpl/pair.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/vector_c.hpp>
-#include <boost/mpl/joint_view.hpp>
 
-#include <boost/fusion/adapted/mpl.hpp>
 #include <boost/fusion/adapted/boost_array.hpp>
+#include <boost/fusion/adapted/mpl.hpp>
 
 #if BOOST_VERSION >= 105800
 #include <boost/fusion/include/move.hpp>
@@ -48,125 +48,116 @@
 #include <boost/fusion/include/copy.hpp>
 #endif
 
-namespace flexiblesusy {
-namespace @ModelName@_cxx_diagrams {
-// Declare a type that can hold the field indices for any given field
-template<class Field> struct field_indices {
-   using type = std::array<int, Field::numberOfFieldIndices>;
-};
+namespace flexiblesusy
+{
+namespace @ModelName@_cxx_diagrams
+{
+   // Declare a type that can hold the field indices for any given field
+   template <class Field>
+   struct field_indices {
+      using type = std::array<int, Field::numberOfFieldIndices>;
+   };
 
-namespace detail
-{
-template<class Field>
-struct number_of_field_indices
-{
-  static constexpr int value =
-    std::tuple_size<typename field_indices<Field>::type>::value;
-  using type = boost::mpl::int_<value>;
-};
+   namespace detail
+   {
+   template <class Field>
+   struct number_of_field_indices {
+      static constexpr int value =
+         std::tuple_size<typename field_indices<Field>::type>::value;
+      using type = boost::mpl::int_<value>;
+   };
 
-template<class FieldSequence>
-struct total_number_of_field_indices
-{
-  using type = typename boost::mpl::fold<
-    FieldSequence,
-    boost::mpl::int_<0>,
-    boost::mpl::plus<
-      boost::mpl::_1,
-      number_of_field_indices<
-        boost::mpl::_2
-      >
-    >
-  >::type;
-  static constexpr int value = type::value;
-};
-}
+   template <class FieldSequence>
+   struct total_number_of_field_indices {
+      using type = typename boost::mpl::fold<
+         FieldSequence, boost::mpl::int_<0>,
+         boost::mpl::plus<boost::mpl::_1,
+                          number_of_field_indices<boost::mpl::_2>>>::type;
+      static constexpr int value = type::value;
+   };
+   } // namespace detail
 
-template<class Field>
-typename std::enable_if<
-  Field::numberOfGenerations != 1,
-  bool
->::type
-isSMField(const typename field_indices<Field>::type& indices)
-{
-  boost::array<bool, Field::numberOfGenerations> sm_flags;
+   template <class Field>
+   typename std::enable_if<Field::numberOfGenerations != 1, bool>::type
+   isSMField(const typename field_indices<Field>::type& indices)
+   {
+      boost::array<bool, Field::numberOfGenerations> sm_flags;
 
 #if BOOST_VERSION >= 105800
-  boost::fusion::move(typename Field::sm_flags(), sm_flags);
+      boost::fusion::move(typename Field::sm_flags(), sm_flags);
 #else
-  boost::fusion::copy(typename Field::sm_flags(), sm_flags);
+      boost::fusion::copy(typename Field::sm_flags(), sm_flags);
 #endif
 
-  return sm_flags[indices.front()];
-}
+      return sm_flags[indices.front()];
+   }
 
-template<class Field>
-typename std::enable_if<
-  Field::numberOfGenerations == 1,
-  bool
->::type
-isSMField(const typename field_indices<Field>::type &)
-{
-  return boost::mpl::at_c<
-    typename Field::sm_flags,
-    0
-  >::type::value;
-}
+   template <class Field>
+   typename std::enable_if<Field::numberOfGenerations == 1, bool>::type
+   isSMField(const typename field_indices<Field>::type&)
+   {
+      return boost::mpl::at_c<typename Field::sm_flags, 0>::type::value;
+   }
 
-namespace fields
-{
-template<class Field> struct bar
-{
-  using index_bounds = typename Field::index_bounds;
-  static constexpr int numberOfGenerations = Field::numberOfGenerations;
-  using sm_flags = typename Field::sm_flags;
-  static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
-  static constexpr double electric_charge = - Field::electric_charge;
-  using lorentz_conjugate = Field;
+   namespace fields
+   {
+   template <class Field>
+   struct bar {
+      using index_bounds = typename Field::index_bounds;
+      static constexpr int numberOfGenerations = Field::numberOfGenerations;
+      using sm_flags = typename Field::sm_flags;
+      static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
+      static constexpr double electric_charge = -Field::electric_charge;
+      using lorentz_conjugate = Field;
 
-  using type = bar<Field>;
-};
+      using type = bar<Field>;
+   };
 
-template<class Field> struct conj
-{
-  using index_bounds = typename Field::index_bounds;
-  static constexpr int numberOfGenerations = Field::numberOfGenerations;
-  using sm_flags = typename Field::sm_flags;
-  static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
-  static constexpr double electric_charge = - Field::electric_charge;
-  using lorentz_conjugate = Field;
+   template <class Field>
+   struct conj {
+      using index_bounds = typename Field::index_bounds;
+      static constexpr int numberOfGenerations = Field::numberOfGenerations;
+      using sm_flags = typename Field::sm_flags;
+      static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
+      static constexpr double electric_charge = -Field::electric_charge;
+      using lorentz_conjugate = Field;
 
-  using type = conj<Field>;
-};
+      using type = conj<Field>;
+   };
 
-// Double Lorentz conjugation
-template<class Field> struct bar<bar<Field>> {
-   using type = Field;
-};
-template<class Field> struct conj<conj<Field>> {
-   using type = Field;
-};
+   // Double Lorentz conjugation
+   template <class Field>
+   struct bar<bar<Field>> {
+      using type = Field;
+   };
+   template <class Field>
+   struct conj<conj<Field>> {
+      using type = Field;
+   };
 
-// Remove Lorentz conjugation
-template<class Field> struct remove_lorentz_conjugation {
-   using type = Field;
-};
+   // Remove Lorentz conjugation
+   template <class Field>
+   struct remove_lorentz_conjugation {
+      using type = Field;
+   };
 
-template<class Field> struct remove_lorentz_conjugation<bar<Field>> {
-   using type = Field;
-};
+   template <class Field>
+   struct remove_lorentz_conjugation<bar<Field>> {
+      using type = Field;
+   };
 
-template<class Field> struct remove_lorentz_conjugation<conj<Field>> {
-   using type = Field;
-};
+   template <class Field>
+   struct remove_lorentz_conjugation<conj<Field>> {
+      using type = Field;
+   };
 
-@CXXDiagrams_Fields@
-}
+   @CXXDiagrams_Fields@
+   } // namespace fields
 
-using fields::bar;
-using fields::conj;
-using fields::remove_lorentz_conjugation;
-}
-}
+   using fields::bar;
+   using fields::conj;
+   using fields::remove_lorentz_conjugation;
+} // namespace @ModelName@_cxx_diagrams
+} // namespace flexiblesusy
 
 #endif

--- a/templates/cxx_qft/qft.hpp.in
+++ b/templates/cxx_qft/qft.hpp.in
@@ -30,8 +30,8 @@
 
 #include "multiindex.hpp"
 
-#include "@ModelName@_fields.hpp"
 #include "@ModelName@_context_base.hpp"
+#include "@ModelName@_fields.hpp"
 #include "@ModelName@_vertices.hpp"
 
 #endif

--- a/templates/cxx_qft/qft.hpp.in
+++ b/templates/cxx_qft/qft.hpp.in
@@ -1,0 +1,99 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+// File generated at @DateAndTime@
+
+/**
+ * @file cxx_qft/@ModelName@_qft.hpp
+ *
+ * This file was generated at @DateAndTime@ with FlexibleSUSY
+ * @FlexibleSUSYVersion@ and SARAH @SARAHVersion@ .
+ */
+
+#ifndef @ModelName@_CXXQFT_QFT_H
+#define @ModelName@_CXXQFT_QFT_H
+
+#include <boost/range/iterator_range.hpp>
+
+#include "multiindex.hpp"
+
+#include "@ModelName@_fields.hpp"
+
+namespace flexiblesusy {
+namespace @ModelName@_cxx_diagrams {
+namespace detail {
+template<class ObjectWithIndexBounds>
+struct index_bounds
+{
+  using type = typename ObjectWithIndexBounds::index_bounds;
+};
+}
+
+template<class ObjectWithIndexBounds>
+static decltype(
+  boost::make_iterator_range(
+    multiindex<
+      typename detail::index_bounds<ObjectWithIndexBounds>::type::first,
+      typename detail::index_bounds<ObjectWithIndexBounds>::type::second
+    >::begin(),
+    multiindex<
+      typename detail::index_bounds<ObjectWithIndexBounds>::type::first,
+      typename detail::index_bounds<ObjectWithIndexBounds>::type::second
+    >::end()
+  )
+)
+index_range( void )
+{
+  return boost::make_iterator_range(
+    multiindex<
+      typename detail::index_bounds<ObjectWithIndexBounds>::type::first,
+      typename detail::index_bounds<ObjectWithIndexBounds>::type::second
+    >::begin(),
+    multiindex<
+      typename detail::index_bounds<ObjectWithIndexBounds>::type::first,
+      typename detail::index_bounds<ObjectWithIndexBounds>::type::second
+    >::end()
+  );
+}
+
+struct EvaluationContext
+{
+  @ModelName@_mass_eigenstates& model; ///< The model object.
+ 
+  template<class Field>
+  double mass(const typename field_indices<Field>::type& indices) const
+  {
+    using CleanField = typename fields::remove_lorentz_conjugation<
+      Field
+    >::type;
+    return mass_impl<CleanField>(indices);
+  }
+
+private:
+  template<class Field>
+  double mass_impl(const typename field_indices<Field>::type& indices) const;
+};
+
+@CXXDiagrams_MassFunctions@
+
+} // namespace cxx_diagrams
+} // namespace flexiblesusy
+
+#include "@ModelName@_vertices.hpp"
+
+#endif

--- a/templates/cxx_qft/vertices.hpp.in
+++ b/templates/cxx_qft/vertices.hpp.in
@@ -154,7 +154,7 @@ public:
  */
 template<class ...Fields> struct VertexData;
 
-struct ContextBase;
+struct context_base;
 
 template<class ...Fields> class Vertex {
   using Data = VertexData<Fields...>;
@@ -226,7 +226,7 @@ public:
   }
 
   static vertex_type evaluate(const indices_type& indices,
-    const ContextBase& context);
+    const context_base& context);
 };
 
 @CXXDiagrams_VertexData@
@@ -238,7 +238,7 @@ namespace detail {
 @CXXDiagrams_UnitCharge@
 }
 
-static double unit_charge(const ContextBase& context)
+static double unit_charge(const context_base& context)
 {
    return - (detail::unit_charge(context).left().real() /
      fields::Electron::electric_charge);

--- a/templates/cxx_qft/vertices.hpp.in
+++ b/templates/cxx_qft/vertices.hpp.in
@@ -28,24 +28,24 @@
 #ifndef @ModelName@_CXXQFT_VERTICES_H
 #define @ModelName@_CXXQFT_VERTICES_H
 
+#include "concatenate.hpp"
+#include "multiindex.hpp"
 #include "numerics2.hpp"
 #include "wrappers.hpp"
-#include "multiindex.hpp"
-#include "concatenate.hpp"
 
 #include <array>
 
 #include <boost/array.hpp>
-#include <boost/version.hpp>
 #include <boost/range/join.hpp>
+#include <boost/version.hpp>
 
 #include <boost/mpl/erase.hpp>
-#include <boost/mpl/vector_c.hpp>
 #include <boost/mpl/joint_view.hpp>
+#include <boost/mpl/vector_c.hpp>
 
+#include <boost/fusion/adapted/boost_array.hpp>
 #include <boost/fusion/adapted/mpl.hpp>
 #include <boost/fusion/include/vector.hpp>
-#include <boost/fusion/adapted/boost_array.hpp>
 
 #if BOOST_VERSION >= 105800
 #include <boost/fusion/include/move.hpp>
@@ -58,193 +58,173 @@
 #define DERIVEDPARAMETER(p) context.model.p()
 #define PHASE(p) context.model.get_##p()
 
-namespace flexiblesusy {
-namespace @ModelName@_cxx_diagrams {
-class ScalarVertex {
-private:
-  std::complex<double> val;
-public:
-  ScalarVertex(std::complex<double> v)
-  : val(v) {}
-
-  std::complex<double> value() const
-  {
-     return val;
-  }
-
-  bool isZero() const
-  {
-    return (is_zero(val.real()) && is_zero(val.imag()));
-  }
-};
-
-class ChiralVertex {
-private:
-  std::pair<std::complex<double>, std::complex<double>> value;
-public:
-  ChiralVertex(const std::complex<double>& left,
-               const std::complex<double>& right)
-  : value(left, right) {}
-
-  std::complex<double> left() const
-  {
-     return value.first;
-  }
-
-  std::complex<double> right() const
-  {
-     return value.second;
-  }
-
-  bool isZero() const
-  {
-    return (is_zero(value.first.real()) && is_zero(value.first.imag()) &&
-            is_zero(value.second.real()) && is_zero(value.second.imag()));
-  }
-};
-
-class MomentumDifferenceVertex {
-private:
-  std::complex<double> val;
-  int minuendIndex;
-  int subtrahendIndex;
-public:
-  MomentumDifferenceVertex(std::complex<double> v, int mi, int si )
-  : val(v), minuendIndex(mi), subtrahendIndex(si) {}
-
-  std::complex<double> value(int mi, int si) const
-  {
-    if( mi == minuendIndex && si == subtrahendIndex )
-      return val;
-    if( mi == subtrahendIndex && si == minuendIndex )
-      return -val;
-
-    throw std::invalid_argument(
-       "MomentumDifferenceVertex: Wrong index combination" );
-    return 0.0;
-  }
-
-  bool isZero() const
-  {
-    return (is_zero(val.real()) && is_zero(val.imag()));
-  }
-};
-
-class InverseMetricVertex {
-private:
-  std::complex<double> val;
-public:
-  InverseMetricVertex(std::complex<double> v)
-  : val(v) {}
-
-  std::complex<double> value() const
-  {
-    return val;
-  }
-
-  bool isZero() const
-  {
-    return (is_zero(val.real()) && is_zero(val.imag()));
-  }
-};
-
-/**
- * @class VertexData<F...>
- * @brief VertexData data for a vertex with the fields specified by F....
- */
-template<class ...Fields> struct VertexData;
-
-struct context_base;
-
-template<class ...Fields> class Vertex {
-  using Data = VertexData<Fields...>;
-public:
-  using index_bounds = typename boost::mpl::fold<
-    boost::mpl::vector<Fields...>,
-    boost::mpl::pair<
-      boost::mpl::vector<>,
-      boost::mpl::vector<>
-    >,
-    boost::mpl::pair<
-      boost::mpl::joint_view<
-        boost::mpl::first<boost::mpl::_1>,
-        boost::mpl::first<
-          meta::index_bounds<boost::mpl::_2>
-        >
-      >,
-      boost::mpl::joint_view<
-        boost::mpl::second<boost::mpl::_1>,
-        boost::mpl::second<
-          meta::index_bounds<boost::mpl::_2>
-        >
-      >
-    >
-  >::type;
-  using indices_type = std::array<
-    int,
-    detail::total_number_of_field_indices<
-      boost::mpl::vector<Fields...>
-    >::value
-  >;
-  using vertex_type = typename Data::vertex_type;
-
-  template<int FieldIndex>
-  static typename field_indices<
-    typename boost::mpl::at_c<
-      boost::mpl::vector<Fields...>,
-      FieldIndex
-    >::type
-  >::type 
-  field_indices(const indices_type& indices)
-  {
-    using namespace boost::mpl;
-    using fields = vector<Fields...>;
-
-    using result_type = typename field_indices<
-      typename boost::mpl::at_c<fields, FieldIndex>::type
-    >::type;
-
-    using preceeding_fields = typename erase<
-      fields,
-      typename advance<
-        typename begin<fields>::type,
-        int_<FieldIndex>
-      >::type,
-      typename end<fields>::type
-    >::type;
-
-    constexpr int offset = detail::total_number_of_field_indices<
-      preceeding_fields
-    >::value;
-    constexpr int length = std::tuple_size<result_type>::value;
-
-    result_type result_indices;
-    std::copy( indices.begin() + offset,
-               indices.begin() + offset + length,
-               result_indices.begin() );
-    return result_indices;
-  }
-
-  static vertex_type evaluate(const indices_type& indices,
-    const context_base& context);
-};
-
-@CXXDiagrams_VertexData@
-
-
-@CXXDiagrams_Vertices@
-
-namespace detail {
-@CXXDiagrams_UnitCharge@
-}
-
-static double unit_charge(const context_base& context)
+namespace flexiblesusy
 {
-   return - (detail::unit_charge(context).left().real() /
-     fields::Electron::electric_charge);
-}
+namespace @ModelName@_cxx_diagrams
+{
+   class ScalarVertex
+   {
+   private:
+      std::complex<double> val;
 
-} // namespace cxx_diagrams
+   public:
+      ScalarVertex(std::complex<double> v) : val(v) {}
+
+      std::complex<double> value() const { return val; }
+
+      bool isZero() const
+      {
+         return (is_zero(val.real()) && is_zero(val.imag()));
+      }
+   };
+
+   class ChiralVertex
+   {
+   private:
+      std::pair<std::complex<double>, std::complex<double>> value;
+
+   public:
+      ChiralVertex(const std::complex<double>& left,
+                   const std::complex<double>& right)
+         : value(left, right)
+      {
+      }
+
+      std::complex<double> left() const { return value.first; }
+
+      std::complex<double> right() const { return value.second; }
+
+      bool isZero() const
+      {
+         return (is_zero(value.first.real()) && is_zero(value.first.imag()) &&
+                 is_zero(value.second.real()) && is_zero(value.second.imag()));
+      }
+   };
+
+   class MomentumDifferenceVertex
+   {
+   private:
+      std::complex<double> val;
+      int minuendIndex;
+      int subtrahendIndex;
+
+   public:
+      MomentumDifferenceVertex(std::complex<double> v, int mi, int si)
+         : val(v), minuendIndex(mi), subtrahendIndex(si)
+      {
+      }
+
+      std::complex<double> value(int mi, int si) const
+      {
+         if (mi == minuendIndex && si == subtrahendIndex)
+            return val;
+         if (mi == subtrahendIndex && si == minuendIndex)
+            return -val;
+
+         throw std::invalid_argument(
+            "MomentumDifferenceVertex: Wrong index combination");
+         return 0.0;
+      }
+
+      bool isZero() const
+      {
+         return (is_zero(val.real()) && is_zero(val.imag()));
+      }
+   };
+
+   class InverseMetricVertex
+   {
+   private:
+      std::complex<double> val;
+
+   public:
+      InverseMetricVertex(std::complex<double> v) : val(v) {}
+
+      std::complex<double> value() const { return val; }
+
+      bool isZero() const
+      {
+         return (is_zero(val.real()) && is_zero(val.imag()));
+      }
+   };
+
+   /**
+    * @class VertexData<F...>
+    * @brief VertexData data for a vertex with the fields specified by F....
+    */
+   template <class... Fields>
+   struct VertexData;
+
+   struct context_base;
+
+   template <class... Fields>
+   class Vertex
+   {
+      using Data = VertexData<Fields...>;
+
+   public:
+      using index_bounds = typename boost::mpl::fold<
+         boost::mpl::vector<Fields...>,
+         boost::mpl::pair<boost::mpl::vector<>, boost::mpl::vector<>>,
+         boost::mpl::pair<
+            boost::mpl::joint_view<
+               boost::mpl::first<boost::mpl::_1>,
+               boost::mpl::first<meta::index_bounds<boost::mpl::_2>>>,
+            boost::mpl::joint_view<
+               boost::mpl::second<boost::mpl::_1>,
+               boost::mpl::second<meta::index_bounds<boost::mpl::_2>>>>>::type;
+      using indices_type =
+         std::array<int, detail::total_number_of_field_indices<
+                            boost::mpl::vector<Fields...>>::value>;
+      using vertex_type = typename Data::vertex_type;
+
+      template <int FieldIndex>
+      static typename field_indices<typename boost::mpl::at_c<
+         boost::mpl::vector<Fields...>, FieldIndex>::type>::type
+      field_indices(const indices_type& indices)
+      {
+         using namespace boost::mpl;
+         using fields = vector<Fields...>;
+
+         using result_type = typename field_indices<
+            typename boost::mpl::at_c<fields, FieldIndex>::type>::type;
+
+         using preceeding_fields =
+            typename erase<fields,
+                           typename advance<typename begin<fields>::type,
+                                            int_<FieldIndex>>::type,
+                           typename end<fields>::type>::type;
+
+         constexpr int offset =
+            detail::total_number_of_field_indices<preceeding_fields>::value;
+         constexpr int length = std::tuple_size<result_type>::value;
+
+         result_type result_indices;
+         std::copy(indices.begin() + offset, indices.begin() + offset + length,
+                   result_indices.begin());
+         return result_indices;
+      }
+
+      static vertex_type evaluate(const indices_type& indices,
+                                  const context_base& context);
+   };
+
+   @CXXDiagrams_VertexData@
+
+   @CXXDiagrams_Vertices@
+
+   namespace detail
+   {
+      @CXXDiagrams_UnitCharge@
+   }
+
+   static double unit_charge(const context_base& context)
+   {
+      return -(detail::unit_charge(context).left().real() /
+               fields::Electron::electric_charge);
+   }
+
+} // namespace @ModelName@_cxx_diagrams
 } // namespace flexiblesusy
 
 #undef INPUTPARAMETER

--- a/templates/cxx_qft/vertices.hpp.in
+++ b/templates/cxx_qft/vertices.hpp.in
@@ -154,7 +154,7 @@ public:
  */
 template<class ...Fields> struct VertexData;
 
-struct EvaluationContext;
+struct ContextBase;
 
 template<class ...Fields> class Vertex {
   using Data = VertexData<Fields...>;
@@ -169,13 +169,13 @@ public:
       boost::mpl::joint_view<
         boost::mpl::first<boost::mpl::_1>,
         boost::mpl::first<
-          detail::index_bounds<boost::mpl::_2>
+          meta::index_bounds<boost::mpl::_2>
         >
       >,
       boost::mpl::joint_view<
         boost::mpl::second<boost::mpl::_1>,
         boost::mpl::second<
-          detail::index_bounds<boost::mpl::_2>
+          meta::index_bounds<boost::mpl::_2>
         >
       >
     >
@@ -226,7 +226,7 @@ public:
   }
 
   static vertex_type evaluate(const indices_type& indices,
-    const EvaluationContext& context);
+    const ContextBase& context);
 };
 
 @CXXDiagrams_VertexData@
@@ -238,7 +238,7 @@ namespace detail {
 @CXXDiagrams_UnitCharge@
 }
 
-static double unit_charge(const EvaluationContext& context)
+static double unit_charge(const ContextBase& context)
 {
    return - (detail::unit_charge(context).left().real() /
      fields::Electron::electric_charge);

--- a/templates/cxx_qft/vertices.hpp.in
+++ b/templates/cxx_qft/vertices.hpp.in
@@ -19,14 +19,14 @@
 // File generated at @DateAndTime@
 
 /**
- * @file @ModelName@_cxx_diagrams.hpp
+ * @file cxx_qft/@ModelName@_vertices.hpp
  *
  * This file was generated at @DateAndTime@ with FlexibleSUSY
  * @FlexibleSUSYVersion@ and SARAH @SARAHVersion@ .
  */
 
-#ifndef @ModelName@_CXXDIAGRAMS_H
-#define @ModelName@_CXXDIAGRAMS_H
+#ifndef @ModelName@_CXXQFT_VERTICES_H
+#define @ModelName@_CXXQFT_VERTICES_H
 
 #include "numerics2.hpp"
 #include "wrappers.hpp"
@@ -59,157 +59,7 @@
 #define PHASE(p) context.model.get_##p()
 
 namespace flexiblesusy {
-namespace cxx_diagrams {
-
-// Declare a type that can hold the field indices for any given field
-template<class Field> struct field_indices {
-   using type = std::array<int, Field::numberOfFieldIndices>;
-};
-
-namespace detail
-{
-  template<class Field>
-  struct number_of_field_indices
-  {
-    static constexpr int value =
-      std::tuple_size<typename field_indices<Field>::type>::value;
-    using type = boost::mpl::int_<value>;
-  };
-
-  template<class Sequence>
-  struct total_number_of_field_indices
-  {
-    using type = typename boost::mpl::fold<
-      Sequence,
-      boost::mpl::int_<0>,
-      boost::mpl::plus<
-        boost::mpl::_1,
-        number_of_field_indices<
-          boost::mpl::_2
-        >
-      >
-    >::type;
-    static constexpr int value = type::value;
-  };
-}
-
-template<class Field> struct bar
-{
-  using index_bounds = typename Field::index_bounds;
-  static constexpr int numberOfGenerations = Field::numberOfGenerations;
-  using sm_flags = typename Field::sm_flags;
-  static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
-  static constexpr double electric_charge = - Field::electric_charge;
-  using lorentz_conjugate = Field;
-
-  using type = bar<Field>;
-};
-
-template<class Field> struct conj
-{
-  using index_bounds = typename Field::index_bounds;
-  static constexpr int numberOfGenerations = Field::numberOfGenerations;
-  using sm_flags = typename Field::sm_flags;
-  static constexpr int numberOfFieldIndices = Field::numberOfFieldIndices;
-  static constexpr double electric_charge = - Field::electric_charge;
-  using lorentz_conjugate = Field;
-
-  using type = conj<Field>;
-};
-
-// Double Lorentz conjugation
-template<class Field> struct bar<bar<Field>> {
-   using type = Field;
-};
-template<class Field> struct conj<conj<Field>> {
-   using type = Field;
-};
-
-// Remove Lorentz conjugation
-template<class Field> struct remove_lorentz_conjugation {
-   using type = Field;
-};
-
-template<class Field> struct remove_lorentz_conjugation<bar<Field>> {
-   using type = Field;
-};
-
-template<class Field> struct remove_lorentz_conjugation<conj<Field>> {
-   using type = Field;
-};
-
-
-template<class Field>
-typename std::enable_if<
-  Field::numberOfGenerations != 1,
-  bool
->::type
-isSMField(const typename field_indices<Field>::type& indices)
-{
-  boost::array<bool, Field::numberOfGenerations> sm_flags;
-
-#if BOOST_VERSION >= 105800
-  boost::fusion::move(typename Field::sm_flags(), sm_flags);
-#else
-  boost::fusion::copy(typename Field::sm_flags(), sm_flags);
-#endif
-
-  return sm_flags[indices.front()];
-}
-
-template<class Field>
-typename std::enable_if<
-  Field::numberOfGenerations == 1,
-  bool
->::type
-isSMField(const typename field_indices<Field>::type &)
-{
-  return boost::mpl::at_c<
-    typename Field::sm_flags,
-    0
-  >::type::value;
-}
-
-namespace detail
-{
-template<class Begin, class End>
-decltype(
-  boost::make_iterator_range(
-    multiindex<Begin, End>::begin(),
-    multiindex<Begin, End>::end()
-  )
-)
-make_index_range( void )
-{
-  using index = multiindex<Begin, End>;
-
-  return boost::make_iterator_range(
-    index::begin(), index::end()
-  );
-}
-}
-
-template<class ObjectWithIndexBounds>
-struct index_bounds_of
-{
-  using type = typename ObjectWithIndexBounds::index_bounds;
-};
-
-template<class ObjectWithIndexBounds>
-decltype(detail::make_index_range<
-  typename index_bounds_of<ObjectWithIndexBounds>::type::first,
-  typename index_bounds_of<ObjectWithIndexBounds>::type::second
->())
-index_range( void )
-{
-  return detail::make_index_range<
-    typename index_bounds_of<ObjectWithIndexBounds>::type::first,
-    typename index_bounds_of<ObjectWithIndexBounds>::type::second
-  >();
-}
-
-@CXXDiagrams_Fields@
-
+namespace @ModelName@_cxx_diagrams {
 class ScalarVertex {
 private:
   std::complex<double> val;
@@ -319,13 +169,13 @@ public:
       boost::mpl::joint_view<
         boost::mpl::first<boost::mpl::_1>,
         boost::mpl::first<
-          index_bounds_of<boost::mpl::_2>
+          detail::index_bounds<boost::mpl::_2>
         >
       >,
       boost::mpl::joint_view<
         boost::mpl::second<boost::mpl::_1>,
         boost::mpl::second<
-          index_bounds_of<boost::mpl::_2>
+          detail::index_bounds<boost::mpl::_2>
         >
       >
     >
@@ -379,46 +229,19 @@ public:
     const EvaluationContext& context);
 };
 
-
-/**
-* @class EvaluationContext
-* @brief Represents an evaluation context.
-*
-* It simply contains a reference to a model object.
-* All computational functions are forwarded to that object,
-* e.g. mass calculation functions.
-*/
-struct EvaluationContext {
-   @ModelName@_mass_eigenstates& model; ///< The model object.
-
-   template<class Field>
-   double mass(const typename field_indices<Field>::type& indices) const
-   {
-      using CleanField = typename remove_lorentz_conjugation<Field>::type;
-      return mass_impl<CleanField>(indices);
-   }
-
-private:
-   template<class Field>
-   double mass_impl(const typename field_indices<Field>::type& indices) const;
-};
-
-
 @CXXDiagrams_VertexData@
 
 
 @CXXDiagrams_Vertices@
 
-
-@CXXDiagrams_MassFunctions@
-
-namespace impl {
+namespace detail {
 @CXXDiagrams_UnitCharge@
 }
 
 static double unit_charge(const EvaluationContext& context)
 {
-   return -impl::unit_charge(context).left().real() / Electron::electric_charge;
+   return - (detail::unit_charge(context).left().real() /
+     fields::Electron::electric_charge);
 }
 
 } // namespace cxx_diagrams

--- a/templates/edm.cpp.in
+++ b/templates/edm.cpp.in
@@ -28,7 +28,9 @@
 #include "@ModelName@_edm.hpp"
 #include "@ModelName@_mass_eigenstates.hpp"
 
-#include "@ModelName@_cxx_diagrams.hpp"
+#include "cxx_qft/@ModelName@_qft.hpp"
+
+#include "numerics2.hpp"
 
 #define INPUTPARAMETER(p) context.model.get_input().p
 #define MODELPARAMETER(p) context.model.get_##p()
@@ -36,7 +38,7 @@
 #define PHASE(p) context.model.get_##p()
 
 using namespace flexiblesusy;
-using namespace cxx_diagrams;
+using namespace @ModelName@_cxx_diagrams;
 
 namespace {
 static constexpr double oneOver16PiSquared = 0.0063325739776461107152;

--- a/templates/edm.cpp.in
+++ b/templates/edm.cpp.in
@@ -159,16 +159,14 @@ EDMField, PhotonEmitter, ExchangeField
                          PhotonEmitter
                          >;
 
-   constexpr auto indexBounds = FermionVertex::index_bounds;
-
-   for (const auto& index: indexBounds) {
-      const auto edmFieldIndices = FermionVertex::template fieldIndices<0>(index);
+   for (const auto& index: index_range<FermionVertex>()) {
+      const auto edmFieldIndices = FermionVertex::template field_indices<0>(index);
 
       if (edmFieldIndices != indices)
          continue;
 
-      const auto photonEmitterIndices = FermionVertex::template fieldIndices<2>(index);
-      const auto exchangeFieldIndices = FermionVertex::template fieldIndices<1>(index);
+      const auto photonEmitterIndices = FermionVertex::template field_indices<2>(index);
+      const auto exchangeFieldIndices = FermionVertex::template field_indices<1>(index);
       const auto vertex = FermionVertex::evaluate(index, context);
 
       const auto photonEmitterMass = context.mass<PhotonEmitter>(photonEmitterIndices);
@@ -204,16 +202,14 @@ EDMField, PhotonEmitter, ExchangeField
                          PhotonEmitter
                          >;
 
-   constexpr auto indexBounds = FermionVertex::index_bounds;
-
-   for (const auto& index: indexBounds) {
-      const auto edmFieldIndices = FermionVertex::template fieldIndices<0>(index);
+   for (const auto& index: index_range<FermionVertex>()) {
+      const auto edmFieldIndices = FermionVertex::template field_indices<0>(index);
 
       if (edmFieldIndices != indices)
          continue;
 
-      const auto photonEmitterIndices = FermionVertex::template fieldIndices<2>(index);
-      const auto exchangeFieldIndices = FermionVertex::template fieldIndices<1>(index);
+      const auto photonEmitterIndices = FermionVertex::template field_indices<2>(index);
+      const auto exchangeFieldIndices = FermionVertex::template field_indices<1>(index);
       const auto vertex = FermionVertex::evaluate(index, context);
 
       const auto photonEmitterMass = context.mass<PhotonEmitter>(photonEmitterIndices);

--- a/templates/edm.cpp.in
+++ b/templates/edm.cpp.in
@@ -61,7 +61,7 @@ static constexpr double oneOver16PiSquared = 0.0063325739776461107152;
 template<class EDMField, class PhotonEmitter, class ExchangeParticle>
 struct EDMVertexCorrectionSF {
    static double value(const typename field_indices<EDMField>::type& indices,
-                       ContextBase& context);
+                       context_base& context);
 };
 
 /**
@@ -82,7 +82,7 @@ struct EDMVertexCorrectionSF {
 template<class EDMField, class PhotonEmitter, class ExchangeParticle>
 struct EDMVertexCorrectionFS {
    static double value(const typename field_indices<EDMField>::type& indices,
-                       ContextBase& context);
+                       context_base& context);
 };
 } // anonymous namespace
 
@@ -151,7 +151,7 @@ double OneLoopFunctionB(double r)
 template<class EDMField, class PhotonEmitter, class ExchangeField>
 double EDMVertexCorrectionFS<
 EDMField, PhotonEmitter, ExchangeField
->::value(const typename field_indices<EDMField>::type& indices, ContextBase& context)
+>::value(const typename field_indices<EDMField>::type& indices, context_base& context)
 {
    double res = 0.0;
 
@@ -194,7 +194,7 @@ EDMField, PhotonEmitter, ExchangeField
 template<class EDMField, class PhotonEmitter, class ExchangeField>
 double EDMVertexCorrectionSF<
 EDMField, PhotonEmitter, ExchangeField
->::value(const typename field_indices<EDMField>::type& indices, ContextBase& context)
+>::value(const typename field_indices<EDMField>::type& indices, context_base& context)
 {
    double res = 0.0;
 

--- a/templates/edm.cpp.in
+++ b/templates/edm.cpp.in
@@ -61,7 +61,7 @@ static constexpr double oneOver16PiSquared = 0.0063325739776461107152;
 template<class EDMField, class PhotonEmitter, class ExchangeParticle>
 struct EDMVertexCorrectionSF {
    static double value(const typename field_indices<EDMField>::type& indices,
-                       EvaluationContext& context);
+                       ContextBase& context);
 };
 
 /**
@@ -82,7 +82,7 @@ struct EDMVertexCorrectionSF {
 template<class EDMField, class PhotonEmitter, class ExchangeParticle>
 struct EDMVertexCorrectionFS {
    static double value(const typename field_indices<EDMField>::type& indices,
-                       EvaluationContext& context);
+                       ContextBase& context);
 };
 } // anonymous namespace
 
@@ -151,7 +151,7 @@ double OneLoopFunctionB(double r)
 template<class EDMField, class PhotonEmitter, class ExchangeField>
 double EDMVertexCorrectionFS<
 EDMField, PhotonEmitter, ExchangeField
->::value(const typename field_indices<EDMField>::type& indices, EvaluationContext& context)
+>::value(const typename field_indices<EDMField>::type& indices, ContextBase& context)
 {
    double res = 0.0;
 
@@ -194,7 +194,7 @@ EDMField, PhotonEmitter, ExchangeField
 template<class EDMField, class PhotonEmitter, class ExchangeField>
 double EDMVertexCorrectionSF<
 EDMField, PhotonEmitter, ExchangeField
->::value(const typename field_indices<EDMField>::type& indices, EvaluationContext& context)
+>::value(const typename field_indices<EDMField>::type& indices, ContextBase& context)
 {
    double res = 0.0;
 

--- a/templates/module.mk
+++ b/templates/module.mk
@@ -5,6 +5,7 @@ BASE_TEMPLATES := \
 		$(DIR)/cxx_qft/qft.hpp.in \
 		$(DIR)/cxx_qft/fields.hpp.in \
 		$(DIR)/cxx_qft/vertices.hpp.in \
+		$(DIR)/cxx_qft/context_base.hpp.in \
 		$(DIR)/a_muon.hpp.in \
 		$(DIR)/a_muon.cpp.in \
 		$(DIR)/edm.hpp.in \

--- a/templates/module.mk
+++ b/templates/module.mk
@@ -2,7 +2,9 @@ DIR          := templates
 MODNAME      := templates
 
 BASE_TEMPLATES := \
-		$(DIR)/cxx_diagrams.hpp.in \
+		$(DIR)/cxx_qft/qft.hpp.in \
+		$(DIR)/cxx_qft/fields.hpp.in \
+		$(DIR)/cxx_qft/vertices.hpp.in \
 		$(DIR)/a_muon.hpp.in \
 		$(DIR)/a_muon.cpp.in \
 		$(DIR)/edm.hpp.in \

--- a/templates/module.mk.in
+++ b/templates/module.mk.in
@@ -71,6 +71,7 @@ LIB@CLASSNAME@_HDR := \
 		$(DIR)/cxx_qft/@CLASSNAME@_qft.hpp \
 		$(DIR)/cxx_qft/@CLASSNAME@_fields.hpp \
 		$(DIR)/cxx_qft/@CLASSNAME@_vertices.hpp \
+		$(DIR)/cxx_qft/@CLASSNAME@_context_base.hpp \
 		$(DIR)/@CLASSNAME@_a_muon.hpp \
 		$(DIR)/@CLASSNAME@_convergence_tester.hpp \
 		$(DIR)/@CLASSNAME@_edm.hpp \

--- a/templates/module.mk.in
+++ b/templates/module.mk.in
@@ -68,7 +68,9 @@ LL@CLASSNAME@_MMA  := \
 		$(DIR)/run_@CLASSNAME@.m
 
 LIB@CLASSNAME@_HDR := \
-		$(DIR)/@CLASSNAME@_cxx_diagrams.hpp \
+		$(DIR)/cxx_qft/@CLASSNAME@_qft.hpp \
+		$(DIR)/cxx_qft/@CLASSNAME@_fields.hpp \
+		$(DIR)/cxx_qft/@CLASSNAME@_vertices.hpp \
 		$(DIR)/@CLASSNAME@_a_muon.hpp \
 		$(DIR)/@CLASSNAME@_convergence_tester.hpp \
 		$(DIR)/@CLASSNAME@_edm.hpp \


### PR DESCRIPTION
- Make CXXDiagrams stateless
- Do not rely on SARAH`Vertex[]. Instead read the vertices directly from SARAH`VertexList* (dramatic speed increase)
- Give the c++ code a nicer structure
- Adapt the existing code to the new interfaces (still almost the same)

The changes should not affect any results. Could you please do the unit testing (I am unfamiliar with the framework - and doing this on the local cluster would be difficult...)?