### PR TITLE
fixed linking with ifort compiled LoopTools

### DIFF
--- a/configure
+++ b/configure
@@ -1850,7 +1850,7 @@ check_fortran_libs() {
         g77|f77)
             FLIBS="-lg2c -lm" ;;
         ifort)
-            FLIBS="-lifcore -limf -ldl -lintlc -lsvml" ;;
+            FLIBS="-lifcore -lifport -limf -ldl -lintlc -lsvml" ;;
     esac
 }
 


### PR DESCRIPTION
Linking against `LoopTools` compiled with `ifort` yields (among others) the following error
```
undefined reference to 'getenv_'
```
As far as I understand, the problem is that contrary to `gfortran` where everything is in `libgfortran` library intel splits it into multiple ones: `libifort`, `libifport` and others. According to [this](http://ladon.iqfr.csic.es/intel/doc/main_for/mergedProjects/bldaps_for/files_32.htm) `ifport` provides "portability and POSIX support" so it kind of makes sense that adding it  solves the problem with `getenv`.