### PR TITLE
exposed SarahColorIndexQ function

### DIFF
--- a/meta/Vertices.m
+++ b/meta/Vertices.m
@@ -45,6 +45,7 @@ ToRotatedField::usage;
 ReplaceUnrotatedFields::usage;
 StripGroupStructure::usage="Removes group generators and Kronecker deltas.";
 StripFieldIndices::usage;
+SarahColorIndexQ::usage="Checks if an index is a color index. Returns True for indices starting with ct and followed by a number."
 
 FindVertexWithLorentzStructure::usage="";
 SarahToFSVertexConventions::usage="";

--- a/test/module.mk
+++ b/test/module.mk
@@ -86,6 +86,7 @@ TEST_META := \
 		$(DIR)/test_ThreeLoopQCD.m \
 		$(DIR)/test_ThresholdCorrections.m \
 		$(DIR)/test_TreeMasses.m \
+		$(DIR)/test_Vertices.m \
 		$(DIR)/test_Vertices_SortCp.m \
 		$(DIR)/test_Vertices_colorsum.m
 

--- a/test/test_Vertices.m
+++ b/test/test_Vertices.m
@@ -1,0 +1,29 @@
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+Needs["TestSuite`", "TestSuite.m"];
+Needs["Vertices`", "Vertices.m"];
+
+TestEquality[Vertices`SarahColorIndexQ[#], True]& /@ {ct4, ct69, ct666};
+TestEquality[Vertices`SarahColorIndexQ[#], False]& /@ {gt4, gt69, gt666, lt1, lt17, lt381, ctt};
+
+PrintTestSummary[];

--- a/test/test_Vertices_SortCp.m
+++ b/test/test_Vertices_SortCp.m
@@ -100,4 +100,7 @@ TestEquality[RBOM[{bar[Cha[{gI1}]], UChi[{gO1}], VWm},
 
 DeleteDirectory[SARAH`SARAH[OutputDirectory], DeleteContents -> True];
 
+TestEquality[Vertices`SarahColorIndexQ[#], True]& /@ {ct4, ct69, ct666};
+TestEquality[Vertices`SarahColorIndexQ[#], False]& /@ {gt4, gt69, gt666, lt1, lt17, lt381};
+
 PrintTestSummary[];

--- a/test/test_Vertices_SortCp.m
+++ b/test/test_Vertices_SortCp.m
@@ -100,7 +100,4 @@ TestEquality[RBOM[{bar[Cha[{gI1}]], UChi[{gO1}], VWm},
 
 DeleteDirectory[SARAH`SARAH[OutputDirectory], DeleteContents -> True];
 
-TestEquality[Vertices`SarahColorIndexQ[#], True]& /@ {ct4, ct69, ct666};
-TestEquality[Vertices`SarahColorIndexQ[#], False]& /@ {gt4, gt69, gt666, lt1, lt17, lt381};
-
 PrintTestSummary[];


### PR DESCRIPTION
@Expander, @iolojz and me need a function that checks if a field index is a color index. We wrote our own versions but turns out that @jhyeon already had a much better one. We only need to expose it. I also added some unit tests. I wasn't sure where to put them, though. For now they are in the  `test/test_Vertices_SortCp.m` but this doesn't make sense.