### PR TITLE
Feature: less verbose make output

### DIFF
--- a/addons/GM2Calc/module.mk
+++ b/addons/GM2Calc/module.mk
@@ -77,18 +77,18 @@ all-$(MODNAME): $(LIBGM2Calc) $(EXEGM2Calc_EXE)
 		@true
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIBGM2Calc_DEP)
-		-rm -f $(EXEGM2Calc_DEP)
+		$(Q)-rm -f $(LIBGM2Calc_DEP)
+		$(Q)-rm -f $(EXEGM2Calc_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIBGM2Calc)
+		$(Q)-rm -f $(LIBGM2Calc)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIBGM2Calc_OBJ)
-		-rm -f $(EXEGM2Calc_OBJ)
+		$(Q)-rm -f $(LIBGM2Calc_OBJ)
+		$(Q)-rm -f $(EXEGM2Calc_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
-		-rm -f $(EXEGM2Calc_EXE)
+		$(Q)-rm -f $(EXEGM2Calc_EXE)
 
 distclean-$(MODNAME): clean-$(MODNAME)
 
@@ -100,20 +100,22 @@ distclean::     distclean-$(MODNAME)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIBGM2Calc_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBGM2Calc_SRC) $(LIBGM2Calc_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBGM2Calc_HDR) $(LIBGM2Calc_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(EXEGM2Calc_SRC) $(LIBGM2Calc_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBGM2Calc_MK) $(LIBGM2Calc_INSTALL_DIR)
+		$(Q)install -d $(LIBGM2Calc_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBGM2Calc_SRC) $(LIBGM2Calc_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBGM2Calc_HDR) $(LIBGM2Calc_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(EXEGM2Calc_SRC) $(LIBGM2Calc_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBGM2Calc_MK) $(LIBGM2Calc_INSTALL_DIR)
 endif
 
 $(LIBGM2Calc_DEP) $(EXEGM2Calc_DEP) $(LIBGM2Calc_OBJ) $(EXEGM2Calc_OBJ): CPPFLAGS += $(EIGENFLAGS) $(BOOSTFLAGS)
 
 $(LIBGM2Calc): $(LIBGM2Calc_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 $(DIR)/%.x: $(DIR)/%.o $(LIBGM2Calc) $(LIBFLEXI)
-		$(CXX) -o $@ $(call abspathx,$^)
+		@echo "Building $@"
+		$(Q)$(CXX) -o $@ $(call abspathx,$^)
 
 ALLDEP += $(LIBGM2Calc_DEP) $(EXEGM2Calc_DEP)
 ALLSRC += $(LIBGM2Calc_SRC) $(EXEGM2Calc_SRC)

--- a/addons/GM2Calc/module.mk
+++ b/addons/GM2Calc/module.mk
@@ -110,11 +110,11 @@ endif
 $(LIBGM2Calc_DEP) $(EXEGM2Calc_DEP) $(LIBGM2Calc_OBJ) $(EXEGM2Calc_OBJ): CPPFLAGS += $(EIGENFLAGS) $(BOOSTFLAGS)
 
 $(LIBGM2Calc): $(LIBGM2Calc_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 $(DIR)/%.x: $(DIR)/%.o $(LIBGM2Calc) $(LIBFLEXI)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) -o $@ $(call abspathx,$^)
 
 ALLDEP += $(LIBGM2Calc_DEP) $(EXEGM2Calc_DEP)

--- a/addons/test_call_tsil/module.mk
+++ b/addons/test_call_tsil/module.mk
@@ -99,11 +99,11 @@ $(LIBtest_call_tsil_DEP) $(EXEtest_call_tsil_DEP) $(LIBtest_call_tsil_OBJ) $(EXE
 endif
 
 $(LIBtest_call_tsil): $(LIBtest_call_tsil_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 $(EXEtest_call_tsil_EXE): $(EXEtest_call_tsil_OBJ) $(LIBtest_call_tsil) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) -o $@ $(call abspathx,$^) $(filter -%,$(LOOPFUNCLIBS)) $(GSLLIBS) $(BOOSTTHREADLIBS) $(THREADLIBS) $(TSILLIBS) $(FLIBS)
 
 ALLDEP += $(LIBtest_call_tsil_DEP) $(EXEtest_call_tsil_DEP)

--- a/addons/test_call_tsil/module.mk
+++ b/addons/test_call_tsil/module.mk
@@ -50,15 +50,15 @@ all-$(MODNAME): $(LIBtest_call_tsil) $(EXEtest_call_tsil_EXE)
 		@true
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIBtest_call_tsil_DEP)
-		-rm -f $(EXEtest_call_tsil_DEP)
+		$(Q)-rm -f $(LIBtest_call_tsil_DEP)
+		$(Q)-rm -f $(EXEtest_call_tsil_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIBtest_call_tsil)
+		$(Q)-rm -f $(LIBtest_call_tsil)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIBtest_call_tsil_OBJ)
-		-rm -f $(EXEtest_call_tsil_OBJ)
+		$(Q)-rm -f $(LIBtest_call_tsil_OBJ)
+		$(Q)-rm -f $(EXEtest_call_tsil_OBJ)
 
 # BEGIN: NOT EXPORTED ##########################################
 # remove generated files
@@ -69,7 +69,7 @@ clean-$(MODNAME): clean-$(MODNAME)-src
 # END:   NOT EXPORTED ##########################################
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
-		-rm -f $(EXEtest_call_tsil_EXE)
+		$(Q)-rm -f $(EXEtest_call_tsil_EXE)
 
 distclean-$(MODNAME): clean-$(MODNAME)
 
@@ -81,11 +81,11 @@ distclean::     distclean-$(MODNAME)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIBtest_call_tsil_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBtest_call_tsil_SRC) $(LIBtest_call_tsil_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBtest_call_tsil_HDR) $(LIBtest_call_tsil_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(EXEtest_call_tsil_SRC) $(LIBtest_call_tsil_INSTALL_DIR)
-		$(INSTALL_STRIPPED) $(LIBtest_call_tsil_MK) $(LIBtest_call_tsil_INSTALL_DIR) -m u=rw,g=r,o=r
+		$(Q)install -d $(LIBtest_call_tsil_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBtest_call_tsil_SRC) $(LIBtest_call_tsil_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBtest_call_tsil_HDR) $(LIBtest_call_tsil_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(EXEtest_call_tsil_SRC) $(LIBtest_call_tsil_INSTALL_DIR)
+		$(Q)$(INSTALL_STRIPPED) $(LIBtest_call_tsil_MK) $(LIBtest_call_tsil_INSTALL_DIR) -m u=rw,g=r,o=r
 endif
 
 $(LIBtest_call_tsil_DEP) $(EXEtest_call_tsil_DEP) $(LIBtest_call_tsil_OBJ) $(EXEtest_call_tsil_OBJ): CPPFLAGS += $(GSLFLAGS) $(EIGENFLAGS) $(BOOSTFLAGS)
@@ -99,10 +99,12 @@ $(LIBtest_call_tsil_DEP) $(EXEtest_call_tsil_DEP) $(LIBtest_call_tsil_OBJ) $(EXE
 endif
 
 $(LIBtest_call_tsil): $(LIBtest_call_tsil_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 $(EXEtest_call_tsil_EXE): $(EXEtest_call_tsil_OBJ) $(LIBtest_call_tsil) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		$(CXX) -o $@ $(call abspathx,$^) $(filter -%,$(LOOPFUNCLIBS)) $(GSLLIBS) $(BOOSTTHREADLIBS) $(THREADLIBS) $(TSILLIBS) $(FLIBS)
+		@echo "Building $@"
+		$(Q)$(CXX) -o $@ $(call abspathx,$^) $(filter -%,$(LOOPFUNCLIBS)) $(GSLLIBS) $(BOOSTTHREADLIBS) $(THREADLIBS) $(TSILLIBS) $(FLIBS)
 
 ALLDEP += $(LIBtest_call_tsil_DEP) $(EXEtest_call_tsil_DEP)
 ALLSRC += $(LIBtest_call_tsil_SRC) $(EXEtest_call_tsil_SRC)

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -79,6 +79,12 @@ THREADLIBS         := @THREADLIBS@
 TSILFLAGS          := @TSILFLAGS@
 TSILLIBS           := @TSILLIBS@
 
+ifeq ($(VERBOSE),1)
+  Q :=
+else
+  Q := @
+endif
+
 # the modules add their dependency files to this variable
 ALLDEP   :=
 # the modules add soucre files to be created to this variable
@@ -152,12 +158,12 @@ install-src::
 	$(error Installation directory is not set!  To set in please run: ./configure --with-install-dir=/path/to/install/dir)
 else
 install-src::
-	install -d $(INSTALL_DIR)
-	$(INSTALL_STRIPPED) $(CONFIGURE_SCRIPT) $(INSTALL_DIR) -m u=rwx,g=r,o=r
-	$(INSTALL_STRIPPED) $(README_FILE) $(INSTALL_DIR) -m u=rw,g=r,o=r
-	$(INSTALL_STRIPPED) $(AUTHORS_FILE) $(INSTALL_DIR) -m u=rw,g=r,o=r
-	$(INSTALL_STRIPPED) $(COPYING_FILE) $(INSTALL_DIR) -m u=rw,g=r,o=r
-	$(INSTALL_STRIPPED) $(ChangeLog_FILE) $(INSTALL_DIR) -m u=rw,g=r,o=r
+	$(Q)install -d $(INSTALL_DIR)
+	$(Q)$(INSTALL_STRIPPED) $(CONFIGURE_SCRIPT) $(INSTALL_DIR) -m u=rwx,g=r,o=r
+	$(Q)$(INSTALL_STRIPPED) $(README_FILE) $(INSTALL_DIR) -m u=rw,g=r,o=r
+	$(Q)$(INSTALL_STRIPPED) $(AUTHORS_FILE) $(INSTALL_DIR) -m u=rw,g=r,o=r
+	$(Q)$(INSTALL_STRIPPED) $(COPYING_FILE) $(INSTALL_DIR) -m u=rw,g=r,o=r
+	$(Q)$(INSTALL_STRIPPED) $(ChangeLog_FILE) $(INSTALL_DIR) -m u=rw,g=r,o=r
 
 ifeq ($(ENABLE_META),yes)
 install-src:: allsrc
@@ -205,43 +211,46 @@ allll:    $(ALLLL)
 alltest:  $(ALLTST)
 
 clean-dep:
-	-rm -f $(ALLDEP)
+	$(Q)-rm -f $(ALLDEP)
 
 clean-executables:
-	-rm -f $(ALLEXE)
+	$(Q)-rm -f $(ALLEXE)
 
 clean-lib:
-	-rm -f $(ALLLIB) $(ALLLL)
+	$(Q)-rm -f $(ALLLIB) $(ALLLL)
 
 depend:  clean-dep
 depend:  $(ALLDEP)
 
 %.d: %.cpp | $(DEPGEN)
-	$(DEPGEN) $(CPPFLAGS) -MM -MI -o '$@' -MT '$*.o' $^
+	$(Q)$(DEPGEN) $(CPPFLAGS) -MM -MI -o '$@' -MT '$*.o' $^
 
 %.d: %.c | $(DEPGEN)
-	$(DEPGEN) $(CPPFLAGS) -MM -MI -o '$@' -MT '$*.o' $^
+	$(Q)$(DEPGEN) $(CPPFLAGS) -MM -MI -o '$@' -MT '$*.o' $^
 
 %.d: %.f | $(DEPGEN)
-	$(DEPGEN) $(CPPFLAGS) -MM -MI -o '$@' -MT '$*.o' $^
+	$(Q)$(DEPGEN) $(CPPFLAGS) -MM -MI -o '$@' -MT '$*.o' $^
 
 %.d: %.F | $(DEPGEN)
-	$(DEPGEN) $(CPPFLAGS) -MM -MI -o '$@' -MT '$*.o' $^
+	$(Q)$(DEPGEN) $(CPPFLAGS) -MM -MI -o '$@' -MT '$*.o' $^
 
 %.o: %.cpp
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+	@echo "Building $@"
+	$(Q)$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 %.o: %.f
-	$(FC) $(FFLAGS) -c $< -o $@
+	@echo "Building $@"
+	$(Q)$(FC) $(FFLAGS) -c $< -o $@
 
 %.o: %.F
-	$(FC) $(FFLAGS) $(CPPFLAGS) -c $< -o $@
+	@echo "Building $@"
+	$(Q)$(FC) $(FFLAGS) $(CPPFLAGS) -c $< -o $@
 
 distclean::
-	-rm -f Makefile
-	-rm -f $(FSCONFIG)
-	-rm -f $(SARAH_DEP_GEN)
-	-rm -f config.boost config.log config.math config.sarah config.status
+	$(Q)-rm -f Makefile
+	$(Q)-rm -f $(FSCONFIG)
+	$(Q)-rm -f $(SARAH_DEP_GEN)
+	$(Q)-rm -f config.boost config.log config.math config.sarah config.status
 
 librarylink: allll
 	@true

--- a/config/Makefile.in
+++ b/config/Makefile.in
@@ -108,6 +108,9 @@ SHELL = /bin/sh
 # disable built-in rules to improve speed
 MAKEFLAGS += -rR --include-dir=$(CURDIR)
 
+# message printed for each target
+MSG = echo "Building $@"
+
 # flexiblesusy-config script
 FSCONFIG := @FSCONFIG@
 

--- a/config/module.mk
+++ b/config/module.mk
@@ -80,7 +80,7 @@ clean::         clean-$(MODNAME)
 distclean::     distclean-$(MODNAME)
 
 $(DEPGEN_EXE): $(DEPGEN_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) $(CXXFLAGS) -o $@ $^ $(LDLIBS)
 
 ALLEXE += $(DEPGEN_EXE)

--- a/config/module.mk
+++ b/config/module.mk
@@ -44,15 +44,15 @@ all-$(MODNAME):
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(CONFIG_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(CONFIG_TMPL) $(CONFIG_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(CONFIG_MK) $(CONFIG_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(DEPGEN_SRC) $(CONFIG_INSTALL_DIR)
-		install -m u=rwx,g=r,o=r $(MATH_INC_PATHS) $(CONFIG_INSTALL_DIR)
-		$(INSTALL_STRIPPED) $(MAKEFILE_IN) $(CONFIG_INSTALL_DIR) -m u=rw,g=r,o=r
-		$(INSTALL_STRIPPED) $(REMOVE_EXPORT_MARKERS) $(CONFIG_INSTALL_DIR) -m u=rwx,g=r,o=r
-		$(INSTALL_STRIPPED) $(INSTALL_STRIPPED) $(CONFIG_INSTALL_DIR) -m u=rwx,g=r,o=r
-		$(INSTALL_STRIPPED) $(CONVERT_DOS_PATHS) $(CONFIG_INSTALL_DIR) -m u=rwx,g=r,o=r
+		$(Q)install -d $(CONFIG_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(CONFIG_TMPL) $(CONFIG_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(CONFIG_MK) $(CONFIG_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(DEPGEN_SRC) $(CONFIG_INSTALL_DIR)
+		$(Q)install -m u=rwx,g=r,o=r $(MATH_INC_PATHS) $(CONFIG_INSTALL_DIR)
+		$(Q)$(INSTALL_STRIPPED) $(MAKEFILE_IN) $(CONFIG_INSTALL_DIR) -m u=rw,g=r,o=r
+		$(Q)$(INSTALL_STRIPPED) $(REMOVE_EXPORT_MARKERS) $(CONFIG_INSTALL_DIR) -m u=rwx,g=r,o=r
+		$(Q)$(INSTALL_STRIPPED) $(INSTALL_STRIPPED) $(CONFIG_INSTALL_DIR) -m u=rwx,g=r,o=r
+		$(Q)$(INSTALL_STRIPPED) $(CONVERT_DOS_PATHS) $(CONFIG_INSTALL_DIR) -m u=rwx,g=r,o=r
 endif
 
 clean-$(MODNAME)-dep:
@@ -62,16 +62,16 @@ clean-$(MODNAME)-lib:
 		@true
 
 clean-$(MODNAME)-obj:
-		-rm -f $(DEPGEN_OBJ)
+		$(Q)-rm -f $(DEPGEN_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
-		-rm -f $(DEPGEN_EXE)
+		$(Q)-rm -f $(DEPGEN_EXE)
 
 distclean-$(MODNAME): clean-$(MODNAME)
-		-rm -f $(CONFIG_HDR)
-		-rm -f $(FLEXIBLESUSY_VERSION_FILE)
-		-rm -f $(FLEXIBLESUSY_GIT_COMMIT_FILE)
-		-rm -f $(REQUIRED_SARAH_VERSION_FILE)
+		$(Q)-rm -f $(CONFIG_HDR)
+		$(Q)-rm -f $(FLEXIBLESUSY_VERSION_FILE)
+		$(Q)-rm -f $(FLEXIBLESUSY_GIT_COMMIT_FILE)
+		$(Q)-rm -f $(REQUIRED_SARAH_VERSION_FILE)
 
 clean-obj::     clean-$(MODNAME)-obj
 
@@ -80,6 +80,7 @@ clean::         clean-$(MODNAME)
 distclean::     distclean-$(MODNAME)
 
 $(DEPGEN_EXE): $(DEPGEN_OBJ)
-		$(CXX) $(CXXFLAGS) -o $@ $^ $(LDLIBS)
+		@echo "Building $@"
+		$(Q)$(CXX) $(CXXFLAGS) -o $@ $^ $(LDLIBS)
 
 ALLEXE += $(DEPGEN_EXE)

--- a/doc/manuals/module.mk
+++ b/doc/manuals/module.mk
@@ -120,10 +120,10 @@ LATEX_TMP       := \
 		$(MODNAME)-pdf
 
 clean-$(MODNAME):
-		-rm -f $(LATEX_TMP)
+		$(Q)-rm -f $(LATEX_TMP)
 
 distclean-$(MODNAME): clean-$(MODNAME)
-		-rm -f $(PAPER_PDF)
+		$(Q)-rm -f $(PAPER_PDF)
 
 clean::         clean-$(MODNAME)
 
@@ -131,78 +131,78 @@ distclean::     distclean-$(MODNAME)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(MANUALS_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(MANUALS_MK) $(MANUALS_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(PAPER_SRC) $(MANUALS_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(PAPER_STY) $(MANUALS_INSTALL_DIR)
-		install -d $(INSTALL_DIR)/$(MANUALS_EXAMPLES_DIR)
-		install -m u=rw,g=r,o=r $(MANUALS_EXAMPLES) $(INSTALL_DIR)/$(MANUALS_EXAMPLES_DIR)
+		$(Q)install -d $(MANUALS_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_MK) $(MANUALS_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(PAPER_SRC) $(MANUALS_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(PAPER_STY) $(MANUALS_INSTALL_DIR)
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_EXAMPLES_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_EXAMPLES) $(INSTALL_DIR)/$(MANUALS_EXAMPLES_DIR)
 
-		install -d $(INSTALL_DIR)/$(MANUALS_FEYNMAN_DIR)
-		install -m u=rw,g=r,o=r $(MANUALS_FEYNMAN) $(INSTALL_DIR)/$(MANUALS_FEYNMAN_DIR)
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_FEYNMAN_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_FEYNMAN) $(INSTALL_DIR)/$(MANUALS_FEYNMAN_DIR)
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/THDMIIMSSMBC
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_THDMIIMSSMBC) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/THDMIIMSSMBC
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/THDMIIMSSMBC
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_THDMIIMSSMBC) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/THDMIIMSSMBC
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/HSSUSY
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_HSSUSY) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/HSSUSY
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/HSSUSY
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_HSSUSY) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/HSSUSY
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/FlexibleMW
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_FlexibleMW) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/FlexibleMW
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/FlexibleMW
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_FlexibleMW) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/FlexibleMW
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSM_multiple_solutions
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CMSSM_multiple_solutions) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSM_multiple_solutions
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSM_multiple_solutions
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CMSSM_multiple_solutions) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSM_multiple_solutions
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CE6SSM
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CE6SSM) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CE6SSM
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CE6SSM
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CE6SSM) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CE6SSM
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CSE6SSM
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CSE6SSM) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CSE6SSM
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CSE6SSM
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CSE6SSM) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CSE6SSM
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CNMSSM
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CNMSSM) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CNMSSM
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CNMSSM
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CNMSSM) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CNMSSM
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/semi_analytic_benchmark
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_semi_analytic_benchmark) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/semi_analytic_benchmark
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/semi_analytic_benchmark
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_semi_analytic_benchmark) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/semi_analytic_benchmark
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/Himalaya
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_Himalaya) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/Himalaya
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/Himalaya
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_Himalaya) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/Himalaya
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSMCPV
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CMSSMCPV) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSMCPV
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSMCPV
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CMSSMCPV) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSMCPV
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/FlexibleEFTHiggs
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_FlexibleEFTHiggs) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/FlexibleEFTHiggs
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/FlexibleEFTHiggs
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_FlexibleEFTHiggs) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/FlexibleEFTHiggs
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSM_solution_regions
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CMSSM_solution_regions) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSM_solution_regions
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSM_solution_regions
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_CMSSM_solution_regions) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/CMSSM_solution_regions
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/semi_analytic_rel_errs
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_semi_analytic_rel_errs) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/semi_analytic_rel_errs
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/semi_analytic_rel_errs
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_semi_analytic_rel_errs) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/semi_analytic_rel_errs
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/MSSMMuBMu
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_MSSMMuBMu) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/MSSMMuBMu
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/MSSMMuBMu
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_MSSMMuBMu) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/MSSMMuBMu
 
