### PR TITLE
Add function to access specific contractions of a diagram.

### DIFF
--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -39,6 +39,7 @@ LorentzConjugate::usage="";
 CreateFields::usage="";
 FeynmanDiagramsOfType::usage="";
 VerticesForDiagram::usage="";
+ContractionsBetweenVerticesForDiagramFromGraph::usage="";
 CreateVertexData::usage="";
 CreateVertices::usage="";
 VertexRulesForVertices::usage="";
@@ -185,6 +186,20 @@ FeynmanDiagramsOfType[adjacencyMatrix_List,externalFields_List] :=
   ]
 
 VerticesForDiagram[diagram_] := Select[diagram,Length[#] > 1 &]
+
+ContractionsBetweenVerticesForDiagramFromGraph[v1_Integer, v2_Integer,
+		diagram_List, graph_List] :=
+	Module[{fields1 = diagram[[v1]], fields2 = diagram[[v2]],
+			preceedingNumberOfFields1 = Total[graph[[v1, ;;v2]]] - graph[[v1,v2]],
+			preceedingNumberOfFields2 = Total[graph[[v2, ;;v1]]] - graph[[v2,v1]],
+			contractedFieldIndices1, contractedFieldIndices2},
+		contractedFieldIndices1 = Table[k, {k, preceedingNumberOfFields1 + 1,
+			preceedingNumberOfFields1 + graph[[v1,v2]]}];
+		contractedFieldIndices2 = Table[k, {k, preceedingNumberOfFields2 + 1,
+			preceedingNumberOfFields2 + graph[[v2,v1]]}];
+		
+		Transpose[{contractedFieldIndices1, contractedFieldIndices2}]
+	]
 
 CreateVertexData[fields_List] := 
   Module[{dataClassName},


### PR DESCRIPTION
This function is needed for the work towards calculating colour factors as it can be used to reveal which colour (or arbitrary gauge group) indices from fields "at a given vertex" are contracted with corresponding indices at another (or the same) vertex. 
More generally, having access to the contractions is in some cases necessary to unambiguously identify the diagram in question -- Note that this information has always been available, but not in an obvious way.

The name of the function is terribly long, but every function argument is necessary... 