### PR TITLE
Two cxxdiagrams fixes

### DIFF
--- a/meta/EDM.m
+++ b/meta/EDM.m
@@ -86,8 +86,7 @@ EDMCreateInterfaceFunctionForField[field_,gTaggedDiagrams_List] :=
                  "const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates& model )\n" <>
                  "{\n" <>
                  IndentText[
-                   FlexibleSUSY`FSModelName <> "_mass_eigenstates model_ = model;\n" <>
-                   "context_base context{ model_ };\n" <>
+                   "context_base context{ model };\n" <>
                    "std::array<int, " <> ToString @ numberOfIndices <>
                      "> indices = {" <>
                        If[TreeMasses`GetDimension[field] =!= 1,

--- a/meta/NPointFunctions.m
+++ b/meta/NPointFunctions.m
@@ -307,7 +307,7 @@ CXXArgStringForNPointFunctionPrototype[nPointFunction_] :=
     numberOfMomenta = If[FreeQ[nPointFunction, SARAH`Mom[_Integer, ___]],
       0, Length[nPointFunction[[1,1]]] + Length[nPointFunction[[1,2]]]];
 
-    "( " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates model, " <>
+    "( const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates &model, " <>
        "const std::array<int, " <>
       ToString[numberOfIndices] <> "> &indices, const std::array<Eigen::Vector4d, " <>
       ToString[numberOfMomenta] <> "> &momenta = { " <>
@@ -321,7 +321,7 @@ CXXArgStringForNPointFunctionDefinition[nPointFunction_] :=
     numberOfMomenta = If[FreeQ[nPointFunction, SARAH`Mom[_Integer, ___]],
       0, Length[nPointFunction[[1,1]]] + Length[nPointFunction[[1,2]]]];
 
-    "( " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates model, const std::array<int, " <>
+    "( const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates &model, const std::array<int, " <>
       ToString[numberOfIndices] <> "> &indices, const std::array<Eigen::Vector4d, " <>
       ToString[numberOfMomenta] <> "> &momenta )"
   ]

--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -257,7 +257,7 @@ void run_to_MSUSY(@ModelName@_mass_eigenstates& model)
    }
 }
 
-double calculate_a_muon_impl(@ModelName@_mass_eigenstates& model)
+double calculate_a_muon_impl(const @ModelName@_mass_eigenstates& model)
 {
    VERBOSE_MSG("@ModelName@_a_muon: calculating a_mu at Q = " << model.get_scale());
 

--- a/templates/cxx_qft/context_base.hpp.in
+++ b/templates/cxx_qft/context_base.hpp.in
@@ -36,7 +36,7 @@ namespace flexiblesusy
 namespace @ModelName@_cxx_diagrams
 {
    struct context_base {
-      @ModelName@_mass_eigenstates& model; ///< The model object.
+      @ModelName@_mass_eigenstates model; ///< The model object.
 
       template <class Field>
       double mass(const typename field_indices<Field>::type& indices) const
@@ -46,7 +46,7 @@ namespace @ModelName@_cxx_diagrams
          return mass_impl<CleanField>(indices);
       }
 
-      context_base(@ModelName@_mass_eigenstates& m) : model(m) {}
+      context_base(const @ModelName@_mass_eigenstates& m) : model(m) {}
       context_base(const context_base&) = default;
       context_base(context_base&&) = default;
 

--- a/templates/cxx_qft/npointfunctions.hpp.in
+++ b/templates/cxx_qft/npointfunctions.hpp.in
@@ -219,7 +219,7 @@ class correlation_function_context
 
 public:
   correlation_function_context(
-    @ModelName@_mass_eigenstates &m,
+    const @ModelName@_mass_eigenstates &m,
     const std::array<int, NumberOfExternalIndices> &ei,
     const std::array<Eigen::Vector4d, NumberOfExternalMomenta> &em
   ) : context_with_vertices( m ),

--- a/templates/edm.cpp.in
+++ b/templates/edm.cpp.in
@@ -30,6 +30,7 @@
 
 #include "cxx_qft/@ModelName@_qft.hpp"
 
+#include "wrappers.hpp"
 #include "numerics2.hpp"
 
 #define INPUTPARAMETER(p) context.model.get_input().p


### PR DESCRIPTION
Until now `context_base` only stored a reference to a `mass_eigenstates` object due to "performance" reasons. This is a really bad idea as I managed to produce undefined behaviour in my code and it took myself two hours to find out what the issue was... Therefore, we now simply store the whole `mass_eigenstates` object inside `context_base`. This does not affect performance at all because copies are cheap.

Also add a missing header to `templates/edm.cpp.in`