-		install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/MSSMCPV
-		install -m u=rw,g=r,o=r $(MANUALS_PLOTS_MSSMCPV) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/MSSMCPV
+		$(Q)install -d $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/MSSMCPV
+		$(Q)install -m u=rw,g=r,o=r $(MANUALS_PLOTS_MSSMCPV) $(INSTALL_DIR)/$(MANUALS_PLOTS_DIR)/MSSMCPV
 
 endif
 
 $(MODNAME)-pdf: $(PAPER_PDF)
 
 $(PAPER_PDF_1): $(PAPER_SRC_1) $(PAPER_STY)
-		cd $(MANUALS_DIR) && pdflatex flexiblesusy-1.0.tex
-		cd $(MANUALS_DIR) && pdflatex flexiblesusy-1.0.tex
-		cd $(MANUALS_DIR) && pdflatex flexiblesusy-1.0.tex
+		$(Q)cd $(MANUALS_DIR) && pdflatex flexiblesusy-1.0.tex
+		$(Q)cd $(MANUALS_DIR) && pdflatex flexiblesusy-1.0.tex
+		$(Q)cd $(MANUALS_DIR) && pdflatex flexiblesusy-1.0.tex
 
 $(PAPER_PDF_2): $(PAPER_SRC_2) $(PAPER_STY)
