### PR TITLE
excluding ScalarLeptoquark model from release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -70,6 +70,7 @@ model_files/NUHMSSMNoFVNoMomIt  export-ignore
 model_files/rootMSSM            export-ignore
 model_files/YukawaCMSSM         export-ignore
 model_files/UnbrokenMSSM        export-ignore
+model_files/ScalarLeptoquarks   export-ignore
 model_files/SMEWSBAtMZ          export-ignore
 model_files/SMHighScale         export-ignore
 model_files/SMHighPrecision     export-ignore


### PR DESCRIPTION
The `ScalarLeptoquarks` model, which is now part of the `development` branch, has not yet been thoroughly tested. It is still useful for testing though, since it produces non-trivial color factors for observables. We might therefore want to exclude it from releases for now.