### PR TITLE
take into account mixing of SM and BSM particles in IsSMParticleElementwise

### DIFF
--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -181,8 +181,11 @@ IsSMUpQuark::usage="";
 IsSMDownQuark::usage="";
 IsSMQuark::usage="";
 IsSMParticle::usage="";
-IsSMParticleElementwise::usage="Maps a predicate over the multiplet, \
-indicating whether the element belongs to the SM or not";
+IsSMParticleElementwise::usage=
+"For a given multiplet this function returns a list indicating whether
+the element is a SM-like field or not.  The function assumes that BSM
+fields are always heavier than the SM fields.";
+
 IsElectricallyCharged::usage="";
 ContainsGoldstone::usage="";
 
@@ -310,8 +313,19 @@ IsOfType[sym_[__], type_Symbol, states_:FlexibleSUSY`FSEigenstates] :=
 IsSMParticle[sym_List] := And @@ (IsSMParticle /@ sym);
 IsSMParticle[sym_[__]] := IsSMParticle[sym];
 IsSMParticle[sym_] := SARAH`SMQ[sym, Higgs -> True];
+
+MakeTrueFalse[n_, t_] :=
+    Join[Array[True&, n]] /; t >= n;
+
+MakeTrueFalse[n_, t_] :=
+    Join[Array[True&, t], Array[False&, n - t]];
+
 IsSMParticleElementwise[sym_] :=
-   (IsSMParticle[#] || IsSMGoldstone[#])& /@ Table[sym[i], {i, GetDimension[sym]}];
+    Which[
+        IsSMLepton[sym], MakeTrueFalse[GetDimension[sym], 3],
+        IsSMQuark[sym], MakeTrueFalse[GetDimension[sym], 3],
+        True, (IsSMParticle[#] || IsSMGoldstone[#]) & /@ Table[sym[i], {i, GetDimension[sym]}]
+    ];
 
 IsScalar[Susyno`LieGroups`conj[sym_]] := IsScalar[sym];
 IsScalar[SARAH`bar[sym_]] := IsScalar[sym];

--- a/test/module.mk
+++ b/test/module.mk
@@ -291,6 +291,9 @@ TEST_SRC += \
 endif
 
 ifeq ($(WITH_munuSSM), yes)
+TEST_META += \
+		$(DIR)/test_munuSSM_TreeMasses.m
+
 TEST_SRC += \
 		$(DIR)/test_munuSSM_gmm2.cpp
 endif
@@ -488,6 +491,11 @@ TEST_SRC += \
 		$(DIR)/test_CMSSMCPV_tree_level_spectrum.cpp
 TEST_SH += \
 		$(DIR)/test_CMSSMCPV_spectrum.sh
+endif
+
+ifeq ($(WITH_MSSMNoFV),yes)
+TEST_META += \
+		$(DIR)/test_MSSMNoFV_TreeMasses.m
 endif
 
 ifeq ($(WITH_NMSSMCPV),yes)

--- a/test/test_MRSSM2_gmm2.cpp
+++ b/test/test_MRSSM2_gmm2.cpp
@@ -62,12 +62,12 @@ BOOST_AUTO_TEST_CASE( test_amu )
    MRSSM2_slha<MRSSM2<Two_scale>> m = setup_MRSSM2(input, qedqcd);
 
    auto amu = MRSSM2_a_muon::calculate_a_muon(m, qedqcd);
-   BOOST_CHECK_CLOSE_FRACTION(amu, -8.176261599534122e-11, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(amu, -8.1729622840653898e-11, 1e-7);
 
    // neutralino dominance
    input.ml2Input = DiagonalMatrix3(Sqr(8000), Sqr(8000), Sqr(8000));
    m = setup_MRSSM2(input, qedqcd);
 
    amu = MRSSM2_a_muon::calculate_a_muon(m, qedqcd);
-   BOOST_CHECK_CLOSE_FRACTION(amu, 6.229934186618265e-12, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(amu, 6.2643225826834355e-12, 1e-7);
 }

--- a/test/test_MSSMNoFV_TreeMasses.m
+++ b/test/test_MSSMNoFV_TreeMasses.m
@@ -1,0 +1,60 @@
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+Get["utils/load-FlexibleSUSY.m"];
+Start["MSSMNoFV"];
+Needs["TestSuite`", "TestSuite.m"];
+
+Print["testing IsSMParticleElementwise[] ..."];
+
+TestEquality[IsSMParticleElementwise[Fu], {True}];
+TestEquality[IsSMParticleElementwise[Fd], {True}];
+TestEquality[IsSMParticleElementwise[Fs], {True}];
+TestEquality[IsSMParticleElementwise[Fc], {True}];
+TestEquality[IsSMParticleElementwise[Ft], {True}];
+TestEquality[IsSMParticleElementwise[Fb], {True}];
+TestEquality[IsSMParticleElementwise[Fe], {True}];
+TestEquality[IsSMParticleElementwise[Fm], {True}];
+TestEquality[IsSMParticleElementwise[Ftau], {True}];
+TestEquality[IsSMParticleElementwise[Chi], {False, False, False, False}];
+TestEquality[IsSMParticleElementwise[Cha], {False, False}];
+TestEquality[IsSMParticleElementwise[Glu], {False}];
+TestEquality[IsSMParticleElementwise[VP], {True}];
+TestEquality[IsSMParticleElementwise[VZ], {True}];
+TestEquality[IsSMParticleElementwise[VWm], {True}];
+TestEquality[IsSMParticleElementwise[Su], {False, False}];
+TestEquality[IsSMParticleElementwise[Sd], {False, False}];
+TestEquality[IsSMParticleElementwise[Ss], {False, False}];
+TestEquality[IsSMParticleElementwise[Sc], {False, False}];
+TestEquality[IsSMParticleElementwise[St], {False, False}];
+TestEquality[IsSMParticleElementwise[Sb], {False, False}];
+TestEquality[IsSMParticleElementwise[Se], {False, False}];
+TestEquality[IsSMParticleElementwise[Sm], {False, False}];
+TestEquality[IsSMParticleElementwise[Stau], {False, False}];
+TestEquality[IsSMParticleElementwise[SveL], {False}];
+TestEquality[IsSMParticleElementwise[SvmL], {False}];
+TestEquality[IsSMParticleElementwise[SvtL], {False}];
+TestEquality[IsSMParticleElementwise[hh], {False, False}];
+TestEquality[IsSMParticleElementwise[Ah], {True, False}];
+TestEquality[IsSMParticleElementwise[Hpm], {True, False}];
+
+PrintTestSummary[];

--- a/test/test_munuSSM_TreeMasses.m
+++ b/test/test_munuSSM_TreeMasses.m
@@ -1,0 +1,43 @@
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+Get["utils/load-FlexibleSUSY.m"];
+Start["munuSSM"];
+Needs["TestSuite`", "TestSuite.m"];
+
+Print["testing IsSMParticleElementwise[] ..."];
+
+TestEquality[IsSMParticleElementwise[Fu], {True, True, True}];
+TestEquality[IsSMParticleElementwise[Fd], {True, True, True}];
+TestEquality[IsSMParticleElementwise[Chi], {True, True, True, False, False, False, False, False}];
+TestEquality[IsSMParticleElementwise[Cha], {True, True, True, False, False}];
+TestEquality[IsSMParticleElementwise[Glu], {False}];
+TestEquality[IsSMParticleElementwise[VP], {True}];
+TestEquality[IsSMParticleElementwise[VZ], {True}];
+TestEquality[IsSMParticleElementwise[VWm], {True}];
+TestEquality[IsSMParticleElementwise[Su], {False, False, False, False, False, False}];
+TestEquality[IsSMParticleElementwise[Sd], {False, False, False, False, False, False}];
+TestEquality[IsSMParticleElementwise[hh], {False, False, False, False, False, False}];
+TestEquality[IsSMParticleElementwise[Ah], {True, False, False, False, False, False}];
+TestEquality[IsSMParticleElementwise[Hpm], {True, False, False, False, False, False, False, False}];
+
+PrintTestSummary[];

--- a/test/test_munuSSM_gmm2.cpp
+++ b/test/test_munuSSM_gmm2.cpp
@@ -128,7 +128,7 @@ Block YVIN
 
    munuSSM_slha<munuSSM<Two_scale>> m = setup_munuSSM(input, qedqcd, settings);
 
-   constexpr double reference_value = 1.2407012653192522e-09;
+   constexpr double reference_value = 2.1176299646121334e-09;
 
    double amu = munuSSM_a_muon::calculate_a_muon(m, qedqcd);
 


### PR DESCRIPTION
This fixes (g-2) in the munuSSM, where the Cha and Chi multiplets both contain SM fields.

This fix assumes that BSM particles are always heavier than SM ones.