-		cd $(MANUALS_DIR) && pdflatex flexiblesusy-2.0.tex
-		cd $(MANUALS_DIR) && bibtex flexiblesusy-2.0
-		cd $(MANUALS_DIR) && pdflatex flexiblesusy-2.0.tex
-		cd $(MANUALS_DIR) && pdflatex flexiblesusy-2.0.tex
+		$(Q)cd $(MANUALS_DIR) && pdflatex flexiblesusy-2.0.tex
+		$(Q)cd $(MANUALS_DIR) && bibtex flexiblesusy-2.0
+		$(Q)cd $(MANUALS_DIR) && pdflatex flexiblesusy-2.0.tex
+		$(Q)cd $(MANUALS_DIR) && pdflatex flexiblesusy-2.0.tex
 
 $(PAPER_PDF_3): $(PAPER_SRC_3) $(PAPER_STY)
-		cd $(MANUALS_DIR) && pdflatex flexiblesusy-new_features.tex
-		cd $(MANUALS_DIR) && bibtex flexiblesusy-new_features
-		cd $(MANUALS_DIR) && pdflatex flexiblesusy-new_features.tex
-		cd $(MANUALS_DIR) && pdflatex flexiblesusy-new_features.tex
+		$(Q)cd $(MANUALS_DIR) && pdflatex flexiblesusy-new_features.tex
+		$(Q)cd $(MANUALS_DIR) && bibtex flexiblesusy-new_features
+		$(Q)cd $(MANUALS_DIR) && pdflatex flexiblesusy-new_features.tex
+		$(Q)cd $(MANUALS_DIR) && pdflatex flexiblesusy-new_features.tex

