### PR TITLE
replace muon pole mass in a_mu

### DIFF
--- a/meta/AMuon.m
+++ b/meta/AMuon.m
@@ -25,7 +25,6 @@ BeginPackage["AMuon`", {"SARAH`", "CXXDiagrams`", "TextFormatting`", "TreeMasses
 AMuonContributingGraphs::usage="";
 AMuonGetMuon::usage="";
 AMuonContributingDiagramsForGraph::usage="";
-AMuonCreateMuonPhysicalMass::usage="";
 AMuonCreateCalculation::usage="";
 AMuonGetMSUSY::usage="";
 
@@ -54,6 +53,7 @@ AMuonGetMuon[] := If[TreeMasses`GetDimension[TreeMasses`GetSMMuonLeptonMultiplet
                 Cases[SARAH`ParticleDefinitions[FlexibleSUSY`FSEigenstates],
                       {p_, {Description -> "Muon", ___}} -> p, 1][[1]]
                ]
+
 GetCXXMuonIndex[] := If[TreeMasses`GetDimension[TreeMasses`GetSMMuonLeptonMultiplet[]] =!= 1,
                         1,
                         Null]
@@ -80,13 +80,6 @@ IsDiagramSupported[vertexCorrectionGraph,diagram_] :=
     
     Return[False];
   ]
-
-AMuonCreateMuonPhysicalMass[] := "return context.model.get_physical().M" <>
-                             CXXDiagrams`CXXNameOfField[AMuonGetMuon[]] <>
-                             If[GetCXXMuonIndex[] =!= Null,
-                                "( " <> ToString @ GetCXXMuonIndex[] <> " )",
-                                ""] <>
-                             ";"
 
 AMuonCreateCalculation[gTaggedDiagrams_List] :=
   Module[{muon = AMuonGetMuon[], cxxMuonIndex = GetCXXMuonIndex[],
@@ -115,7 +108,7 @@ AMuonCreateCalculation[gTaggedDiagrams_List] :=
 					CXXDiagrams`ColourFactorForIndexedDiagramFromGraph[indexedDiagram, graph]] <>
 				" * " <> 
 				CXXEvaluatorForDiagramFromGraph[diagram, graph] <>
-				"::value(indices, context);"
+				"::value(indices, context, qedqcd);"
 			] & /@ diagrams, "\n"]
 		] & /@ gTaggedDiagrams, "\n"]
   ];

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -2216,8 +2216,6 @@ WriteFToFConversionInNucleusClass[leptonPairs_List, files_List] :=
 (* Write the AMuon c++ files *)
 WriteAMuonClass[files_List] :=
     Module[{graphs,diagrams,vertices,
-            muonPoleMass,
-            muonPhysicalMass,
             calculation,
             getMSUSY},
       graphs = AMuon`AMuonContributingGraphs[];
@@ -2225,14 +2223,12 @@ WriteAMuonClass[files_List] :=
       
       vertices = Flatten[CXXDiagrams`VerticesForDiagram /@ Flatten[diagrams,1],1];
       
-      muonPhysicalMass = AMuon`AMuonCreateMuonPhysicalMass[];
       calculation = AMuon`AMuonCreateCalculation @ Transpose[{graphs,diagrams}];
             
       getMSUSY = AMuon`AMuonGetMSUSY[];
       
       WriteOut`ReplaceInFiles[files,
         {"@AMuon_MuonField@"      -> CXXDiagrams`CXXNameOfField[AMuon`AMuonGetMuon[]],
-         "@AMuon_MuonPhysicalMass@"       -> TextFormatting`IndentText[muonPhysicalMass],
          "@AMuon_Calculation@"    -> TextFormatting`IndentText[calculation],
          "@AMuon_GetMSUSY@"       -> IndentText[WrapLines[getMSUSY]],
          Sequence @@ GeneralReplacementRules[]

--- a/meta/Observables.m
+++ b/meta/Observables.m
@@ -265,10 +265,10 @@ CreateClearObservablesFunction[observables_List] :=
           ];
 
 CalculateObservable[obs_ /; obs === FlexibleSUSYObservable`aMuon, structName_String] :=
-    structName <> ".AMU = " <> FlexibleSUSY`FSModelName <> "_a_muon::calculate_a_muon(MODEL);";
+    structName <> ".AMU = " <> FlexibleSUSY`FSModelName <> "_a_muon::calculate_a_muon(MODEL, qedqcd);";
 
 CalculateObservable[obs_ /; obs === FlexibleSUSYObservable`aMuonUncertainty, structName_String] :=
