### PR TITLE
Add a flag to re-enable stripping of colour structures from vertices and use it.

### DIFF
--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -217,12 +217,14 @@ CreateVertexData[fields_List] :=
 
 (* Returns the necessary c++ code corresponding to the vertices that need to be calculated.
  The returned value is a list {prototypes, definitions}. *)
-CreateVertices[vertices_List] :=
-  StringJoin @ Riffle[CreateVertex /@ DeleteDuplicates[vertices], "\n\n"]
+CreateVertices[vertices_List, OptionsPattern[{StripColorStructure -> False}]] :=
+  StringJoin @ Riffle[
+		CreateVertex[#, StripColorStructure -> OptionValue[StripColorStructure]] & /@
+			DeleteDuplicates[vertices], "\n\n"]
 
 (* Creates the actual c++ code for a vertex with given fields.
  You should never need to change this code! *)
-CreateVertex[fields_List] :=
+CreateVertex[fields_List, OptionsPattern[{StripColorStructure -> False}]] :=
   Module[{functionClassName},
     LoadVerticesIfNecessary[];
     functionClassName = "Vertex<" <> StringJoin @ Riffle[
@@ -232,17 +234,21 @@ CreateVertex[fields_List] :=
     functionClassName <> "::vertex_type\n" <>
     functionClassName <> "::evaluate(const indices_type& indices, const context_base& context)\n" <>
     "{\n" <>
-    TextFormatting`IndentText @ VertexFunctionBodyForFields[fields] <> "\n" <>
+    TextFormatting`IndentText @ VertexFunctionBodyForFields[fields,
+			StripColorStructure -> OptionValue[StripColorStructure]] <> "\n" <>
     "}"
   ]
 
-VertexFunctionBodyForFields[fields_List] := 
-  Switch[Length[fields],
-         3, VertexFunctionBodyForFieldsImpl[fields, SARAH`VertexList3],
-         4, VertexFunctionBodyForFieldsImpl[fields, SARAH`VertexList4],
-         _, "non-(3,4)-point vertex"]
+VertexFunctionBodyForFields[fields_List, OptionsPattern[{StripColorStructure -> False}]] := 
+	Switch[Length[fields],
+		3, VertexFunctionBodyForFieldsImpl[fields, SARAH`VertexList3,
+			StripColorStructure -> OptionValue[StripColorStructure]],
+		4, VertexFunctionBodyForFieldsImpl[fields, SARAH`VertexList4,
+			StripColorStructure -> OptionValue[StripColorStructure]],
+		_, "non-(3,4)-point vertex"]
 
-VertexFunctionBodyForFieldsImpl[fields_List, vertexList_List] :=
+VertexFunctionBodyForFieldsImpl[fields_List, vertexList_List,
+		OptionsPattern[{StripColorStructure -> False}]] :=
   Module[{sortedFields, sortedIndexedFields, indexedFields,
           fieldsOrdering, sortedFieldsOrdering, inverseFOrdering,
           fOrderingWRTSortedF, vertex, vExpression, vertexIsZero = False,
@@ -290,7 +296,8 @@ VertexFunctionBodyForFieldsImpl[fields_List, vertexList_List] :=
       expr = CanonicalizeCoupling[SARAH`Cp @@ fields,
         sortedFields, sortedIndexedFields] /. vertexRules;
       
-      expr = Vertices`SarahToFSVertexConventions[sortedFields, expr];
+      expr = Vertices`SarahToFSVertexConventions[sortedFields, expr,
+				StripColorStructure -> OptionValue[StripColorStructure]];
       expr = TreeMasses`ReplaceDependenciesReverse[expr];
       DeclareIndices[StripLorentzIndices /@ indexedFields, "indices"] <>
       Parameters`CreateLocalConstRefs[expr] <> "\n" <>
@@ -310,8 +317,10 @@ VertexFunctionBodyForFieldsImpl[fields_List, vertexList_List] :=
       exprR = CanonicalizeCoupling[(SARAH`Cp @@ fields)[SARAH`PR],
         sortedFields, sortedIndexedFields] /. vertexRules;
 
-      exprL = Vertices`SarahToFSVertexConventions[sortedFields, exprL];
-      exprR = Vertices`SarahToFSVertexConventions[sortedFields, exprR];
+      exprL = Vertices`SarahToFSVertexConventions[sortedFields, exprL,
+				StripColorStructure -> OptionValue[StripColorStructure]];
+      exprR = Vertices`SarahToFSVertexConventions[sortedFields, exprR,
+				StripColorStructure -> OptionValue[StripColorStructure]];
       exprL = TreeMasses`ReplaceDependenciesReverse[exprL];
       exprR = TreeMasses`ReplaceDependenciesReverse[exprR];
       DeclareIndices[StripLorentzIndices /@ indexedFields, "indices"] <>
@@ -330,7 +339,8 @@ VertexFunctionBodyForFieldsImpl[fields_List, vertexList_List] :=
       expr = CanonicalizeCoupling[SARAH`Cp @@ fields,
         sortedFields, sortedIndexedFields] /. vertexRules;
       
-      expr = Vertices`SarahToFSVertexConventions[sortedFields, expr];
+      expr = Vertices`SarahToFSVertexConventions[sortedFields, expr,
+				StripColorStructure -> OptionValue[StripColorStructure]];
       expr = TreeMasses`ReplaceDependenciesReverse[expr];
       "int minuend_index = " <> 
         ToString[Position[indexedFields, incomingScalar][[1,1]] - 1] <> ";\n" <>
@@ -348,7 +358,8 @@ VertexFunctionBodyForFieldsImpl[fields_List, vertexList_List] :=
       expr = CanonicalizeCoupling[SARAH`Cp @@ fields,
         sortedFields, sortedIndexedFields] /. vertexRules;
       
-      expr = Vertices`SarahToFSVertexConventions[sortedFields, expr];
+      expr = Vertices`SarahToFSVertexConventions[sortedFields, expr,
+				StripColorStructure -> OptionValue[StripColorStructure]];
       expr = TreeMasses`ReplaceDependenciesReverse[expr];
       DeclareIndices[StripLorentzIndices /@ indexedFields, "indices"] <>
       Parameters`CreateLocalConstRefs[expr] <> "\n" <>

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -1990,13 +1990,15 @@ WriteObservables[extraSLHAOutputBlocks_, files_List] :=
            ];
            
 (* Write the CXXDiagrams c++ files *)
-WriteCXXDiagramClass[vertices_List,files_List] :=
+WriteCXXDiagramClass[vertices_List,files_List,
+		OptionsPattern[{StripColorStructure -> False}]] :=
   Module[{fields, nPointFunctions, vertexData, cxxVertices, massFunctions, unitCharge},
     fields = CXXDiagrams`CreateFields[];
     vertexData = StringJoin @ Riffle[CXXDiagrams`CreateVertexData
                                      /@ DeleteDuplicates[vertices],
                                      "\n\n"];
-    cxxVertices = CXXDiagrams`CreateVertices[vertices];
+    cxxVertices = CXXDiagrams`CreateVertices[vertices,
+			StripColorStructure -> OptionValue[StripColorStructure]];
     massFunctions = CXXDiagrams`CreateMassFunctions[];
     unitCharge = CXXDiagrams`CreateUnitCharge[];
     
@@ -4103,7 +4105,8 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
            If[DirectoryQ[cxxQFTOutputDir] === False,
               CreateDirectory[cxxQFTOutputDir]];
            
-           WriteCXXDiagramClass[Join[edmVertices,aMuonVertices],cxxQFTFiles];
+           WriteCXXDiagramClass[Join[edmVertices,aMuonVertices],cxxQFTFiles,
+					   StripColorStructure -> True];
 
            PrintHeadline["Creating Mathematica interface"];
            Print["Creating LibraryLink ", FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> ".mx"}], " ..."];