--- a/doc/models/module.mk
+++ b/doc/models/module.mk
@@ -31,11 +31,11 @@ DOC_MODELS_EXAMPLES := \
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(DOC_MODELS_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(DOC_MODELS_MK) $(DOC_MODELS_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(DOC_MODELS_RST) $(DOC_MODELS_INSTALL_DIR)
-		install -d $(INSTALL_DIR)/$(DOC_MODELS_IMAGE_DIR)
-		install -m u=rw,g=r,o=r $(DOC_MODELS_IMAGES) $(INSTALL_DIR)/$(DOC_MODELS_IMAGE_DIR)
-		install -d $(INSTALL_DIR)/$(DOC_MODELS_EXAMPLE_DIR)
-		install -m u=rw,g=r,o=r $(DOC_MODELS_EXAMPLES) $(INSTALL_DIR)/$(DOC_MODELS_EXAMPLE_DIR)
+		$(Q)install -d $(DOC_MODELS_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(DOC_MODELS_MK) $(DOC_MODELS_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(DOC_MODELS_RST) $(DOC_MODELS_INSTALL_DIR)
+		$(Q)install -d $(INSTALL_DIR)/$(DOC_MODELS_IMAGE_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(DOC_MODELS_IMAGES) $(INSTALL_DIR)/$(DOC_MODELS_IMAGE_DIR)
+		$(Q)install -d $(INSTALL_DIR)/$(DOC_MODELS_EXAMPLE_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(DOC_MODELS_EXAMPLES) $(INSTALL_DIR)/$(DOC_MODELS_EXAMPLE_DIR)
 endif

--- a/doc/module.mk
+++ b/doc/module.mk
@@ -44,19 +44,19 @@ all-$(MODNAME): doc-html doc-man doc-pdf
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(DOC_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(DOC_TMPL) $(DOC_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(DOC_MK) $(DOC_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(DOXYFILE) $(DOC_INSTALL_DIR)
-		install -d $(INSTALL_DIR)/$(IMAGE_DIR)
-		install -m u=rw,g=r,o=r $(IMAGES) $(INSTALL_DIR)/$(IMAGE_DIR)
+		$(Q)install -d $(DOC_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(DOC_TMPL) $(DOC_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(DOC_MK) $(DOC_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(DOXYFILE) $(DOC_INSTALL_DIR)
+		$(Q)install -d $(INSTALL_DIR)/$(IMAGE_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(IMAGES) $(INSTALL_DIR)/$(IMAGE_DIR)
 endif
 
 clean-$(MODNAME): clean-doc-manuals
 
 distclean-$(MODNAME): clean-$(MODNAME) distclean-doc-manuals
-		-rm -rf $(HTML_OUTPUT_DIR)
-		-rm -f $(DOXYGEN_MAINPAGE)
+		$(Q)-rm -rf $(HTML_OUTPUT_DIR)
+		$(Q)-rm -f $(DOXYGEN_MAINPAGE)
 
 clean::         clean-$(MODNAME)
 

--- a/examples/module.mk
+++ b/examples/module.mk
@@ -24,16 +24,16 @@ all-$(MODNAME): $(EXAMPLES_EXE)
 		@true
 
 clean-$(MODNAME)-dep:
-		-rm -f $(EXAMPLES_DEP)
+		$(Q)-rm -f $(EXAMPLES_DEP)
 
 clean-$(MODNAME)-lib:
 		@true
 
 clean-$(MODNAME)-obj:
-		-rm -f $(EXAMPLES_OBJ)
+		$(Q)-rm -f $(EXAMPLES_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
-		-rm -f $(EXAMPLES_EXE)
+		$(Q)-rm -f $(EXAMPLES_EXE)
 
 distclean-$(MODNAME): clean-$(MODNAME)
 		-@for d in $(STANDALONE_DIR); do \

--- a/fflite/module.mk
+++ b/fflite/module.mk
@@ -78,7 +78,7 @@ clean::         clean-$(MODNAME)
 distclean::     distclean-$(MODNAME)
 
 $(LIBFFLITE): $(LIBFFLITE_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 ifeq ($(ENABLE_FFLITE),yes)

--- a/fflite/module.mk
+++ b/fflite/module.mk
@@ -51,20 +51,20 @@ all-$(MODNAME): $(LIBFFLITE)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIBFFLITE_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBFFLITE_SRC) $(LIBFFLITE_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBFFLITE_HDR) $(LIBFFLITE_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBFFLITE_MK) $(LIBFFLITE_INSTALL_DIR)
+		$(Q)install -d $(LIBFFLITE_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBFFLITE_SRC) $(LIBFFLITE_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBFFLITE_HDR) $(LIBFFLITE_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBFFLITE_MK) $(LIBFFLITE_INSTALL_DIR)
 endif
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIBFFLITE_DEP)
+		$(Q)-rm -f $(LIBFFLITE_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIBFFLITE)
+		$(Q)-rm -f $(LIBFFLITE)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIBFFLITE_OBJ)
+		$(Q)-rm -f $(LIBFFLITE_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
 		@true
@@ -78,7 +78,8 @@ clean::         clean-$(MODNAME)
 distclean::     distclean-$(MODNAME)
 
 $(LIBFFLITE): $(LIBFFLITE_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 ifeq ($(ENABLE_FFLITE),yes)
 ALLDEP += $(LIBFFLITE_DEP)

--- a/model_specific/MSSM_higgs/module.mk
+++ b/model_specific/MSSM_higgs/module.mk
@@ -31,20 +31,20 @@ all-$(MODNAME): $(LIB_model_specific_MSSM_higgs)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIB_model_specific_MSSM_higgs_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_higgs_SRC) $(LIB_model_specific_MSSM_higgs_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_higgs_HDR) $(LIB_model_specific_MSSM_higgs_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_higgs_MK) $(LIB_model_specific_MSSM_higgs_INSTALL_DIR)
+		$(Q)install -d $(LIB_model_specific_MSSM_higgs_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_higgs_SRC) $(LIB_model_specific_MSSM_higgs_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_higgs_HDR) $(LIB_model_specific_MSSM_higgs_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_higgs_MK) $(LIB_model_specific_MSSM_higgs_INSTALL_DIR)
 endif
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIB_model_specific_MSSM_higgs_DEP)
+		$(Q)-rm -f $(LIB_model_specific_MSSM_higgs_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIB_model_specific_MSSM_higgs)
+		$(Q)-rm -f $(LIB_model_specific_MSSM_higgs)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIB_model_specific_MSSM_higgs_OBJ)
+		$(Q)-rm -f $(LIB_model_specific_MSSM_higgs_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
 		@true
@@ -65,10 +65,12 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_MSSM_higgs): $(LIB_model_specific_MSSM_higgs_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_MSSM_higgs): $(LIB_model_specific_MSSM_higgs_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 
 ALLDEP += $(LIB_model_specific_MSSM_higgs_DEP)

--- a/model_specific/MSSM_higgs/module.mk
+++ b/model_specific/MSSM_higgs/module.mk
@@ -65,11 +65,11 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_MSSM_higgs): $(LIB_model_specific_MSSM_higgs_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_MSSM_higgs): $(LIB_model_specific_MSSM_higgs_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 

--- a/model_specific/MSSM_thresholds/module.mk
+++ b/model_specific/MSSM_thresholds/module.mk
@@ -34,20 +34,20 @@ all-$(MODNAME): $(LIB_model_specific_MSSM_thresholds)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIB_model_specific_MSSM_thresholds_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_thresholds_SRC) $(LIB_model_specific_MSSM_thresholds_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_thresholds_HDR) $(LIB_model_specific_MSSM_thresholds_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_thresholds_MK) $(LIB_model_specific_MSSM_thresholds_INSTALL_DIR)
+		$(Q)install -d $(LIB_model_specific_MSSM_thresholds_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_thresholds_SRC) $(LIB_model_specific_MSSM_thresholds_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_thresholds_HDR) $(LIB_model_specific_MSSM_thresholds_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_MSSM_thresholds_MK) $(LIB_model_specific_MSSM_thresholds_INSTALL_DIR)
 endif
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIB_model_specific_MSSM_thresholds_DEP)
+		$(Q)-rm -f $(LIB_model_specific_MSSM_thresholds_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIB_model_specific_MSSM_thresholds)
+		$(Q)-rm -f $(LIB_model_specific_MSSM_thresholds)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIB_model_specific_MSSM_thresholds_OBJ)
+		$(Q)-rm -f $(LIB_model_specific_MSSM_thresholds_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
 		@true
@@ -68,10 +68,12 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_MSSM_thresholds): $(LIB_model_specific_MSSM_thresholds_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_MSSM_thresholds): $(LIB_model_specific_MSSM_thresholds_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 
 ALLDEP += $(LIB_model_specific_MSSM_thresholds_DEP)

--- a/model_specific/MSSM_thresholds/module.mk
+++ b/model_specific/MSSM_thresholds/module.mk
@@ -68,11 +68,11 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_MSSM_thresholds): $(LIB_model_specific_MSSM_thresholds_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_MSSM_thresholds): $(LIB_model_specific_MSSM_thresholds_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 

--- a/model_specific/NMSSM_higgs/module.mk
+++ b/model_specific/NMSSM_higgs/module.mk
@@ -35,20 +35,20 @@ all-$(MODNAME): $(LIB_model_specific_NMSSM_higgs)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIB_model_specific_NMSSM_higgs_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_NMSSM_higgs_SRC) $(LIB_model_specific_NMSSM_higgs_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_NMSSM_higgs_HDR) $(LIB_model_specific_NMSSM_higgs_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_NMSSM_higgs_MK) $(LIB_model_specific_NMSSM_higgs_INSTALL_DIR)
+		$(Q)install -d $(LIB_model_specific_NMSSM_higgs_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_NMSSM_higgs_SRC) $(LIB_model_specific_NMSSM_higgs_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_NMSSM_higgs_HDR) $(LIB_model_specific_NMSSM_higgs_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_NMSSM_higgs_MK) $(LIB_model_specific_NMSSM_higgs_INSTALL_DIR)
 endif
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIB_model_specific_NMSSM_higgs_DEP)
+		$(Q)-rm -f $(LIB_model_specific_NMSSM_higgs_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIB_model_specific_NMSSM_higgs)
+		$(Q)-rm -f $(LIB_model_specific_NMSSM_higgs)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIB_model_specific_NMSSM_higgs_OBJ)
+		$(Q)-rm -f $(LIB_model_specific_NMSSM_higgs_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
 		@true
@@ -71,10 +71,12 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_NMSSM_higgs): $(LIB_model_specific_NMSSM_higgs_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_NMSSM_higgs): $(LIB_model_specific_NMSSM_higgs_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 
 ALLDEP += $(LIB_model_specific_NMSSM_higgs_DEP)

--- a/model_specific/NMSSM_higgs/module.mk
+++ b/model_specific/NMSSM_higgs/module.mk
@@ -71,11 +71,11 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_NMSSM_higgs): $(LIB_model_specific_NMSSM_higgs_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_NMSSM_higgs): $(LIB_model_specific_NMSSM_higgs_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 

--- a/model_specific/SM/module.mk
+++ b/model_specific/SM/module.mk
@@ -82,11 +82,11 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_SM): $(LIB_model_specific_SM_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_SM): $(LIB_model_specific_SM_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 

--- a/model_specific/SM/module.mk
+++ b/model_specific/SM/module.mk
@@ -48,20 +48,20 @@ all-$(MODNAME): $(LIB_model_specific_SM)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIB_model_specific_SM_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_SM_SRC) $(LIB_model_specific_SM_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_SM_HDR) $(LIB_model_specific_SM_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_SM_MK) $(LIB_model_specific_SM_INSTALL_DIR)
+		$(Q)install -d $(LIB_model_specific_SM_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_SM_SRC) $(LIB_model_specific_SM_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_SM_HDR) $(LIB_model_specific_SM_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_SM_MK) $(LIB_model_specific_SM_INSTALL_DIR)
 endif
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIB_model_specific_SM_DEP)
+		$(Q)-rm -f $(LIB_model_specific_SM_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIB_model_specific_SM)
+		$(Q)-rm -f $(LIB_model_specific_SM)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIB_model_specific_SM_OBJ)
+		$(Q)-rm -f $(LIB_model_specific_SM_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
 		@true
@@ -82,10 +82,12 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_SM): $(LIB_model_specific_SM_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_SM): $(LIB_model_specific_SM_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 
 ALLDEP += $(LIB_model_specific_SM_DEP)

--- a/model_specific/SM_thresholds/module.mk
+++ b/model_specific/SM_thresholds/module.mk
@@ -62,11 +62,11 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_SM_thresholds): $(LIB_model_specific_SM_thresholds_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_SM_thresholds): $(LIB_model_specific_SM_thresholds_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 

--- a/model_specific/SM_thresholds/module.mk
+++ b/model_specific/SM_thresholds/module.mk
@@ -28,20 +28,20 @@ all-$(MODNAME): $(LIB_model_specific_SM_thresholds)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIB_model_specific_SM_thresholds_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_SM_thresholds_SRC) $(LIB_model_specific_SM_thresholds_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_SM_thresholds_HDR) $(LIB_model_specific_SM_thresholds_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_SM_thresholds_MK) $(LIB_model_specific_SM_thresholds_INSTALL_DIR)
+		$(Q)install -d $(LIB_model_specific_SM_thresholds_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_SM_thresholds_SRC) $(LIB_model_specific_SM_thresholds_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_SM_thresholds_HDR) $(LIB_model_specific_SM_thresholds_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_SM_thresholds_MK) $(LIB_model_specific_SM_thresholds_INSTALL_DIR)
 endif
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIB_model_specific_SM_thresholds_DEP)
+		$(Q)-rm -f $(LIB_model_specific_SM_thresholds_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIB_model_specific_SM_thresholds)
+		$(Q)-rm -f $(LIB_model_specific_SM_thresholds)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIB_model_specific_SM_thresholds_OBJ)
+		$(Q)-rm -f $(LIB_model_specific_SM_thresholds_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
 		@true
@@ -62,10 +62,12 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_SM_thresholds): $(LIB_model_specific_SM_thresholds_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_SM_thresholds): $(LIB_model_specific_SM_thresholds_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 
 ALLDEP += $(LIB_model_specific_SM_thresholds_DEP)

--- a/model_specific/SplitMSSM/module.mk
+++ b/model_specific/SplitMSSM/module.mk
@@ -64,11 +64,11 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_SplitMSSM): $(LIB_model_specific_SplitMSSM_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_SplitMSSM): $(LIB_model_specific_SplitMSSM_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 

--- a/model_specific/SplitMSSM/module.mk
+++ b/model_specific/SplitMSSM/module.mk
@@ -30,20 +30,20 @@ all-$(MODNAME): $(LIB_model_specific_SplitMSSM)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIB_model_specific_SplitMSSM_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_SplitMSSM_SRC) $(LIB_model_specific_SplitMSSM_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_SplitMSSM_HDR) $(LIB_model_specific_SplitMSSM_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB_model_specific_SplitMSSM_MK) $(LIB_model_specific_SplitMSSM_INSTALL_DIR)
+		$(Q)install -d $(LIB_model_specific_SplitMSSM_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_SplitMSSM_SRC) $(LIB_model_specific_SplitMSSM_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_SplitMSSM_HDR) $(LIB_model_specific_SplitMSSM_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB_model_specific_SplitMSSM_MK) $(LIB_model_specific_SplitMSSM_INSTALL_DIR)
 endif
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIB_model_specific_SplitMSSM_DEP)
+		$(Q)-rm -f $(LIB_model_specific_SplitMSSM_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIB_model_specific_SplitMSSM)
+		$(Q)-rm -f $(LIB_model_specific_SplitMSSM)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIB_model_specific_SplitMSSM_OBJ)
+		$(Q)-rm -f $(LIB_model_specific_SplitMSSM_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
 		@true
@@ -64,10 +64,12 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIB_model_specific_SplitMSSM): $(LIB_model_specific_SplitMSSM_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIB_model_specific_SplitMSSM): $(LIB_model_specific_SplitMSSM_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 
 ALLDEP += $(LIB_model_specific_SplitMSSM_DEP)

--- a/slhaea/module.mk
+++ b/slhaea/module.mk
@@ -16,9 +16,9 @@ all-$(MODNAME):
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(SLHAEA_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(SLHAEA_HDR) $(SLHAEA_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(SLHAEA_MK) $(SLHAEA_INSTALL_DIR)
+		$(Q)install -d $(SLHAEA_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(SLHAEA_HDR) $(SLHAEA_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(SLHAEA_MK) $(SLHAEA_INSTALL_DIR)
 endif
 
 clean-$(MODNAME):

--- a/src/module.mk
+++ b/src/module.mk
@@ -189,11 +189,11 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIBFLEXI): $(LIBFLEXI_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIBFLEXI): $(LIBFLEXI_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 

--- a/src/module.mk
+++ b/src/module.mk
@@ -155,20 +155,20 @@ all-$(MODNAME): $(LIBFLEXI)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(LIBFLEXI_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBFLEXI_SRC) $(LIBFLEXI_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBFLEXI_HDR) $(LIBFLEXI_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIBFLEXI_MK) $(LIBFLEXI_INSTALL_DIR)
+		$(Q)install -d $(LIBFLEXI_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBFLEXI_SRC) $(LIBFLEXI_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBFLEXI_HDR) $(LIBFLEXI_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIBFLEXI_MK) $(LIBFLEXI_INSTALL_DIR)
 endif
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIBFLEXI_DEP)
+		$(Q)-rm -f $(LIBFLEXI_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIBFLEXI)
+		$(Q)-rm -f $(LIBFLEXI)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIBFLEXI_OBJ)
+		$(Q)-rm -f $(LIBFLEXI_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
 		@true
@@ -189,10 +189,12 @@ endif
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIBFLEXI): $(LIBFLEXI_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS)
 else
 $(LIBFLEXI): $(LIBFLEXI_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 
 ALLDEP += $(LIBFLEXI_DEP)

--- a/templates/module.mk.in
+++ b/templates/module.mk.in
@@ -203,56 +203,56 @@ all-$(MODNAME): $(LIB@CLASSNAME@) $(EXE@CLASSNAME@_EXE)
 
 ifneq ($(INSTALL_DIR),)
 install-src::
-		install -d $(@CLASSNAME@_INSTALL_DIR)
-		install -d $(@CLASSNAME@_INSTALL_CXXQFT_DIR)
-		install -m u=rw,g=r,o=r $(LIB@CLASSNAME@_SRC) $(@CLASSNAME@_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB@CLASSNAME@_HDR) $(@CLASSNAME@_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LIB@CLASSNAME@_CXXQFT_HDR) $(@CLASSNAME@_INSTALL_CXXQFT_DIR)
-		install -m u=rw,g=r,o=r $(EXE@CLASSNAME@_SRC) $(@CLASSNAME@_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LL@CLASSNAME@_SRC) $(@CLASSNAME@_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(LL@CLASSNAME@_MMA) $(@CLASSNAME@_INSTALL_DIR)
-		$(INSTALL_STRIPPED) $(@CLASSNAME@_MK) $(@CLASSNAME@_INSTALL_DIR) -m u=rw,g=r,o=r
-		install -m u=rw,g=r,o=r $(@CLASSNAME@_INCLUDE_MK) $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)install -d $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)install -d $(@CLASSNAME@_INSTALL_CXXQFT_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB@CLASSNAME@_SRC) $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB@CLASSNAME@_HDR) $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LIB@CLASSNAME@_CXXQFT_HDR) $(@CLASSNAME@_INSTALL_CXXQFT_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(EXE@CLASSNAME@_SRC) $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LL@CLASSNAME@_SRC) $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(LL@CLASSNAME@_MMA) $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)$(INSTALL_STRIPPED) $(@CLASSNAME@_MK) $(@CLASSNAME@_INSTALL_DIR) -m u=rw,g=r,o=r
+		$(Q)install -m u=rw,g=r,o=r $(@CLASSNAME@_INCLUDE_MK) $(@CLASSNAME@_INSTALL_DIR)
 ifneq ($(@CLASSNAME@_SLHA_INPUT),)
-		install -m u=rw,g=r,o=r $(@CLASSNAME@_SLHA_INPUT) $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(@CLASSNAME@_SLHA_INPUT) $(@CLASSNAME@_INSTALL_DIR)
 endif
-		install -m u=rw,g=r,o=r $(@CLASSNAME@_REFERENCES) $(@CLASSNAME@_INSTALL_DIR)
-		install -m u=rw,g=r,o=r $(@CLASSNAME@_GNUPLOT) $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(@CLASSNAME@_REFERENCES) $(@CLASSNAME@_INSTALL_DIR)
+		$(Q)install -m u=rw,g=r,o=r $(@CLASSNAME@_GNUPLOT) $(@CLASSNAME@_INSTALL_DIR)
 endif
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIB@CLASSNAME@_DEP)
-		-rm -f $(EXE@CLASSNAME@_DEP)
-		-rm -f $(LL@CLASSNAME@_DEP)
+		$(Q)-rm -f $(LIB@CLASSNAME@_DEP)
+		$(Q)-rm -f $(EXE@CLASSNAME@_DEP)
+		$(Q)-rm -f $(LL@CLASSNAME@_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIB@CLASSNAME@)
-		-rm -f $(LL@CLASSNAME@_LIB)
+		$(Q)-rm -f $(LIB@CLASSNAME@)
+		$(Q)-rm -f $(LL@CLASSNAME@_LIB)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIB@CLASSNAME@_OBJ)
-		-rm -f $(EXE@CLASSNAME@_OBJ)
-		-rm -f $(LL@CLASSNAME@_OBJ)
+		$(Q)-rm -f $(LIB@CLASSNAME@_OBJ)
+		$(Q)-rm -f $(EXE@CLASSNAME@_OBJ)
+		$(Q)-rm -f $(LL@CLASSNAME@_OBJ)
 
 # BEGIN: NOT EXPORTED ##########################################
 clean-$(MODNAME)-src:
