### PR TITLE
TreeMasses: Add IsSMParticleWithGoldstone

### DIFF
--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -222,7 +222,7 @@ CreateFields[] :=
                         If[TreeMasses`GetDimension[#] === 1,
                            CXXBoolValue @ TreeMasses`IsSMParticle[#],
                            StringJoin @ Riffle[CXXBoolValue /@
-                             (TreeMasses`IsSMParticle[#] & /@ Table[#[{k}],{k,TreeMasses`GetDimension[#]}]),
+                             TreeMasses`IsSMParticleWithGoldStone[#],
                                                ", "]] <>
                         ">;\n" <>
                 "static constexpr int numberOfFieldIndices = " <>

--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -222,7 +222,7 @@ CreateFields[] :=
                         If[TreeMasses`GetDimension[#] === 1,
                            CXXBoolValue @ TreeMasses`IsSMParticle[#],
                            StringJoin @ Riffle[CXXBoolValue /@
-                             TreeMasses`IsSMParticleWithGoldStone[#],
+                             TreeMasses`IsSMParticleElementwise[#],
                                                ", "]] <>
                         ">;\n" <>
                 "static constexpr int numberOfFieldIndices = " <>

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -2102,7 +2102,6 @@ WriteFFVFormFactorsClass[extParticles_List, files_List] :=
       WriteOut`ReplaceInFiles[files,
          {"@FFVFormFactors_InterfacePrototypes@"   -> interfacePrototypes,
           "@FFVFormFactors_InterfaceDefinitions@"  -> interfaceDefinitions,
-          "@FFVFormFactors_ChargedHiggsMultiplet@" -> CXXDiagrams`CXXNameOfField[SARAH`ChargedHiggs],
           "@FFVFormFactors_GluonName@" -> CXXDiagrams`CXXNameOfField[TreeMasses`GetGluon[]],
           "@FFVFormFactors_PhotonName@" -> CXXDiagrams`CXXNameOfField[TreeMasses`GetPhoton[]],
           Sequence @@ GeneralReplacementRules[]}

--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -310,10 +310,8 @@ IsOfType[sym_[__], type_Symbol, states_:FlexibleSUSY`FSEigenstates] :=
 IsSMParticle[sym_List] := And @@ (IsSMParticle /@ sym);
 IsSMParticle[sym_[__]] := IsSMParticle[sym];
 IsSMParticle[sym_] := SARAH`SMQ[sym, Higgs -> True];
-IsSMParticleWithGoldStone[sym_] := If[sym === SARAH`ChargedHiggs || sym === SARAH`PseudoScalar,
-    Join[{True}, ConstantArray[SARAH`SMQ[sym, Higgs -> True], GetDimension[sym]-1]],
-    ConstantArray[SARAH`SMQ[sym, Higgs -> True], GetDimension[sym]]
-];
+IsSMParticleWithGoldStone[sym_] :=
+   (IsSMParticle[#] || IsSMGoldstone[#])& /@ Table[sym[i], {i, GetDimension[sym]}]
 
 IsScalar[Susyno`LieGroups`conj[sym_]] := IsScalar[sym];
 IsScalar[SARAH`bar[sym_]] := IsScalar[sym];

--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -311,7 +311,7 @@ IsSMParticle[sym_List] := And @@ (IsSMParticle /@ sym);
 IsSMParticle[sym_[__]] := IsSMParticle[sym];
 IsSMParticle[sym_] := SARAH`SMQ[sym, Higgs -> True];
 IsSMParticleElementwise[sym_] :=
-   (IsSMParticle[#] || IsSMGoldstone[#])& /@ Table[sym[i], {i, GetDimension[sym]}]
+   (IsSMParticle[#] || IsSMGoldstone[#])& /@ Table[sym[i], {i, GetDimension[sym]}];
 
 IsScalar[Susyno`LieGroups`conj[sym_]] := IsScalar[sym];
 IsScalar[SARAH`bar[sym_]] := IsScalar[sym];

--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -181,6 +181,8 @@ IsSMUpQuark::usage="";
 IsSMDownQuark::usage="";
 IsSMQuark::usage="";
 IsSMParticle::usage="";
+IsSMParticleWithGoldStone::usage="Checks whether the field multiplet is a \
+  SM field whereby the first index of charged Higgs and pseudoscalar Higgs is set to true.";
 IsElectricallyCharged::usage="";
 ContainsGoldstone::usage="";
 
@@ -308,6 +310,10 @@ IsOfType[sym_[__], type_Symbol, states_:FlexibleSUSY`FSEigenstates] :=
 IsSMParticle[sym_List] := And @@ (IsSMParticle /@ sym);
 IsSMParticle[sym_[__]] := IsSMParticle[sym];
 IsSMParticle[sym_] := SARAH`SMQ[sym, Higgs -> True];
+IsSMParticleWithGoldStone[sym_] := If[sym === SARAH`ChargedHiggs || sym === SARAH`PseudoScalar,
+    Join[{True}, ConstantArray[SARAH`SMQ[sym, Higgs -> True], GetDimension[sym]-1]],
+    ConstantArray[SARAH`SMQ[sym, Higgs -> True], GetDimension[sym]]
+];
 
 IsScalar[Susyno`LieGroups`conj[sym_]] := IsScalar[sym];
 IsScalar[SARAH`bar[sym_]] := IsScalar[sym];

--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -181,8 +181,8 @@ IsSMUpQuark::usage="";
 IsSMDownQuark::usage="";
 IsSMQuark::usage="";
 IsSMParticle::usage="";
-IsSMParticleWithGoldStone::usage="Checks whether the field multiplet is a \
-  SM field whereby the first index of charged Higgs and pseudoscalar Higgs is set to true.";
+IsSMParticleElementwise::usage="Maps a predicate over the multiplet, \
+indicating whether the element belongs to the SM or not";
 IsElectricallyCharged::usage="";
 ContainsGoldstone::usage="";
 
@@ -310,7 +310,7 @@ IsOfType[sym_[__], type_Symbol, states_:FlexibleSUSY`FSEigenstates] :=
 IsSMParticle[sym_List] := And @@ (IsSMParticle /@ sym);
 IsSMParticle[sym_[__]] := IsSMParticle[sym];
 IsSMParticle[sym_] := SARAH`SMQ[sym, Higgs -> True];
-IsSMParticleWithGoldStone[sym_] :=
+IsSMParticleElementwise[sym_] :=
    (IsSMParticle[#] || IsSMGoldstone[#])& /@ Table[sym[i], {i, GetDimension[sym]}]
 
 IsScalar[Susyno`LieGroups`conj[sym_]] := IsScalar[sym];

--- a/templates/FFV_form_factors.cpp.in
+++ b/templates/FFV_form_factors.cpp.in
@@ -235,13 +235,9 @@ std::valarray<std::complex<double>> FFV_SSF<Fj, Fi, V, SA, SB, F>::value(
          if (scalarFieldIndicesIn != scalarIndicesOut) 
             continue;
 
-         // Throw out SM Goldstone, it could crash if SM is used.
-         // if ( std::is_same<S, ChargedHiggsMultiplet>::type::value || 
-               //   std::is_same<S, typename ChargedHiggsMultiplet::lorentz_conjugate>::type::value )
-         // {
-            // if ( scalarFieldIndicesIn[0] == 0 )
-               //  continue;
-         // }
+          if (isSMField<SA>(scalarFieldIndicesIn) && isSMField<F>(fermionFieldIndicesIn)) {
+            continue;
+          }
 
          const auto vertexIn = VertexFBarFjSBar::evaluate(indexIn, context);
          const auto vertexOut = VertexFiBarFS::evaluate(indexOut, context);
@@ -319,12 +315,8 @@ std::valarray<std::complex<double>> FFV_FFS<Fj, Fi, V, FA, FB, S>::value(
          if (scalarFieldIndicesIn != scalarIndicesOut) 
             continue;
 
-         // Throw out SM Goldstone, it could crash if SM is used.
-         if ( std::is_same<S, ChargedHiggsMultiplet>::type::value || 
-                 std::is_same<S, typename ChargedHiggsMultiplet::lorentz_conjugate>::type::value )
-         {
-            if ( fermionFieldIndicesIn[0] == 0 )
-                continue;
+         if (isSMField<S>(scalarFieldIndicesIn) && isSMField<FA>(fermionFieldIndicesIn)) {
+            continue;
          }
 
          const auto vertexIn = VertexFBarFjSBar::evaluate(indexIn, context);

--- a/templates/FFV_form_factors.cpp.in
+++ b/templates/FFV_form_factors.cpp.in
@@ -39,7 +39,6 @@ using namespace @ModelName@_cxx_diagrams::fields;
 
 namespace {
 
-using ChargedHiggsMultiplet = @FFVFormFactors_ChargedHiggsMultiplet@;
 static constexpr double oneOver32PiSquared = 1.0/(32.0*Pi*Pi);
 
 /**


### PR DESCRIPTION
Currently, we have the `IsSMParticle` function which asks `SARAH` whether the field multiplet is a SM multiplet or not. For BSM models the Higgs multiplets are labeled as `False` by default. @wkotlarski and I think that it is reasonable to assume that the first field in the charged Higgs and pseudoscalar Higgs multiplet are SM Goldstone bosons. This is important to avoid overcounting in the `FFVFormFactor` module.

This is a temporary fix until we have a good `IsSMParticle` check at runtime.