--- a/meta/Vertices.m
+++ b/meta/Vertices.m
@@ -316,18 +316,21 @@ VertexExp[cpPattern_, nPointFunctions_, massMatrices_] := Module[{
 	Parameters`ApplyGUTNormalization[]
 ];
 
-SarahToFSVertexConventions[sortedFields_List, expr_] :=
-  Module[{contraction},
-    StripGroupStructure[expr, {}];
-    contraction = Block[{
-	    SARAH`sum
-	    (* corrupts a polynomial (monomial + monomial + ...) summand *)
-	},
-	ExpandSarahSum @ SimplifyContraction @ expr];
+SarahToFSVertexConventions[sortedFields_List, expr_,
+		OptionsPattern[{StripColorStructure -> False}]] :=
+	Module[{contraction},
+		contraction = If[OptionValue[StripColorStructure],
+			StripGroupStructure[expr, {}],
+			expr];
+		
+		(* corrupts a polynomial (monomial + monomial + ...) summand *)
+    contraction = Block[{SARAH`sum},
+			ExpandSarahSum @ SimplifyContraction @ contraction];
+		
     (* see SPhenoCouplingList[] in SARAH/Package/SPheno/SPhenoCoupling.m
        for the following sign factor *)
     -I TreeMasses`ReplaceDependencies[contraction] /.
-	Parameters`ApplyGUTNormalization[]
+			Parameters`ApplyGUTNormalization[]
   ]
 
 SARAHVertex[fieldsInRotatedCp_List] := Module[{


### PR DESCRIPTION
Title says it all. This does not break g-2 or edm any more than it already was in the presence of non-trivial colour structures in the corresponding calculations. Such structures would have led to non-compiling code before this commit and now it is (again) correctly tracked in issue https://github.com/FlexibleSUSY/FlexibleSUSY/issues/24.