-		-rm -f $(LIB@CLASSNAME@_SRC)
-		-rm -f $(LIB@CLASSNAME@_HDR)
-		-rm -f $(LIB@CLASSNAME@_CXXQFT_HDR)
-		-rm -f $(EXE@CLASSNAME@_SRC)
-		-rm -f $(LL@CLASSNAME@_SRC)
-		-rm -f $(LL@CLASSNAME@_MMA)
-		-rm -f $(METACODE_STAMP_@CLASSNAME@)
-		-rm -f $(@CLASSNAME@_INCLUDE_MK)
-		-rm -f $(@CLASSNAME@_SLHA_INPUT)
-		-rm -f $(@CLASSNAME@_REFERENCES)
-		-rm -f $(@CLASSNAME@_GNUPLOT)
+		$(Q)-rm -f $(LIB@CLASSNAME@_SRC)
+		$(Q)-rm -f $(LIB@CLASSNAME@_HDR)
+		$(Q)-rm -f $(LIB@CLASSNAME@_CXXQFT_HDR)
+		$(Q)-rm -f $(EXE@CLASSNAME@_SRC)
+		$(Q)-rm -f $(LL@CLASSNAME@_SRC)
+		$(Q)-rm -f $(LL@CLASSNAME@_MMA)
+		$(Q)-rm -f $(METACODE_STAMP_@CLASSNAME@)
+		$(Q)-rm -f $(@CLASSNAME@_INCLUDE_MK)
+		$(Q)-rm -f $(@CLASSNAME@_SLHA_INPUT)
+		$(Q)-rm -f $(@CLASSNAME@_REFERENCES)
+		$(Q)-rm -f $(@CLASSNAME@_GNUPLOT)
 
 distclean-$(MODNAME): clean-$(MODNAME)-src
 # END:   NOT EXPORTED ##########################################
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-lib clean-$(MODNAME)-obj
-		-rm -f $(EXE@CLASSNAME@_EXE)
+		$(Q)-rm -f $(EXE@CLASSNAME@_EXE)
 
 distclean-$(MODNAME): clean-$(MODNAME)
 		@true
