### PR TITLE
fixing unit tests for amu with MRSSM and SM

### DIFF
--- a/templates/l_to_lgamma.hpp.in
+++ b/templates/l_to_lgamma.hpp.in
@@ -35,7 +35,7 @@ namespace flexiblesusy {
 class @ModelName@_mass_eigenstates;
 
 namespace @ModelName@_l_to_lgamma {
-template <typename T1, typename T2>
+template <typename FIn, typename FOut, typename T1, typename T2>
 double lepton_total_decay_width(
       T1 const&, T2 const&, 
       const @ModelName@_mass_eigenstates&, const softsusy::QedQcd&);

--- a/test/test_MRSSM2.hpp
+++ b/test/test_MRSSM2.hpp
@@ -21,15 +21,17 @@
 
 #include <tuple>
 
-#include "lowe.h"
 #include "MRSSM2_two_scale_spectrum_generator.hpp"
 
-using namespace flexiblesusy;
+namespace softsusy {
+   class QedQcd;
+} // namespace softsusy
 
-MRSSM2_slha<MRSSM2<Two_scale>>
-setup_MRSSM2(const MRSSM2_input_parameters& input)
+namespace flexiblesusy {
+
+inline MRSSM2_slha<MRSSM2<Two_scale>>
+setup_MRSSM2(const MRSSM2_input_parameters& input, const softsusy::QedQcd& qedqcd)
 {
-    softsusy::QedQcd qedqcd;
 
     Spectrum_generator_settings settings;
     settings.set(Spectrum_generator_settings::calculate_sm_masses, 0);
@@ -41,5 +43,7 @@ setup_MRSSM2(const MRSSM2_input_parameters& input)
 
     return std::get<0>(spectrum_generator.get_models_slha());
 }
+
+} // namespace flexiblesusy
 
 #endif

--- a/test/test_MRSSM2_gmm2.cpp
+++ b/test/test_MRSSM2_gmm2.cpp
@@ -23,6 +23,7 @@
 
 #include "test_MRSSM2.hpp"
 
+#include "lowe.h"
 #include "wrappers.hpp"
 #include "MRSSM2_a_muon.hpp"
 
@@ -57,15 +58,16 @@ BOOST_AUTO_TEST_CASE( test_amu )
    input.MDWBTInput = 500;
    input.MDGocInput = 1500;
 
-   MRSSM2_slha<MRSSM2<Two_scale>> m = setup_MRSSM2(input);
+   softsusy::QedQcd qedqcd;
+   MRSSM2_slha<MRSSM2<Two_scale>> m = setup_MRSSM2(input, qedqcd);
 
-   auto amu = MRSSM2_a_muon::calculate_a_muon(m);
-   BOOST_CHECK_CLOSE(amu, -8.30e-11, 1.0);
+   auto amu = MRSSM2_a_muon::calculate_a_muon(m, qedqcd);
+   BOOST_CHECK_CLOSE_FRACTION(amu, -8.17626160e-11, 1e-7);
 
    // neutralino dominance
    input.ml2Input = DiagonalMatrix3(Sqr(8000), Sqr(8000), Sqr(8000));
-   m = setup_MRSSM2(input);
+   m = setup_MRSSM2(input, qedqcd);
 
-   amu = MRSSM2_a_muon::calculate_a_muon(m);
-   BOOST_CHECK_CLOSE(amu, 6.33e-12, 1.0);
+   amu = MRSSM2_a_muon::calculate_a_muon(m, qedqcd);
+   BOOST_CHECK_CLOSE_FRACTION(amu, 6.22993418e-12, 1e-7);
 }

--- a/test/test_MRSSM2_gmm2.cpp
+++ b/test/test_MRSSM2_gmm2.cpp
@@ -62,12 +62,12 @@ BOOST_AUTO_TEST_CASE( test_amu )
    MRSSM2_slha<MRSSM2<Two_scale>> m = setup_MRSSM2(input, qedqcd);
 
    auto amu = MRSSM2_a_muon::calculate_a_muon(m, qedqcd);
-   BOOST_CHECK_CLOSE_FRACTION(amu, -8.17626160e-11, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(amu, -8.176261599534122e-11, 1e-7);
 
    // neutralino dominance
    input.ml2Input = DiagonalMatrix3(Sqr(8000), Sqr(8000), Sqr(8000));
    m = setup_MRSSM2(input, qedqcd);
 
    amu = MRSSM2_a_muon::calculate_a_muon(m, qedqcd);
-   BOOST_CHECK_CLOSE_FRACTION(amu, 6.22993418e-12, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(amu, 6.229934186618265e-12, 1e-7);
 }

--- a/test/test_MRSSM2_l_to_lgamma.cpp
+++ b/test/test_MRSSM2_l_to_lgamma.cpp
@@ -24,6 +24,7 @@
 #include "test_MRSSM2.hpp"
 
 #include "wrappers.hpp"
+#include "cxx_qft/MRSSM2_qft.hpp"
 #include "MRSSM2_l_to_lgamma.hpp"
 
 using namespace flexiblesusy;
@@ -57,20 +58,16 @@ BOOST_AUTO_TEST_CASE( test_l_to_lgamma )
    input.MDWBTInput = 500;
    input.MDGocInput = 1500;
 
-   MRSSM2_slha<MRSSM2<Two_scale>> m = setup_MRSSM2(input);
-
    softsusy::QedQcd qedqcd;
+
+   MRSSM2_slha<MRSSM2<Two_scale>> m = setup_MRSSM2(input, qedqcd);
+
+   using MRSSM2_cxx_diagrams::fields::Fe;
+   auto width = MRSSM2_l_to_lgamma::lepton_total_decay_width<Fe,Fe>(std::array<int,1> {1}, std::array<int,1> {0}, m, qedqcd);
+
    Physical_input physical_inputs;
 
-   auto width = MRSSM2_l_to_lgamma::lepton_total_decay_width(std::array<int,1> {1}, std::array<int,1> {0}, m, qedqcd);
-
    auto brMuEGamma = MRSSM2_l_to_lgamma::calculate_Fe_to_Fe_VP(1, 0, m, qedqcd, physical_inputs);
-   //auto amu = MRSSM2_a_muon::calculate_a_muon(m);
-   //BOOST_CHECK_CLOSE(amu, -8.30e-11, 1.0);
-
-   // neutralino dominance
-   input.ml2Input = DiagonalMatrix3(Sqr(8000), Sqr(8000), Sqr(8000));
-   m = setup_MRSSM2(input);
 
    BOOST_CHECK_CLOSE_FRACTION(brMuEGamma, 1.3147385103144814e-15, 1e-4);
 }

--- a/test/test_SM_gmm2.cpp
+++ b/test/test_SM_gmm2.cpp
@@ -23,6 +23,8 @@
 
 #include "test_SM.hpp"
 
+#include "lowe.h"
+
 #include "SM_two_scale_model.hpp"
 #include "SM_a_muon.hpp"
 
@@ -38,7 +40,9 @@ BOOST_AUTO_TEST_CASE( test_zero )
    setup_SM_const(sm, input);
    sm.calculate_DRbar_masses();
 
-   const double amu = SM_a_muon::calculate_a_muon(sm);
+   softsusy::QedQcd qedqcd;
+
+   const double amu = SM_a_muon::calculate_a_muon(sm, qedqcd);
 
    BOOST_CHECK_SMALL(amu, 1e-15);
 }

