### PR TITLE
Fix reduce precision of amu test

### DIFF
--- a/test/test_munuSSM_gmm2.cpp
+++ b/test/test_munuSSM_gmm2.cpp
@@ -130,5 +130,5 @@ Block YVIN
 
    double amu = munuSSM_a_muon::calculate_a_muon(m, qedqcd);
 
-   BOOST_CHECK_CLOSE_FRACTION(amu, reference_value, 5e-8);
+   BOOST_CHECK_CLOSE_FRACTION(amu, reference_value, 1e-7);
 }

--- a/test/test_munuSSM_gmm2.cpp
+++ b/test/test_munuSSM_gmm2.cpp
@@ -126,17 +126,9 @@ Block YVIN
 
    munuSSM_slha<munuSSM<Two_scale>> m = setup_munuSSM(input, qedqcd, settings);
 
-#if defined(__INTEL_COMPILER)
-   constexpr double reference_value = 1.24070126531925e-09;
-#elif defined(__clang__)
-   constexpr double reference_value = 1.24070101020353e-09;
-#elif defined(__GNUC__)
-   constexpr double reference_value = 1.24070097343634e-09;
-#else
-   BOOST_TEST_MESSAGE(false, "No reference value for this compiler");
-#endif
+   constexpr double reference_value = 1.2407009e-09;
 
    double amu = munuSSM_a_muon::calculate_a_muon(m, qedqcd);
 
-   BOOST_CHECK_CLOSE_FRACTION(amu, reference_value, 2e-15);
+   BOOST_CHECK_CLOSE_FRACTION(amu, reference_value, 5e-8);
 }


### PR DESCRIPTION
There is a problem with a stability of the result while changing systems/compilers. I find that the relative differences are of the order of 10<sup>-8</sup>. This is something I actually wanted to talk to you about. `FlexibleSUSY` loses half of digits of precision before we get a final result. That is weird.