@@ -266,7 +266,7 @@ clean::         clean-$(MODNAME)
 distclean::     distclean-$(MODNAME)
 
 pack-$(MODNAME)-src:
-		tar -czf $(@CLASSNAME@_TARBALL) \
+		$(Q)tar -czf $(@CLASSNAME@_TARBALL) \
 		$(LIB@CLASSNAME@_SRC) $(LIB@CLASSNAME@_HDR) $(LIB@CLASSNAME@_CXXQFT_HDR) \
 		$(EXE@CLASSNAME@_SRC) \
 		$(LL@CLASSNAME@_SRC) $(LL@CLASSNAME@_MMA) \
@@ -283,7 +283,8 @@ run-metacode-$(MODNAME): $(METACODE_STAMP_@CLASSNAME@)
 
 ifeq ($(ENABLE_META),yes)
 $(METACODE_STAMP_@CLASSNAME@): $(DIR)/start.m $(DIR)/FlexibleSUSY.m $(META_SRC) $(TEMPLATES) $(SARAH_MODEL_FILES_@CLASSNAME@)
-		"$(MATH)" -run "Get[\"$<\"]; Quit[]" || (echo "Error: The code generation failed!"; exit 1)
+		@echo "Running $<"
+		$(Q)"$(MATH)" -run "Get[\"$<\"]; Quit[]" || (echo "Error: The code generation failed!"; exit 1)
 		@touch "$(METACODE_STAMP_@CLASSNAME@)"
 		@echo "Note: to regenerate @CLASSNAME@ source files," \
 		      "please remove the file "