-    structName <> ".AMUUNCERTAINTY = " <> FlexibleSUSY`FSModelName <> "_a_muon::calculate_a_muon_uncertainty(MODEL);";
+    structName <> ".AMUUNCERTAINTY = " <> FlexibleSUSY`FSModelName <> "_a_muon::calculate_a_muon_uncertainty(MODEL, qedqcd);";
 
 CalculateObservable[obs_ /; obs === FlexibleSUSYObservable`aMuonGM2Calc, structName_String] :=
     "#ifdef ENABLE_GM2Calc\n" <>

--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -30,6 +30,7 @@
 
 #include "cxx_qft/@ModelName@_qft.hpp"
 
+#include "lowe.h"
 #include "wrappers.hpp"
 #include "numerics2.hpp"
 

--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -51,7 +51,7 @@ double OneLoopFunctionF2C(double);
 double OneLoopFunctionF1N(double);
 double OneLoopFunctionF2N(double);
 
-double get_QED_2L(context_base&);
+double get_QED_2L(context_base&, const softsusy::QedQcd&);
 
 /**
  * @class AMuonVertexCorrectionSF
@@ -72,7 +72,8 @@ double get_QED_2L(context_base&);
 template<class PhotonEmitter, class ExchangeParticle>
 struct AMuonVertexCorrectionSF {
    static double value(const typename field_indices<Muon>::type& indices,
-                       const context_base& context);
+                       const context_base& context,
+                       const softsusy::QedQcd&);
 };
 
 /**
@@ -94,7 +95,8 @@ struct AMuonVertexCorrectionSF {
 template<class PhotonEmitter, class ExchangeParticle>
 struct AMuonVertexCorrectionFS {
    static double value(const typename field_indices<Muon>::type& indices,
-                       const context_base& context);
+                       const context_base& context,
+                       const softsusy::QedQcd&);
 };
 
 /**
@@ -257,7 +259,7 @@ void run_to_MSUSY(@ModelName@_mass_eigenstates& model)
    }
 }
 
-double calculate_a_muon_impl(const @ModelName@_mass_eigenstates& model)
+double calculate_a_muon_impl(const @ModelName@_mass_eigenstates& model, const softsusy::QedQcd& qedqcd)
 {
    VERBOSE_MSG("@ModelName@_a_muon: calculating a_mu at Q = " << model.get_scale());
 
@@ -269,7 +271,7 @@ double calculate_a_muon_impl(const @ModelName@_mass_eigenstates& model)
 @AMuon_Calculation@
 
    // add 2-loop QED logarithms
-   val *= 1. + get_QED_2L(context);
+   val *= 1. + get_QED_2L(context, qedqcd);
 
    return val;
 }
@@ -294,12 +296,12 @@ std::array<double,N> generate_scales(double mean, double factor)
 }
 
 /// returns minimum and maximum a_mu when scale is varied by a factor 2
-std::pair<double,double> vary_scale(const @ModelName@_mass_eigenstates& model)
+std::pair<double,double> vary_scale(const @ModelName@_mass_eigenstates& model, const softsusy::QedQcd& qedqcd)
 {
    auto scales = generate_scales<7>(model.get_scale(), 2.);
 
    std::transform(scales.begin(), scales.end(), scales.begin(),
-                  [&model] (double scale) {
+                  [&model,&qedqcd] (double scale) {
                      double amu = 0.;
                      try {
                         auto m = model;
@@ -308,7 +310,7 @@ std::pair<double,double> vary_scale(const @ModelName@_mass_eigenstates& model)
                         m.calculate_DRbar_masses();
                         m.solve_ewsb();
                         m.calculate_M@AMuon_MuonField@_pole();
-                        amu = calculate_a_muon_impl(m);
+                        amu = calculate_a_muon_impl(m, qedqcd);
                      }
                      catch(const Error& e) {
                         ERROR("@ModelName@_a_muon: scale variation: " << e.what());
@@ -321,14 +323,14 @@ std::pair<double,double> vary_scale(const @ModelName@_mass_eigenstates& model)
    return std::make_pair(*(minmax.first), *(minmax.second));
 }
 
-double muonPhysicalMass(const context_base& context)
+double muonPhysicalMass(const softsusy::QedQcd& qedqcd)
 {
-@AMuon_MuonPhysicalMass@
+   return qedqcd.displayMass(softsusy::mMuon);
 }
 
 } // anonymous namespace
 
-double @ModelName@_a_muon::calculate_a_muon(const @ModelName@_mass_eigenstates& model_)
+double @ModelName@_a_muon::calculate_a_muon(const @ModelName@_mass_eigenstates& model_, const softsusy::QedQcd& qedqcd)
 {
    @ModelName@_mass_eigenstates model(model_);
 
@@ -342,17 +344,17 @@ double @ModelName@_a_muon::calculate_a_muon(const @ModelName@_mass_eigenstates& 
       return std::numeric_limits<double>::quiet_NaN();
    }
 
-   double m_muon_pole = muonPhysicalMass(context_base{model});
+   double m_muon_pole = muonPhysicalMass(qedqcd);
 
    if (m_muon_pole == 0.0) {
       model.solve_ewsb();
       model.calculate_M@AMuon_MuonField@_pole();
    }
 
-   return calculate_a_muon_impl(model);
+   return calculate_a_muon_impl(model, qedqcd);
 }
 
-double @ModelName@_a_muon::calculate_a_muon_uncertainty(const @ModelName@_mass_eigenstates& model_)
+double @ModelName@_a_muon::calculate_a_muon_uncertainty(const @ModelName@_mass_eigenstates& model_, const softsusy::QedQcd& qedqcd)
 {
    @ModelName@_mass_eigenstates model(model_);
 
@@ -366,17 +368,17 @@ double @ModelName@_a_muon::calculate_a_muon_uncertainty(const @ModelName@_mass_e
       return std::numeric_limits<double>::quiet_NaN();
    }
 
-   const auto delta_amu_scale_minmax = vary_scale(model);
+   const auto delta_amu_scale_minmax = vary_scale(model, qedqcd);
    const auto delta_amu_scale = std::abs(delta_amu_scale_minmax.second - delta_amu_scale_minmax.first);
 
    return delta_amu_scale;
 }
 
 namespace {
-double get_QED_2L(context_base& context)
+double get_QED_2L(context_base& context, const softsusy::QedQcd& qedqcd)
 {
    const double MSUSY = Abs(get_MSUSY(context.model));
-   const double m_muon = muonPhysicalMass(context);
+   const double m_muon = muonPhysicalMass(qedqcd);
    const double alpha_em = Sqr(Muon::electric_charge * unit_charge(context))/(4*Pi);
    const double qed_2L = alpha_em/(4*Pi) * 16 * FiniteLog(m_muon/MSUSY);
 
@@ -386,7 +388,7 @@ double get_QED_2L(context_base& context)
 template<class PhotonEmitter, class ExchangeField>
 double AMuonVertexCorrectionFS<
 PhotonEmitter, ExchangeField
->::value(const typename field_indices<Muon>::type& indices, const context_base& context)
+>::value(const typename field_indices<Muon>::type& indices, const context_base& context, const softsusy::QedQcd& qedqcd)
 {
    double res = 0.0;
 
@@ -433,7 +435,7 @@ PhotonEmitter, ExchangeField
          photonEmitterMass / 3.0 * coeffB * OneLoopFunctionF2C(massRatioSquared);
 
       const double preFactor = oneOver16PiSqr * photonEmitterChargeCount
-         * muonPhysicalMass(context) / (exchangeFieldMass * exchangeFieldMass);
+         * muonPhysicalMass(qedqcd) / (exchangeFieldMass * exchangeFieldMass);
 
       res += preFactor * (part1 + part2);
    }
@@ -444,7 +446,7 @@ PhotonEmitter, ExchangeField
 template<class PhotonEmitter, class ExchangeField>
 double AMuonVertexCorrectionSF<
 PhotonEmitter, ExchangeField
->::value(const typename field_indices<Muon>::type& indices, const context_base& context)
+>::value(const typename field_indices<Muon>::type& indices, const context_base& context, const softsusy::QedQcd& qedqcd)
 {
    double res = 0.0;
 
@@ -488,7 +490,7 @@ PhotonEmitter, ExchangeField
       const double part2 = exchangeFieldMass / (6.0 * muonMass) * coeffB * OneLoopFunctionF2N(massRatioSquared);
 
       const double preFactor = - oneOver16PiSqr * photonEmitterChargeCount
-         * muonPhysicalMass(context) * muonMass / (photonEmitterMass * photonEmitterMass);
+         * muonPhysicalMass(qedqcd) * muonMass / (photonEmitterMass * photonEmitterMass);
 
       res += preFactor * (part1 + part2);
    }

--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -326,7 +326,7 @@ std::pair<double,double> vary_scale(const @ModelName@_mass_eigenstates& model, c
 
 double muonPhysicalMass(const softsusy::QedQcd& qedqcd)
 {
-   return qedqcd.displayMass(softsusy::mMuon);
+   return qedqcd.displayPoleMmuon();
 }
 
 } // anonymous namespace

--- a/templates/a_muon.hpp.in
+++ b/templates/a_muon.hpp.in
@@ -28,7 +28,9 @@
 #ifndef @ModelName@_A_MUON_H
 #define @ModelName@_A_MUON_H
 
-#include "lowe.h"
+namespace softsusy {
+   class QedQcd;
+} // namespace softsusy
 
 namespace flexiblesusy {
 class @ModelName@_mass_eigenstates;

--- a/templates/a_muon.hpp.in
+++ b/templates/a_muon.hpp.in
@@ -28,6 +28,8 @@
 #ifndef @ModelName@_A_MUON_H
 #define @ModelName@_A_MUON_H
 
+#include "lowe.h"
+
 namespace flexiblesusy {
 class @ModelName@_mass_eigenstates;
 
@@ -36,13 +38,13 @@ namespace @ModelName@_a_muon {
 * @fn calculate_a_muon
 * @brief Calculates \f$a_\mu = (g-2)_\mu/2\f$ of the muon.
 */
-double calculate_a_muon(const @ModelName@_mass_eigenstates& model);
+double calculate_a_muon(const @ModelName@_mass_eigenstates& model, const softsusy::QedQcd& qedqcd);
 
 /**
 * @fn calculate_a_muon_uncertainty
 * @brief Calculates \f$\Delta a_\mu\f$ of the muon.
 */
-double calculate_a_muon_uncertainty(const @ModelName@_mass_eigenstates& model);
+double calculate_a_muon_uncertainty(const @ModelName@_mass_eigenstates& model, const softsusy::QedQcd& qedqcd);
 } // namespace @ModelName@_a_muon
 } // namespace flexiblesusy
 

--- a/templates/l_to_lgamma.cpp.in
+++ b/templates/l_to_lgamma.cpp.in
@@ -44,6 +44,7 @@ using namespace @ModelName@_FFV_form_factors;
 namespace flexiblesusy {
 namespace @ModelName@_l_to_lgamma {
 
+   /*
 template <typename T1, typename T2>
 double lepton_total_decay_width(
       T1 const& indices1, T2 const& indices2, 
@@ -66,6 +67,7 @@ double lepton_total_decay_width(
       // higher order correction
       //* (1.0 + 0.5 * Alpha * (6.25-Sqr(Pi))/Pi)
 }
+*/
 
 @LToLGamma_InterfaceDefinitions@
 }

--- a/test/module.mk
+++ b/test/module.mk
@@ -289,6 +289,11 @@ TEST_SRC += \
 		$(DIR)/test_lowNUHMSSMSemiAnalytic_consistent_solutions.cpp
 endif
 
+ifeq ($(WITH_munuSSM), yes)
+TEST_SRC += \
+		$(DIR)/test_munuSSM_gmm2.cpp
+endif
+
 ifeq ($(WITH_munuSSM) $(WITH_munuSSMSemiAnalytic), yes yes)
 TEST_SH += \
 		$(DIR)/test_munuSSMSemiAnalytic_spectrum.sh
@@ -955,6 +960,8 @@ $(DIR)/test_lowNUHMSSMSemiAnalytic_ewsb.x: $(LIBlowNUHMSSMSemiAnalytic)
 $(DIR)/test_lowNUHMSSMSemiAnalytic_semi_analytic_solutions.x: $(LIBlowNUHMSSMSemiAnalytic)
 
 $(DIR)/test_lowNUHMSSMSemiAnalytic_consistent_solutions.x: $(LIBlowNUHMSSMSemiAnalytic) $(LIBlowNUHMSSM)
+
+$(DIR)/test_munuSSM_gmm2.x: $(LIBmunuSSM)
 
 $(DIR)/test_munuSSMSemiAnalytic_ewsb.x: $(LIBmunuSSMSemiAnalytic)
 

--- a/test/test_munuSSM.hpp
+++ b/test/test_munuSSM.hpp
@@ -1,0 +1,84 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+#ifndef TEST_munuSSM_H
+#define TEST_munuSSM_H
+
+#include <tuple>
+
+#include "lowe.h"
+#include "munuSSM_two_scale_spectrum_generator.hpp"
+
+using namespace flexiblesusy;
+
+munuSSM_slha<munuSSM<Two_scale>>
+setup_munuSSM(const munuSSM_input_parameters& input, softsusy::QedQcd& qedqcd)
+{
+
+    Spectrum_generator_settings settings;
+    settings.set(Spectrum_generator_settings::precision, 1e-4);
+    settings.set(Spectrum_generator_settings::max_iterations, 0);
+    settings.set(Spectrum_generator_settings::calculate_sm_masses, 1);
+    settings.set(Spectrum_generator_settings::calculate_bsm_masses, 1);
+    settings.set(Spectrum_generator_settings::ewsb_loop_order, 1);
+    settings.set(Spectrum_generator_settings::pole_mass_loop_order, 1);
+    settings.set(Spectrum_generator_settings::beta_loop_order, 2);
+    settings.set(Spectrum_generator_settings::threshold_corrections_loop_order, 2);
+    settings.set(Spectrum_generator_settings::top_pole_qcd_corrections, 1);
+    settings.set(Spectrum_generator_settings::threshold_corrections, 123111321);
+    settings.set(Spectrum_generator_settings::higgs_2loop_correction_at_as, 1);
+    settings.set(Spectrum_generator_settings::higgs_2loop_correction_ab_as, 1);
+    settings.set(Spectrum_generator_settings::higgs_2loop_correction_at_at, 1);
+    settings.set(Spectrum_generator_settings::higgs_2loop_correction_atau_atau, 1);
+    settings.set(Spectrum_generator_settings::higgs_3loop_ren_scheme_atb_as2, 1);
+    settings.set(Spectrum_generator_settings::higgs_3loop_correction_at_as2, 1);
+    settings.set(Spectrum_generator_settings::higgs_3loop_correction_ab_as2, 1);
+    settings.set(Spectrum_generator_settings::higgs_3loop_correction_at2_as, 1);
+    settings.set(Spectrum_generator_settings::higgs_3loop_correction_at3, 1);
+    settings.set(Spectrum_generator_settings::higgs_4loop_correction_at_as3, 1);
+    settings.set(Spectrum_generator_settings::beta_zero_threshold, 1e-16);
+
+    qedqcd.setAlpha(softsusy::ALPHA, 1./1.279340000e+02);
+    qedqcd.setAlphaEmInput(1./1.279340000e+02);
+    qedqcd.setFermiConstant(1.166378700e-05);
+    qedqcd.setAlphaSInput(1.176000000e-01);
+    qedqcd.setAlpha(softsusy::ALPHAS, 1.176000000e-01);
+    qedqcd.setPoleMZ(9.118760000e+01);
+    qedqcd.setMbMb(4.200000000e+00);
+    qedqcd.setPoleMt(1.733000000e+02);
+    qedqcd.setPoleMtau(1.777000000e+00);
+    qedqcd.setNeutrinoPoleMass(3, 0);
+    qedqcd.setPoleMW(80.404);
+    qedqcd.setPoleMel(5.109989020e-04);
+    qedqcd.setNeutrinoPoleMass(1, 0);
+    qedqcd.setPoleMmuon(1.056583570e-01);
+    qedqcd.setMass(softsusy::mMuon, 1.056583570e-01);
+    qedqcd.setNeutrinoPoleMass(2, 0);
+    qedqcd.setMd2GeV(4.750000000e-03);
+    qedqcd.setMu2GeV(2.400000000e-03);
+    qedqcd.setMs2GeV(1.040000000e-01);
+    qedqcd.setMcMc(1.270000000e+00);
+
+    munuSSM_spectrum_generator<Two_scale> spectrum_generator;
+    spectrum_generator.set_settings(settings);
+    spectrum_generator.run(qedqcd, input);
+
+    return std::get<0>(spectrum_generator.get_models_slha());
+}
+
+#endif

--- a/test/test_munuSSM_gmm2.cpp
+++ b/test/test_munuSSM_gmm2.cpp
@@ -1,0 +1,69 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE test_munuSSM_gmm2
+
+#include <boost/test/unit_test.hpp>
+
+#include "test_munuSSM.hpp"
+
+#include "wrappers.hpp"
+#include "munuSSM_a_muon.hpp"
+
+using namespace flexiblesusy;
+
+BOOST_AUTO_TEST_CASE( test_amu ) {
+
+   munuSSM_input_parameters input;
+
+   // Block MINPAR
+   input.m0 = 500.;
+   input.m12 = 300.;
+   input.TanBeta = 10.;
+   input.Azero = -10.;
+
+   // Block EXTPAR
+   input.LambdaInput = 0.2;
+   input.KappaInput = 0.1;
+   input.vRInput = 10.;
+   input.vL1Input = 10.;
+   input.vL2Input = 10.;
+   input.vL3Input = 10.;
+
+   // Block YVIN
+   input.YvInput << 0.01, 0.01, 0.01;
+
+   softsusy::QedQcd qedqcd;
+
+   munuSSM_slha<munuSSM<Two_scale>> m = setup_munuSSM(input, qedqcd);
+
+#if defined(__INTEL_COMPILER)
+   constexpr double reference_value = 1.24070126531925e-09;
+#elif defined(__clang__)
+   constexpr double reference_value = 1.24070101020353e-09;
+#elif defined(__GNUC__)
+   constexpr double reference_value = 1.24070097343634e-09;
+#else
+   BOOST_TEST_MESSAGE(false, "No reference value for this compiler");
+#endif
+
+   double amu = munuSSM_a_muon::calculate_a_muon(m, qedqcd);
+
+   BOOST_CHECK_CLOSE_FRACTION(amu, reference_value, 2e-15);
+}


### PR DESCRIPTION
This addresses problem discussed in #82. Since we need an access to muon mass from the input file an `softsusy::QedQcd` needs to be passed around.  