### PR TITLE
NPointFunctions: Adapt mass rule to FormCalc-9.6 and newer

### DIFF
--- a/meta/NPointFunctions/internal.m
+++ b/meta/NPointFunctions/internal.m
@@ -268,7 +268,7 @@ SetFSConventionRules[] :=
        SARAH`Mass[ToExpression[#][{indices}]]) & /@ fieldNames[[All,1]],
       (Symbol["Mass" <> #] ->  
        SARAH`Mass[ToExpression[#]]) & /@ fieldNames[[All,1]],
-      {FeynArts`Mass[field_,faSpec_] :> SARAH`Mass[field]}
+      {FeynArts`Mass[field_,faSpec_ : Null] :> SARAH`Mass[field]}
     ];
 
     couplingRules = {


### PR DESCRIPTION
Starting with FormCalc-9.6, the FeynArts`Mass convention has changed. This should fix the FormCalc to FS replacement rule. @iolojz could you have a look at this?