@@ -306,13 +307,16 @@ $(LL@CLASSNAME@_OBJ) $(LL@CLASSNAME@_LIB): \
 	CPPFLAGS += $(LLFLAGS)
 
 $(LIB@CLASSNAME@): $(LIB@CLASSNAME@_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 $(DIR)/%.x: $(DIR)/%.o $(LIB@CLASSNAME@) $(MOD@CLASSNAME@_LIB) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		$(CXX) $(LDFLAGS) -o $@ $(call abspathx,$(ADDONLIBS) $^ $(LIBGM2Calc)) $(filter -%,$(LOOPFUNCLIBS)) $(HIMALAYALIBS) $(GSLLIBS) $(BOOSTTHREADLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS) $(LDLIBS)
+		@echo "Building $@"
+		$(Q)$(CXX) $(LDFLAGS) -o $@ $(call abspathx,$(ADDONLIBS) $^ $(LIBGM2Calc)) $(filter -%,$(LOOPFUNCLIBS)) $(HIMALAYALIBS) $(GSLLIBS) $(BOOSTTHREADLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS) $(LDLIBS)
 
 $(LL@CLASSNAME@_LIB): $(LL@CLASSNAME@_OBJ) $(LIB@CLASSNAME@) $(MOD@CLASSNAME@_LIB) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		$(LIBLNK_MAKE_LIB_CMD) $@ $(CPPFLAGS) $(CFLAGS) $(call abspathx,$(ADDONLIBS) $^ $(LIBGM2Calc)) $(filter -%,$(LOOPFUNCLIBS)) $(HIMALAYALIBS) $(GSLLIBS) $(BOOSTTHREADLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS) $(LDLIBS) $(LLLIBS)
+		@echo "Building $@"
+		$(Q)$(LIBLNK_MAKE_LIB_CMD) $@ $(CPPFLAGS) $(CFLAGS) $(call abspathx,$(ADDONLIBS) $^ $(LIBGM2Calc)) $(filter -%,$(LOOPFUNCLIBS)) $(HIMALAYALIBS) $(GSLLIBS) $(BOOSTTHREADLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS) $(LDLIBS) $(LLLIBS)
 
 ALLDEP += $(LIB@CLASSNAME@_DEP) $(EXE@CLASSNAME@_DEP)
 ALLSRC += $(LIB@CLASSNAME@_SRC) $(EXE@CLASSNAME@_SRC)

--- a/templates/module.mk.in
+++ b/templates/module.mk.in
@@ -283,7 +283,7 @@ run-metacode-$(MODNAME): $(METACODE_STAMP_@CLASSNAME@)
 
 ifeq ($(ENABLE_META),yes)
 $(METACODE_STAMP_@CLASSNAME@): $(DIR)/start.m $(DIR)/FlexibleSUSY.m $(META_SRC) $(TEMPLATES) $(SARAH_MODEL_FILES_@CLASSNAME@)
-		@echo "Running $<"
+		@$(MSG)
 		$(Q)"$(MATH)" -run "Get[\"$<\"]; Quit[]" || (echo "Error: The code generation failed!"; exit 1)
 		@touch "$(METACODE_STAMP_@CLASSNAME@)"
 		@echo "Note: to regenerate @CLASSNAME@ source files," \
@@ -307,15 +307,15 @@ $(LL@CLASSNAME@_OBJ) $(LL@CLASSNAME@_LIB): \
 	CPPFLAGS += $(LLFLAGS)
 
 $(LIB@CLASSNAME@): $(LIB@CLASSNAME@_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 $(DIR)/%.x: $(DIR)/%.o $(LIB@CLASSNAME@) $(MOD@CLASSNAME@_LIB) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) $(LDFLAGS) -o $@ $(call abspathx,$(ADDONLIBS) $^ $(LIBGM2Calc)) $(filter -%,$(LOOPFUNCLIBS)) $(HIMALAYALIBS) $(GSLLIBS) $(BOOSTTHREADLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS) $(LDLIBS)
 
 $(LL@CLASSNAME@_LIB): $(LL@CLASSNAME@_OBJ) $(LIB@CLASSNAME@) $(MOD@CLASSNAME@_LIB) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(LIBLNK_MAKE_LIB_CMD) $@ $(CPPFLAGS) $(CFLAGS) $(call abspathx,$(ADDONLIBS) $^ $(LIBGM2Calc)) $(filter -%,$(LOOPFUNCLIBS)) $(HIMALAYALIBS) $(GSLLIBS) $(BOOSTTHREADLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS) $(THREADLIBS) $(LDLIBS) $(LLLIBS)
 
 ALLDEP += $(LIB@CLASSNAME@_DEP) $(EXE@CLASSNAME@_DEP)

--- a/test/SOFTSUSY/module.mk
+++ b/test/SOFTSUSY/module.mk
@@ -110,15 +110,15 @@ $(LIBSOFTSUSY_OBJ) $(RUN_SOFTSUSY_OBJ) $(RUN_SOFTPOINT_OBJ): \
 	CPPFLAGS += $(MODSOFTSUSY_INC) $(BOOSTFLAGS) $(EIGENFLAGS)
 
 $(LIBSOFTSUSY): $(LIBSOFTSUSY_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 $(RUN_SOFTSUSY_EXE): $(RUN_SOFTSUSY_OBJ) $(LIBSOFTSUSY) $(MODSOFTSUSY_LIB) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) -o $@ $(call abspathx,$^) $(filter -%,$(LOOPFUNCLIBS)) $(FLIBS)
 
 $(RUN_SOFTPOINT_EXE): $(RUN_SOFTPOINT_OBJ) $(LIBSOFTSUSY) $(MODSOFTSUSY_LIB) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) -o $@ $(call abspathx,$^) $(filter -%,$(LOOPFUNCLIBS)) $(FLIBS)
 
 ALLDEP += $(LIBSOFTSUSY_DEP) $(RUN_SOFTSUSY_DEP) $(RUN_SOFTPOINT_DEP)

--- a/test/SOFTSUSY/module.mk
+++ b/test/SOFTSUSY/module.mk
@@ -82,22 +82,22 @@ RUN_SOFTPOINT_EXE := $(RUN_SOFTPOINT_OBJ:.o=.x)
 all-$(MODNAME): $(LIBSOFTSUSY)
 
 clean-$(MODNAME)-dep:
-		-rm -f $(LIBSOFTSUSY_DEP)
-		-rm -f $(RUN_SOFTSUSY_DEP)
-		-rm -f $(RUN_SOFTPOINT_DEP)
+		$(Q)-rm -f $(LIBSOFTSUSY_DEP)
+		$(Q)-rm -f $(RUN_SOFTSUSY_DEP)
+		$(Q)-rm -f $(RUN_SOFTPOINT_DEP)
 
 clean-$(MODNAME)-lib:
-		-rm -f $(LIBSOFTSUSY)
+		$(Q)-rm -f $(LIBSOFTSUSY)
 
 clean-$(MODNAME)-obj:
-		-rm -f $(LIBSOFTSUSY_OBJ)
-		-rm -f $(RUN_SOFTSUSY_OBJ)
-		-rm -f $(RUN_SOFTPOINT_OBJ)
+		$(Q)-rm -f $(LIBSOFTSUSY_OBJ)
+		$(Q)-rm -f $(RUN_SOFTSUSY_OBJ)
+		$(Q)-rm -f $(RUN_SOFTPOINT_OBJ)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-obj
-		-rm -f $(LIBSOFTSUSY)
-		-rm -f $(RUN_SOFTSUSY_EXE)
-		-rm -f $(RUN_SOFTPOINT_EXE)
+		$(Q)-rm -f $(LIBSOFTSUSY)
+		$(Q)-rm -f $(RUN_SOFTSUSY_EXE)
+		$(Q)-rm -f $(RUN_SOFTPOINT_EXE)
 
 distclean-$(MODNAME): clean-$(MODNAME)
 
@@ -110,13 +110,16 @@ $(LIBSOFTSUSY_OBJ) $(RUN_SOFTSUSY_OBJ) $(RUN_SOFTPOINT_OBJ): \
 	CPPFLAGS += $(MODSOFTSUSY_INC) $(BOOSTFLAGS) $(EIGENFLAGS)
 
 $(LIBSOFTSUSY): $(LIBSOFTSUSY_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 
 $(RUN_SOFTSUSY_EXE): $(RUN_SOFTSUSY_OBJ) $(LIBSOFTSUSY) $(MODSOFTSUSY_LIB) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		$(CXX) -o $@ $(call abspathx,$^) $(filter -%,$(LOOPFUNCLIBS)) $(FLIBS)
+		@echo "Building $@"
+		$(Q)$(CXX) -o $@ $(call abspathx,$^) $(filter -%,$(LOOPFUNCLIBS)) $(FLIBS)
 
 $(RUN_SOFTPOINT_EXE): $(RUN_SOFTPOINT_OBJ) $(LIBSOFTSUSY) $(MODSOFTSUSY_LIB) $(LIBFLEXI) $(filter-out -%,$(LOOPFUNCLIBS))
-		$(CXX) -o $@ $(call abspathx,$^) $(filter -%,$(LOOPFUNCLIBS)) $(FLIBS)
+		@echo "Building $@"
+		$(Q)$(CXX) -o $@ $(call abspathx,$^) $(filter -%,$(LOOPFUNCLIBS)) $(FLIBS)
 
 ALLDEP += $(LIBSOFTSUSY_DEP) $(RUN_SOFTSUSY_DEP) $(RUN_SOFTPOINT_DEP)
 ALLLIB += $(LIBSOFTSUSY)

--- a/test/module.mk
+++ b/test/module.mk
@@ -682,24 +682,24 @@ all-$(MODNAME): $(LIBTEST) $(TEST_EXE) $(TEST_XML)
 		@true
 
 clean-$(MODNAME)-dep: clean-SOFTSUSY-dep
-		-rm -f $(TEST_DEP)
-		-rm -f $(LIBTEST_DEP)
+		$(Q)-rm -f $(TEST_DEP)
+		$(Q)-rm -f $(LIBTEST_DEP)
 
 clean-$(MODNAME)-lib: clean-SOFTSUSY-lib
-		-rm -f $(LIBTEST)
+		$(Q)-rm -f $(LIBTEST)
 
 clean-$(MODNAME)-obj: clean-SOFTSUSY-obj
-		-rm -f $(TEST_OBJ)
-		-rm -f $(LIBTEST_OBJ)
+		$(Q)-rm -f $(TEST_OBJ)
+		$(Q)-rm -f $(LIBTEST_OBJ)
 
 clean-$(MODNAME)-log:
-		-rm -f $(TEST_XML)
-		-rm -f $(TEST_ALL_XML)
-		-rm -f $(TEST_ALL_LOG)
+		$(Q)-rm -f $(TEST_XML)
+		$(Q)-rm -f $(TEST_ALL_XML)
+		$(Q)-rm -f $(TEST_ALL_LOG)
 
 clean-$(MODNAME): clean-$(MODNAME)-dep clean-$(MODNAME)-obj \
                   clean-$(MODNAME)-lib clean-$(MODNAME)-log
-		-rm -f $(TEST_EXE)
+		$(Q)-rm -f $(TEST_EXE)
 
 distclean-$(MODNAME): clean-$(MODNAME)
 		@true
@@ -776,13 +776,16 @@ $(DIR)/test_CMSSM_NMSSM_linking.x: $(LIBCMSSM) $(LIBNMSSM)
 
 ifeq ($(ENABLE_LOOPTOOLS),yes)
 $(DIR)/test_pv_fflite.x: $(DIR)/test_pv_crosschecks.cpp src/pv.cpp $(LIBFFLITE)
-		$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $(call abspathx,$^) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) $(FLIBS)
+		@echo "Building $@"
+		$(Q)$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $(call abspathx,$^) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) $(FLIBS)
 
 $(DIR)/test_pv_looptools.x: $(DIR)/test_pv_crosschecks.cpp $(LIBFLEXI)
