### PR TITLE
NPointFunctions: Add rule for FFV couplings and additional rule for SSV couplings (FormCalc 9.7)

### DIFF
--- a/meta/NPointFunctions/internal.m
+++ b/meta/NPointFunctions/internal.m
@@ -292,6 +292,10 @@ SetFSConventionRules[] :=
                                    LorentzIndex[{fields}[[i2]]]]],
         FeynArts`G[_][0][fields__][
             FeynArts`Mom[i1_Integer] - FeynArts`Mom[i2_Integer]] :>
+          SARAH`Cp[fields][SARAH`Mom[{fields}[[i1]]] - SARAH`Mom[{fields}[[i2]]]],
+        (*Since FormCalc-9.7*)
+        FeynArts`G[_][0][fields__][Global`FourVector[
+            FeynArts`Mom[i1_Integer] - FeynArts`Mom[i2_Integer], FeynArts`KI1[3]]] :>
           SARAH`Cp[fields][SARAH`Mom[{fields}[[i1]]] - SARAH`Mom[{fields}[[i2]]]]
 
     };

--- a/meta/NPointFunctions/internal.m
+++ b/meta/NPointFunctions/internal.m
@@ -281,6 +281,12 @@ SetFSConventionRules[] :=
             FeynArts`NonCommutative[Global`ChiralityProjector[1]]] :>
           SARAH`Cp[fields][SARAH`PR],
         FeynArts`G[_][0][fields__][
+            FeynArts`NonCommutative[Global`DiracMatrix[FeynArts`KI1[3]],Global`ChiralityProjector[-1]]] :>
+          SARAH`Cp[fields][SARAH`PL],
+        FeynArts`G[_][0][fields__][
+            FeynArts`NonCommutative[Global`DiracMatrix[FeynArts`KI1[3]],Global`ChiralityProjector[1]]] :>
+          SARAH`Cp[fields][SARAH`PR],
+        FeynArts`G[_][0][fields__][
             Global`MetricTensor[KI1[i1_Integer],KI1[i2_Integer]]] :>
           SARAH`Cp[fields][SARAH`g[LorentzIndex[{fields}[[i1]]],
                                    LorentzIndex[{fields}[[i2]]]]],


### PR DESCRIPTION
First of all, the FFV couplings from FormCalc are not translated into SARAH/FS couplings. My proposal is to remove the Lorentz structure and keep the information about left and right projection as usual.

Secondly with FormCalc-9.7, the internal convention for generic SSV couplings has changed. Commit 1701bd8 should add the missing rule.