### PR TITLE
checking for FeynArts/FormCalc only if meta code generation is enabled

### DIFF
--- a/configure
+++ b/configure
@@ -3259,10 +3259,9 @@ if test "x${enable_meta}" = "xyes"; then
     case "$operating_system" in
 	CYGWIN_NT*) check_cygpath ;;
     esac
+    check_feynarts
+    check_formcalc
 fi
-
-check_feynarts
-check_formcalc
 
 if test "x${enable_compile}" = "xyes"; then
     check_multiarch

--- a/configure
+++ b/configure
@@ -3261,6 +3261,9 @@ if test "x${enable_meta}" = "xyes"; then
     esac
     check_feynarts
     check_formcalc
+else
+    enable_feynarts=no
+    enable_formcalc=no
 fi
 
 if test "x${enable_compile}" = "xyes"; then


### PR DESCRIPTION
This avoids a failure of `./configure --disable-meta` if Mathematica is not available.