-		$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $(call abspathx,$^) $(LOOPTOOLSLIBS) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) $(FLIBS)
+		@echo "Building $@"
+		$(Q)$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $(call abspathx,$^) $(LOOPTOOLSLIBS) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) $(FLIBS)
 
 $(DIR)/test_pv_softsusy.x: $(DIR)/test_pv_crosschecks.cpp src/pv.cpp $(filter-out %pv.o,$(LIBFLEXI_OBJ))
-		$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $(call abspathx,$^) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS)
+		@echo "Building $@"
+		$(Q)$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $(call abspathx,$^) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS)
 endif
 
 $(DIR)/test_CMSSMNoFV_benchmark.x.xml: $(RUN_CMSSM_EXE) $(RUN_SOFTPOINT_EXE)
@@ -797,15 +800,18 @@ $(DIR)/test_loopfunctions.x: $(LIBCMSSM)
 $(DIR)/test_sfermions.x: $(LIBCMSSM)
 
 $(DIR)/test_SM_cxxdiagrams.cpp : $(DIR)/test_SM_cxxdiagrams.meta $(DIR)/test_SM_cxxdiagrams.cpp.in $(META_SRC) $(METACODE_STAMP_SM)
-		"$(MATH)" -run "AppendTo[\$$Path, \"./meta/\"]; Get[\"$<\"]; Quit[0];"
+		@echo "Building $@"
+		$(Q)"$(MATH)" -run "AppendTo[\$$Path, \"./meta/\"]; Get[\"$<\"]; Quit[0];"
 $(DIR)/test_SM_cxxdiagrams.x: $(LIBSM)
 
 $(DIR)/test_SM_npointfunctions.cpp : $(DIR)/test_SM_npointfunctions.meta $(DIR)/test_SM_npointfunctions.cpp.in $(META_SRC) $(METACODE_STAMP_SM)
-		"$(MATH)" -run "AppendTo[\$$Path, \"./meta/\"]; Get[\"$<\"]; Quit[0];"
+		@echo "Building $@"
+		$(Q)"$(MATH)" -run "AppendTo[\$$Path, \"./meta/\"]; Get[\"$<\"]; Quit[0];"
 $(DIR)/test_SM_npointfunctions.x: $(LIBSM)
 
 $(DIR)/test_MSSM_npointfunctions.cpp : $(DIR)/test_MSSM_npointfunctions.meta $(DIR)/test_MSSM_npointfunctions.cpp.in $(META_SRC) $(METACODE_STAMP_MSSM)
-		"$(MATH)" -run "AppendTo[\$$Path, \"./meta/\"]; Get[\"$<\"]; Quit[0];"
+		@echo "Building $@"
+		$(Q)"$(MATH)" -run "AppendTo[\$$Path, \"./meta/\"]; Get[\"$<\"]; Quit[0];"
 $(DIR)/test_MSSM_npointfunctions.x: $(LIBMSSM)
 
 $(DIR)/test_CMSSM_database.x: $(LIBCMSSM)
@@ -1010,7 +1016,8 @@ $(TEST_EXE): $(LIBSOFTSUSY) $(MODtest_LIB) $(LIBTEST) $(LIBFLEXI) $(filter-out -
 
 # general test rule
 $(DIR)/test_%.x: $(DIR)/test_%.o
-		$(CXX) -o $@ $(call abspathx,$^) \
+		@echo "Building $@"
+		$(Q)$(CXX) -o $@ $(call abspathx,$^) \
 		$(filter -%,$(LOOPFUNCLIBS)) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) \
 		$(THREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS)
 
@@ -1019,10 +1026,12 @@ $(TEST_OBJ) $(TEST_DEP): CPPFLAGS += -Itest/SOFTSUSY $(MODtest_INC) $(BOOSTFLAGS
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIBTEST): $(LIBTEST_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(THREADLIBS) $(GSLLIBS) $(FLIBS)
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(THREADLIBS) $(GSLLIBS) $(FLIBS)
 else
 $(LIBTEST): $(LIBTEST_OBJ)
-		$(MODULE_MAKE_LIB_CMD) $@ $^
+		@echo "Building $@"
+		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 
 ALLDEP += $(LIBTEST_DEP) $(TEST_DEP)

--- a/test/module.mk
+++ b/test/module.mk
@@ -776,15 +776,15 @@ $(DIR)/test_CMSSM_NMSSM_linking.x: $(LIBCMSSM) $(LIBNMSSM)
 
 ifeq ($(ENABLE_LOOPTOOLS),yes)
 $(DIR)/test_pv_fflite.x: $(DIR)/test_pv_crosschecks.cpp src/pv.cpp $(LIBFFLITE)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $(call abspathx,$^) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) $(FLIBS)
 
 $(DIR)/test_pv_looptools.x: $(DIR)/test_pv_crosschecks.cpp $(LIBFLEXI)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $(call abspathx,$^) $(LOOPTOOLSLIBS) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) $(FLIBS)
 
 $(DIR)/test_pv_softsusy.x: $(DIR)/test_pv_crosschecks.cpp src/pv.cpp $(filter-out %pv.o,$(LIBFLEXI_OBJ))
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $(call abspathx,$^) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) $(GSLLIBS) $(FLIBS)
 endif
 
@@ -800,17 +800,17 @@ $(DIR)/test_loopfunctions.x: $(LIBCMSSM)
 $(DIR)/test_sfermions.x: $(LIBCMSSM)
 
 $(DIR)/test_SM_cxxdiagrams.cpp : $(DIR)/test_SM_cxxdiagrams.meta $(DIR)/test_SM_cxxdiagrams.cpp.in $(META_SRC) $(METACODE_STAMP_SM)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)"$(MATH)" -run "AppendTo[\$$Path, \"./meta/\"]; Get[\"$<\"]; Quit[0];"
 $(DIR)/test_SM_cxxdiagrams.x: $(LIBSM)
 
 $(DIR)/test_SM_npointfunctions.cpp : $(DIR)/test_SM_npointfunctions.meta $(DIR)/test_SM_npointfunctions.cpp.in $(META_SRC) $(METACODE_STAMP_SM)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)"$(MATH)" -run "AppendTo[\$$Path, \"./meta/\"]; Get[\"$<\"]; Quit[0];"
 $(DIR)/test_SM_npointfunctions.x: $(LIBSM)
 
 $(DIR)/test_MSSM_npointfunctions.cpp : $(DIR)/test_MSSM_npointfunctions.meta $(DIR)/test_MSSM_npointfunctions.cpp.in $(META_SRC) $(METACODE_STAMP_MSSM)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)"$(MATH)" -run "AppendTo[\$$Path, \"./meta/\"]; Get[\"$<\"]; Quit[0];"
 $(DIR)/test_MSSM_npointfunctions.x: $(LIBMSSM)
 
@@ -1016,7 +1016,7 @@ $(TEST_EXE): $(LIBSOFTSUSY) $(MODtest_LIB) $(LIBTEST) $(LIBFLEXI) $(filter-out -
 
 # general test rule
 $(DIR)/test_%.x: $(DIR)/test_%.o
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(CXX) -o $@ $(call abspathx,$^) \
 		$(filter -%,$(LOOPFUNCLIBS)) $(BOOSTTESTLIBS) $(BOOSTTHREADLIBS) \
 		$(THREADLIBS) $(GSLLIBS) $(FLIBS) $(SQLITELIBS) $(TSILLIBS)
@@ -1026,11 +1026,11 @@ $(TEST_OBJ) $(TEST_DEP): CPPFLAGS += -Itest/SOFTSUSY $(MODtest_INC) $(BOOSTFLAGS
 
 ifeq ($(ENABLE_SHARED_LIBS),yes)
 $(LIBTEST): $(LIBTEST_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^ $(BOOSTTHREADLIBS) $(THREADLIBS) $(GSLLIBS) $(FLIBS)
 else
 $(LIBTEST): $(LIBTEST_OBJ)
-		@echo "Building $@"
+		@$(MSG)
 		$(Q)$(MODULE_MAKE_LIB_CMD) $@ $^
 endif
 


### PR DESCRIPTION
I propose to make the output of `make` less verbose. With this pull request `make` lists the compiled file(s), but (by default) omits the longish build command. This change improves the readability of the output of make and makes it for example easier to spot errors.

The verbose output can be re-enabled as in CMake by running

    make VERBOSE=1