### PR TITLE
Fix the intel compiler issues with CXXDiagrams

### DIFF
--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -397,13 +397,13 @@ PhotonEmitter, ExchangeField
                       >;
 
    for (const auto& index: index_range<MuonVertex>()) {
-      const auto muonIndices = MuonVertex::template field_indices<0>(index);
+      const auto muonIndices = MuonVertex::template indices_of_field<0>(index);
 
       if (muonIndices != indices)
          continue;
 
-      const auto photonEmitterIndices = MuonVertex::template field_indices<2>(index);
-      const auto exchangeFieldIndices = MuonVertex::template field_indices<1>(index);
+      const auto photonEmitterIndices = MuonVertex::template indices_of_field<2>(index);
+      const auto exchangeFieldIndices = MuonVertex::template indices_of_field<1>(index);
 
       if (isSMField<PhotonEmitter>(photonEmitterIndices) &&
           isSMField<ExchangeField>(exchangeFieldIndices))
@@ -455,13 +455,13 @@ PhotonEmitter, ExchangeField
                       >;
 
    for (const auto& index: index_range<MuonVertex>()) {
-      const auto muonIndices = MuonVertex::template field_indices<0>(index);
+      const auto muonIndices = MuonVertex::template indices_of_field<0>(index);
 
       if (muonIndices != indices)
          continue;
 
-      const auto photonEmitterIndices = MuonVertex::template field_indices<2>(index);
-      const auto exchangeFieldIndices = MuonVertex::template field_indices<1>(index);
+      const auto photonEmitterIndices = MuonVertex::template indices_of_field<2>(index);
+      const auto exchangeFieldIndices = MuonVertex::template indices_of_field<1>(index);
 
       if (isSMField<PhotonEmitter>(photonEmitterIndices) &&
           isSMField<ExchangeField>(exchangeFieldIndices))

--- a/templates/cxx_qft/vertices.hpp.in
+++ b/templates/cxx_qft/vertices.hpp.in
@@ -181,7 +181,7 @@ namespace @ModelName@_cxx_diagrams
       template <int FieldIndex>
       static typename field_indices<typename boost::mpl::at_c<
          boost::mpl::vector<Fields...>, FieldIndex>::type>::type
-      field_indices(const indices_type& indices)
+      indices_of_field(const indices_type& indices)
       {
          using namespace boost::mpl;
          using fields = vector<Fields...>;

--- a/templates/edm.cpp.in
+++ b/templates/edm.cpp.in
@@ -162,13 +162,13 @@ EDMField, PhotonEmitter, ExchangeField
                          >;
 
    for (const auto& index: index_range<FermionVertex>()) {
-      const auto edmFieldIndices = FermionVertex::template field_indices<0>(index);
+      const auto edmFieldIndices = FermionVertex::template indices_of_field<0>(index);
 
       if (edmFieldIndices != indices)
          continue;
 
-      const auto photonEmitterIndices = FermionVertex::template field_indices<2>(index);
-      const auto exchangeFieldIndices = FermionVertex::template field_indices<1>(index);
+      const auto photonEmitterIndices = FermionVertex::template indices_of_field<2>(index);
+      const auto exchangeFieldIndices = FermionVertex::template indices_of_field<1>(index);
       const auto vertex = FermionVertex::evaluate(index, context);
 
       const auto photonEmitterMass = context.mass<PhotonEmitter>(photonEmitterIndices);
@@ -205,13 +205,13 @@ EDMField, PhotonEmitter, ExchangeField
                          >;
 
    for (const auto& index: index_range<FermionVertex>()) {
-      const auto edmFieldIndices = FermionVertex::template field_indices<0>(index);
+      const auto edmFieldIndices = FermionVertex::template indices_of_field<0>(index);
 
       if (edmFieldIndices != indices)
          continue;
 
-      const auto photonEmitterIndices = FermionVertex::template field_indices<2>(index);
-      const auto exchangeFieldIndices = FermionVertex::template field_indices<1>(index);
+      const auto photonEmitterIndices = FermionVertex::template indices_of_field<2>(index);
+      const auto exchangeFieldIndices = FermionVertex::template indices_of_field<1>(index);
       const auto vertex = FermionVertex::evaluate(index, context);
 
       const auto photonEmitterMass = context.mass<PhotonEmitter>(photonEmitterIndices);


### PR DESCRIPTION
Rename `Vertex<...>::field_indices()` to `Vertex<...>::indices_of_field()`. This is less ambiguous, because there also is a type called `field_indices`. It also makes the intel compiler happy.