--- a/test/test_munuSSM.hpp
+++ b/test/test_munuSSM.hpp
@@ -21,10 +21,13 @@
 
 #include <tuple>
 
-#include "lowe.h"
 #include "munuSSM_input_parameters.hpp"
 #include "spectrum_generator_settings.hpp"
 #include "munuSSM_two_scale_spectrum_generator.hpp"
+
+namespace softsusy {
+   class QedQcd;
+} // namespace softsusy
 
 namespace flexiblesusy {
 

--- a/test/test_munuSSM_gmm2.cpp
+++ b/test/test_munuSSM_gmm2.cpp
@@ -22,6 +22,8 @@
 #include <boost/test/unit_test.hpp>
 #include <cstdlib>
 
+#include "lowe.h"
+
 #include "test_munuSSM.hpp"
 
 #include "wrappers.hpp"

--- a/test/test_munuSSM_gmm2.cpp
+++ b/test/test_munuSSM_gmm2.cpp
@@ -128,9 +128,9 @@ Block YVIN
 
    munuSSM_slha<munuSSM<Two_scale>> m = setup_munuSSM(input, qedqcd, settings);
 
-   constexpr double reference_value = 1.2407009e-09;
+   constexpr double reference_value = 1.2407012653192522e-09;
 
    double amu = munuSSM_a_muon::calculate_a_muon(m, qedqcd);
 
-   BOOST_CHECK_CLOSE_FRACTION(amu, reference_value, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(amu, reference_value, 1e-6);
 }


### PR DESCRIPTION
This pull request fixes `SM` and `MRSSM2` units for g-2. It also removes `lowe.h` from being included in the `test_munuSSM.hpp`.