### PR TITLE
test: npointfunctions: fix path for createdVertices

### DIFF
--- a/test/test_MSSM_npointfunctions.meta
+++ b/test/test_MSSM_npointfunctions.meta
@@ -60,7 +60,7 @@ nPointFunctionHeaders = CreateCXXHeaders[];
 
 hhSelfenergyVertices = VerticesForNPointFunction[hhSelfenergy];
 
-cxxDiagramsDir = FileNameJoin[{SARAH`SARAH[OutputDirectory], FlexibleSUSY`FSModelName,
+cxxDiagramsDir = FileNameJoin[{SARAH`$sarahCurrentOutputMainDir,
 	ToString[FlexibleSUSY`FSEigenstates], "CXXDiagrams"}];
 createdVerticesFile = FileNameJoin[{cxxDiagramsDir, "CreatedVertices.m"}];
     

--- a/test/test_MSSM_npointfunctions.meta
+++ b/test/test_MSSM_npointfunctions.meta
@@ -60,12 +60,12 @@ nPointFunctionHeaders = CreateCXXHeaders[];
 
 hhSelfenergyVertices = VerticesForNPointFunction[hhSelfenergy];
 
-cxxDiagramsDir = FileNameJoin[{SARAH`SARAH[OutputDirectory],
+cxxDiagramsDir = FileNameJoin[{SARAH`SARAH[OutputDirectory], FlexibleSUSY`FSModelName,
 	ToString[FlexibleSUSY`FSEigenstates], "CXXDiagrams"}];
 createdVerticesFile = FileNameJoin[{cxxDiagramsDir, "CreatedVertices.m"}];
     
-createdVertices = If[FileExistsQ[cxxDiagramsDir] === True,
-	Get[cxxDiagramsDir], {}];
+createdVertices = If[FileExistsQ[createdVerticesFile] === True,
+	Get[createdVerticesFile], {}];
 
 nPointFunctionVertices = DeleteDuplicates[Join[hhSelfenergyVertices]];
 remainingVertices = Complement[nPointFunctionVertices, createdVertices];

--- a/test/test_SM_cxxdiagrams.meta
+++ b/test/test_SM_cxxdiagrams.meta
@@ -191,12 +191,12 @@ cxxNonzeroVertexPairs = "boost::mpl::vector<\n" <> TextFormatting`IndentText[
 		}],
 	",\n"]]] <> "\n>";
 
-cxxDiagramsDir = FileNameJoin[{SARAH`SARAH[OutputDirectory],
+cxxDiagramsDir = FileNameJoin[{SARAH`$sarahCurrentOutputMainDir,
 	ToString[FlexibleSUSY`FSEigenstates], "CXXDiagrams"}];
 createdVerticesFile = FileNameJoin[{cxxDiagramsDir, "CreatedVertices.m"}];
     
-createdVertices = If[FileExistsQ[cxxDiagramsDir] === True,
-	Get[cxxDiagramsDir], {}];
+createdVertices = If[FileExistsQ[createdVerticesFile] === True,
+	Get[createdVerticesFile], {}];
 
 remainingVertices = Complement[
 	Join[zeroVertices, nonzeroVertexPairs[[All, 1]]], createdVertices];

--- a/test/test_SM_npointfunctions.meta
+++ b/test/test_SM_npointfunctions.meta
@@ -60,7 +60,7 @@ nPointFunctionHeaders = CreateCXXHeaders[];
 
 hhSelfenergyVertices = VerticesForNPointFunction[hhSelfenergy];
 
-cxxDiagramsDir = FileNameJoin[{SARAH`SARAH[OutputDirectory], FlexibleSUSY`FSModelName,
+cxxDiagramsDir = FileNameJoin[{SARAH`$sarahCurrentOutputMainDir,
 	ToString[FlexibleSUSY`FSEigenstates], "CXXDiagrams"}];
 createdVerticesFile = FileNameJoin[{cxxDiagramsDir, "CreatedVertices.m"}];
     

--- a/test/test_SM_npointfunctions.meta
+++ b/test/test_SM_npointfunctions.meta
@@ -60,12 +60,12 @@ nPointFunctionHeaders = CreateCXXHeaders[];
 
 hhSelfenergyVertices = VerticesForNPointFunction[hhSelfenergy];
 
-cxxDiagramsDir = FileNameJoin[{SARAH`SARAH[OutputDirectory],
+cxxDiagramsDir = FileNameJoin[{SARAH`SARAH[OutputDirectory], FlexibleSUSY`FSModelName,
 	ToString[FlexibleSUSY`FSEigenstates], "CXXDiagrams"}];
 createdVerticesFile = FileNameJoin[{cxxDiagramsDir, "CreatedVertices.m"}];
     
-createdVertices = If[FileExistsQ[cxxDiagramsDir] === True,
-	Get[cxxDiagramsDir], {}];
+createdVertices = If[FileExistsQ[createdVerticesFile] === True,
+	Get[createdVerticesFile], {}];
 
 nPointFunctionVertices = DeleteDuplicates[Join[hhSelfenergyVertices]];
 remainingVertices = Complement[nPointFunctionVertices, createdVertices];


### PR DESCRIPTION
Currently, the path for `createdVertices` is wrong. This can cause duplicate definitions of vertices.

@iolojz can you have a look at this?