### PR TITLE
make flexiblesusy::Error inherit from std::runtime_error

### DIFF
--- a/meta/LoopMasses.m
+++ b/meta/LoopMasses.m
@@ -824,7 +824,7 @@ try {
    if (pole_mass_loop_order > 2)
    " <> IndentText["self_energy_3l = self_energy_" <> CConversion`ToValidCSymbolString[particle] <> "_3loop();"] <> "
 } catch (const flexiblesusy::Error& e) {
-   WARNING(\"3-loop Higgs mass calculation failed: \" << e.what());
+   WARNING(\"3-loop Higgs mass calculation failed: \" << e.what_detailed());
    problems.flag_bad_mass(" <> FlexibleSUSY`FSModelName <> "_info::" <> CConversion`ToValidCSymbolString[particle] <> ");
 }
 "

--- a/meta/ThresholdCorrections.m
+++ b/meta/ThresholdCorrections.m
@@ -467,7 +467,7 @@ try {
 
    MODEL->get_problems().unflag_no_sinThetaW_convergence();
 } catch (const Error& e) {
-   VERBOSE_MSG(e.what());
+   VERBOSE_MSG(e.what_detailed());
    MODEL->get_problems().flag_no_sinThetaW_convergence();
 }"
           ];

--- a/model_specific/SM/standard_model.hpp
+++ b/model_specific/SM/standard_model.hpp
@@ -603,8 +603,8 @@ private:
 
    class EEWSBStepFailed : public Error {
    public:
+      EEWSBStepFailed() : Error("Could not perform EWSB step") {}
       virtual ~EEWSBStepFailed() = default;
-      virtual std::string what() const override { return "Could not perform EWSB step."; }
    };
 
    int ewsb_loop_order{4};

--- a/src/database.hpp
+++ b/src/database.hpp
@@ -45,20 +45,14 @@ private:
 
    class DisabledSQLiteError : Error {
    public:
-      explicit DisabledSQLiteError(const std::string& msg_) : msg(msg_) {}
+      explicit DisabledSQLiteError(const std::string& msg) : Error(msg) {}
       virtual ~DisabledSQLiteError() = default;
-      std::string what() const override { return msg; }
-   private:
-      std::string msg;
    };
 
    class SQLiteReadError : Error {
    public:
-      explicit SQLiteReadError(const std::string& msg_) : msg(msg_) {}
+      explicit SQLiteReadError(const std::string& msg) : Error(msg) {}
       virtual ~SQLiteReadError() = default;
-      std::string what() const override { return msg; }
-   private:
-      std::string msg;
    };
 
    sqlite3* db; ///< pointer to database object

--- a/src/error.hpp
+++ b/src/error.hpp
@@ -19,20 +19,24 @@
 #ifndef ERROR_H
 #define ERROR_H
 
+#include <cstring>
+#include <stdexcept>
 #include <string>
 
 namespace flexiblesusy {
 
-class Error {
+class Error : public std::runtime_error {
 public:
+   Error(const std::string& msg) : std::runtime_error(msg) {}
+   Error(const char* msg) : std::runtime_error(msg) {}
    virtual ~Error() = default;
-   virtual std::string what() const = 0;
+   virtual std::string what_detailed() const { return what(); }
 };
 
 class FatalError : public Error {
 public:
+   FatalError() : Error("Fatal error") {}
    virtual ~FatalError() = default;
-   virtual std::string what() const override { return "Fatal error."; };
 };
 
 /**
@@ -41,11 +45,8 @@ public:
  */
 class SetupError : public Error {
 public:
-   explicit SetupError(const std::string& message_) : message(message_) {}
+   explicit SetupError(const std::string& msg) : Error(msg) {}
    virtual ~SetupError() = default;
-   virtual std::string what() const override { return message; }
-private:
-   std::string message;
 };
 
 /**
@@ -55,18 +56,20 @@ private:
 class NoConvergenceError : public Error {
 public:
    explicit NoConvergenceError(int number_of_iterations_, const std::string& msg = "")
-      : message(msg), number_of_iterations(number_of_iterations_) {}
+      : Error(msg)
+      , number_of_iterations(number_of_iterations_) {}
    virtual ~NoConvergenceError() = default;
-   virtual std::string what() const override {
-      if (!message.empty())
-         return message;
+   std::string what_detailed() const override {
+      const auto msg = Error::what();
+
+      if (std::strlen(msg) > 0)
+         return msg;
 
       return "NoConvergenceError: no convergence after "
          + std::to_string(number_of_iterations) + " iterations";
    }
    int get_number_of_iterations() const { return number_of_iterations; }
 private:
-   std::string message;
    int number_of_iterations;
 };
 
@@ -78,11 +81,12 @@ class NoSinThetaWConvergenceError : public Error {
 public:
    NoSinThetaWConvergenceError(int number_of_iterations_,
                                double sin_theta_)
-      : number_of_iterations(number_of_iterations_)
+      : Error("Calculation of Weinberg angle did not converge")
+      , number_of_iterations(number_of_iterations_)
       , sin_theta(sin_theta_)
       {}
    virtual ~NoSinThetaWConvergenceError() = default;
-   virtual std::string what() const override {
+   std::string what_detailed() const override {
       return "NoSinThetaWConvergenceError: no convergence after "
          + std::to_string(number_of_iterations) + " iterations (sin(theta)="
          + std::to_string(sin_theta) + ")";
@@ -100,11 +104,9 @@ private:
  */
 class NonPerturbativeSinThetaW : public Error {
 public:
-   NonPerturbativeSinThetaW() {}
+   NonPerturbativeSinThetaW()
+      : Error("NonPerturbativeSinThetaW: sin(theta) non-perturbative") {}
    virtual ~NonPerturbativeSinThetaW() = default;
-   virtual std::string what() const override {
-      return "NonPerturbativeSinThetaW: sin(theta) non-perturbative";
-   }
 };
 
 /**
@@ -124,12 +126,13 @@ public:
     * something is wrong with the target renormalization scale.
     */
    explicit NonPerturbativeRunningError(double scale_, int parameter_index_ = -1, double value_ = 0)
-      : scale(scale_)
+      : Error("Non-perturbative RG running")
+      , scale(scale_)
       , value(value_)
       , parameter_index(parameter_index_)
       {}
    virtual ~NonPerturbativeRunningError() = default;
-   virtual std::string what() const override {
+   std::string what_detailed() const override {
       if (parameter_index == -1)
          return "NonPerturbativeRunningError: scale Q = " + std::to_string(value);
 
@@ -152,13 +155,9 @@ private:
 
 class NonPerturbativeRunningQedQcdError : public Error {
 public:
-   explicit NonPerturbativeRunningQedQcdError(const std::string& msg_)
-      : msg(msg_)
-      {}
+   explicit NonPerturbativeRunningQedQcdError(const std::string& msg)
+      : Error(msg) {}
    virtual ~NonPerturbativeRunningQedQcdError() = default;
-   virtual std::string what() const override { return msg; }
-private:
-   std::string msg;
 };
 
 /**
@@ -167,15 +166,12 @@ private:
  */
 class OutOfMemoryError : public Error {
 public:
-   explicit OutOfMemoryError(const std::string& msg_)
-      : msg(msg_)
-      {}
+   explicit OutOfMemoryError(const std::string& msg)
+      : Error(msg) {}
    virtual ~OutOfMemoryError() = default;
-   virtual std::string what() const override {
-      return std::string("OutOfMemoryError: Not enought memory: ") + msg;
+   virtual std::string what_detailed() const override {
+      return std::string("OutOfMemoryError: Not enought memory: ") + what();
    }
-private:
-   std::string msg;
 };
 
 /**
@@ -184,22 +180,16 @@ private:
  */
 class OutOfBoundsError : public Error {
 public:
-   OutOfBoundsError(const std::string& msg_)
-      : msg(msg_)
-      {}
+   OutOfBoundsError(const std::string& msg)
+      : Error(msg) {}
    virtual ~OutOfBoundsError() = default;
-   virtual std::string what() const override { return msg; }
-private:
-   std::string msg;
 };
 
 class ReadError : public Error {
 public:
-   explicit ReadError(const std::string& message_) : message(message_) {}
+   explicit ReadError(const std::string& msg)
+      : Error(msg) {}
    virtual ~ReadError() = default;
-   virtual std::string what() const override { return message; }
-private:
-   std::string message;
 };
 
 /**
@@ -208,20 +198,16 @@ private:
  */
 class PhysicalError : public Error {
 public:
-   explicit PhysicalError(const std::string& message_) : message(message_) {}
+   explicit PhysicalError(const std::string& msg)
+      : Error(msg) {}
    virtual ~PhysicalError() = default;
-   virtual std::string what() const override { return message; }
-private:
-   std::string message;
 };
 
 class HimalayaError : public Error {
 public:
-   explicit HimalayaError(const std::string& message_) : message(message_) {}
+   explicit HimalayaError(const std::string& msg)
+      : Error(msg) {}
    virtual ~HimalayaError() = default;
-   virtual std::string what() const override { return message; }
-private:
-   std::string message;
 };
 
 } // namespace flexiblesusy

--- a/src/lattice_solver.hpp
+++ b/src/lattice_solver.hpp
@@ -89,47 +89,36 @@ public:
 
     class MemoryError : public Error {
     public:
-	MemoryError(const std::string& message_) : message(message_) {}
+	MemoryError(const std::string& message_) : Error(message_) {}
 	virtual ~MemoryError() = default;
-	virtual std::string what() const { return message; }
-    private:
-	std::string message;
     };
 
     class SetupError : public Error {
     public:
-	SetupError(const std::string& message_) : message(message_) {}
+	SetupError(const std::string& message_) : Error(message_) {}
 	virtual ~SetupError() = default;
-	virtual std::string what() const { return message; }
-    private:
-	std::string message;
     };
 
     class NonInvertibleMatrixError : public Error {
     public:
 	NonInvertibleMatrixError(const std::string& message_) :
-	    message(message_) {}
+	    Error(message_) {}
 	virtual ~NonInvertibleMatrixError() = default;
-	virtual std::string what() const { return message; }
-    private:
-	std::string message;
     };
 
     class DivergenceError : public Error {
     public:
-	DivergenceError(const std::string& message_) : message(message_) {}
+	DivergenceError(const std::string& message_) : Error(message_) {}
 	virtual ~DivergenceError() = default;
-	virtual std::string what() const { return message; }
-    private:
-	std::string message;
     };
 
     class NoConvergenceError : public Error {
     public:
 	NoConvergenceError(size_t number_of_iterations_)
-	    : number_of_iterations(number_of_iterations_) {}
+	    : Error("RGFlow<Lattice>: no convergence")
+            , number_of_iterations(number_of_iterations_) {}
 	virtual ~NoConvergenceError() = default;
-	virtual std::string what() const {
+	std::string what_detailed() const override {
 	    std::stringstream message;
 	    message << "RGFlow<Lattice>::NoConvergenceError: no convergence"
 		    << " after " << number_of_iterations << " iterations";
@@ -142,11 +131,12 @@ public:
     class NonPerturbativeRunningError : public Error {
     public:
 	NonPerturbativeRunningError(Lattice_model* model_, double scale_)
-	    : model(model_)
+	    : Error("non-perturbative RG running")
+            , model(model_)
 	    , scale(scale_)
 	    {}
 	virtual ~NonPerturbativeRunningError() = default;
-	virtual std::string what() const;
+	std::string what_detailed() const override;
     private:
 	Lattice_model* model;
 	double scale;

--- a/src/rkf_integrator.hpp
+++ b/src/rkf_integrator.hpp
@@ -50,11 +50,8 @@ public:
 private:
    class DisabledOdeintError : Error {
    public:
-      explicit DisabledOdeintError(const std::string& msg_) : msg(msg_) {}
+      explicit DisabledOdeintError(const std::string& msg) : Error(msg) {}
       virtual ~DisabledOdeintError() = default;
-      virtual std::string what() const override { return msg; }
-   private:
-      std::string msg;
    };
 
    struct RKF_observer {

--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -314,7 +314,7 @@ std::pair<double,double> vary_scale(const @ModelName@_mass_eigenstates& model, c
                         amu = calculate_a_muon_impl(m, qedqcd);
                      }
                      catch(const Error& e) {
-                        ERROR("@ModelName@_a_muon: scale variation: " << e.what());
+                        ERROR("@ModelName@_a_muon: scale variation: " << e.what_detailed());
                      }
                      return amu;
                   });
@@ -341,7 +341,7 @@ double @ModelName@_a_muon::calculate_a_muon(const @ModelName@_mass_eigenstates& 
       run_to_MSUSY(model);
       model.get_physical().clear();
    } catch (const Error& e) {
-      ERROR("@ModelName@_a_muon:" << e.what());
+      ERROR("@ModelName@_a_muon:" << e.what_detailed());
       return std::numeric_limits<double>::quiet_NaN();
    }
 
@@ -365,7 +365,7 @@ double @ModelName@_a_muon::calculate_a_muon_uncertainty(const @ModelName@_mass_e
       run_to_MSUSY(model);
       model.get_physical().clear();
    } catch (const Error& e) {
-      ERROR("@ModelName@_a_muon uncertainty: " << e.what());
+      ERROR("@ModelName@_a_muon uncertainty: " << e.what_detailed());
       return std::numeric_limits<double>::quiet_NaN();
    }
 

--- a/templates/librarylink.cpp.in
+++ b/templates/librarylink.cpp.in
@@ -96,10 +96,10 @@ private:
 
 class EUnknownHandle : public Error {
 public:
-   explicit EUnknownHandle(Handle hid_) : hid(hid_) {}
+   explicit EUnknownHandle(Handle hid_) : Error("Unknown handle"), hid(hid_) {}
    virtual ~EUnknownHandle() = default;
-   virtual std::string what() const override {
-      return "Unknown handle: " + ToString(hid);
+   std::string what_detailed() const override {
+      return std::string(what()) + ": " + ToString(hid);
    }
    Handle hid;
 };
@@ -107,10 +107,11 @@ public:
 class ENotEnoughFreeHandles : public Error {
 public:
    explicit ENotEnoughFreeHandles(std::size_t max_handles_)
-      : max_handles(max_handles_) {}
+      : Error("Maximum number of open handles reached")
+      , max_handles(max_handles_) {}
    virtual ~ENotEnoughFreeHandles() = default;
-   virtual std::string what() const override {
-      return "Maximum number of open handles reached: "
+   std::string what_detailed() const override {
+      return std::string(what()) + ": "
          + ToString(max_handles) + ".  Please close some handles!";
    }
    std::size_t max_handles;
@@ -119,10 +120,11 @@ public:
 class EWrongNumberOfParameters : public Error {
 public:
    EWrongNumberOfParameters(mint pars_, mint expected_)
-      : pars(pars_), expected(expected_) {}
+      : Error("Wrong number of arguments")
+      , pars(pars_), expected(expected_) {}
    virtual ~EWrongNumberOfParameters() = default;
-   virtual std::string what() const override {
-      return "Wrong number of arguments: " + ToString(pars)
+   std::string what_detailed() const override {
+      return std::string(what()) + ": " + ToString(pars)
          + ".  Expected: " + ToString(expected);
    }
    mint pars, expected;
@@ -130,9 +132,8 @@ public:
 
 class EInvalidSpectrum : public Error {
 public:
-   EInvalidSpectrum() {}
+   EInvalidSpectrum() : Error("Invalid spectrum") {}
    virtual ~EInvalidSpectrum() = default;
-   virtual std::string what() const override { return "Invalid spectrum"; }
 };
 
 class @ModelName@_spectrum {
@@ -1018,7 +1019,7 @@ DLLEXPORT int FS@ModelName@GetSettings(WolframLibraryData /* libData */, MLINK l
    try {
       find_data(hid).put_settings(link);
    } catch (const flexiblesusy::Error& e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what_detailed() << std::endl;
       put_error_output(link);
    }
 
@@ -1039,7 +1040,7 @@ DLLEXPORT int FS@ModelName@GetSMInputParameters(WolframLibraryData /* libData */
    try {
       find_data(hid).put_sm_input_parameters(link);
    } catch (const flexiblesusy::Error& e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what_detailed() << std::endl;
       put_error_output(link);
    }
 
@@ -1060,7 +1061,7 @@ DLLEXPORT int FS@ModelName@GetInputParameters(WolframLibraryData /* libData */, 
    try {
       find_data(hid).put_input_parameters(link);
    } catch (const flexiblesusy::Error& e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what_detailed() << std::endl;
       put_error_output(link);
    }
 
@@ -1095,7 +1096,7 @@ DLLEXPORT int FS@ModelName@OpenHandle(
 
       MArgument_setInteger(Res, hid);
    } catch (const flexiblesusy::Error& e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what_detailed() << std::endl;
       return LIBRARY_FUNCTION_ERROR;
    }
 
@@ -1145,7 +1146,7 @@ DLLEXPORT int FS@ModelName@Set(
                       libData->MTensor_getRealData(pars),
                       libData->MTensor_getDimensions(pars)[0]));
    } catch (const flexiblesusy::Error& e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what_detailed() << std::endl;
       return LIBRARY_FUNCTION_ERROR;
    }
 
@@ -1167,7 +1168,7 @@ DLLEXPORT int FS@ModelName@GetProblems(
    try {
       find_data(hid).put_problems(link);
    } catch (const flexiblesusy::Error& e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what_detailed() << std::endl;
       put_error_output(link);
    }
 
@@ -1188,7 +1189,7 @@ DLLEXPORT int FS@ModelName@ToSLHA(WolframLibraryData /* libData */, MLINK link)
    try {
       find_data(hid).put_slha(link);
    } catch (const flexiblesusy::Error& e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what_detailed() << std::endl;
       put_error_output(link);
    }
 
@@ -1210,7 +1211,7 @@ DLLEXPORT int FS@ModelName@GetWarnings(
    try {
       find_data(hid).put_warnings(link);
    } catch (const flexiblesusy::Error& e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what_detailed() << std::endl;
       put_error_output(link);
    }
 
@@ -1275,7 +1276,7 @@ DLLEXPORT int FS@ModelName@CalculateObservables(
 
       data.put_observables(link);
    } catch (const flexiblesusy::Error& e) {
-      put_message(link, "FS@ModelName@CalculateObservables", "error", e.what());
+      put_message(link, "FS@ModelName@CalculateObservables", "error", e.what_detailed());
       put_error_output(link);
    }
 

--- a/templates/observables.cpp.in
+++ b/templates/observables.cpp.in
@@ -101,7 +101,7 @@ void @ModelName@_observables::set(const Eigen::ArrayXd& vec)
       try {
          model_at_scale.run_to(scale);
       } catch (const Error& e) {
-         model.get_problems().flag_thrown(e.what());
+         model.get_problems().flag_thrown(e.what_detailed());
          return @ModelName@_observables();
       }
    }
@@ -118,7 +118,7 @@ void @ModelName@_observables::set(const Eigen::ArrayXd& vec)
    try {
 @calculateObservables@
    } catch (const Error& e) {
-      model.get_problems().flag_thrown(e.what());
+      model.get_problems().flag_thrown(e.what_detailed());
    }
 
    return observables;

--- a/templates/run.cpp.in
+++ b/templates/run.cpp.in
@@ -65,7 +65,7 @@ int run_solver(flexiblesusy::@ModelName@_slha_io& slha_io,
       slha_io.fill(input);
       slha_io.fill(physical_input);
    } catch (const Error& error) {
-      ERROR(error.what());
+      ERROR(error.what_detailed());
       return EXIT_FAILURE;
    }
 
@@ -192,7 +192,7 @@ int main(int argc, char* argv[])
       slha_io.read_from_source(slha_input_source);
       slha_io.fill(spectrum_generator_settings);
    } catch (const Error& error) {
-      ERROR(error.what());
+      ERROR(error.what_detailed());
       return EXIT_FAILURE;
    }
 

--- a/templates/semi_analytic_ewsb_solver.hpp.in
+++ b/templates/semi_analytic_ewsb_solver.hpp.in
@@ -71,8 +71,8 @@ private:
 
    class EEWSBStepFailed : public Error {
    public:
+      EEWSBStepFailed() : Error("Could not perform EWSB step") {}
       virtual ~EEWSBStepFailed() {}
-      virtual std::string what() const { return "Could not perform EWSB step."; }
    };
 
    int number_of_iterations{100}; ///< maximum number of iterations

--- a/templates/spectrum_generator_interface.hpp.in
+++ b/templates/spectrum_generator_interface.hpp.in
@@ -139,7 +139,7 @@ void @ModelName@_spectrum_generator_interface<T>::write_running_couplings(
       tmp_model.run_to(start);
    } catch (const Error& error) {
       ERROR("write_running_couplings: running to scale "
-            << start << " failed: " << error.what());
+            << start << " failed: " << error.what_detailed());
       return;
    }
 
@@ -186,11 +186,11 @@ void @ModelName@_spectrum_generator_interface<T>::translate_exception_to_problem
          error.get_scale());
    } catch (const NonPerturbativeRunningQedQcdError& error) {
       model.get_problems().flag_no_perturbative();
-      model.get_problems().flag_thrown(error.what());
+      model.get_problems().flag_thrown(error.what_detailed());
    } catch (const NoSinThetaWConvergenceError&) {
       model.get_problems().flag_no_sinThetaW_convergence();
    } catch (const Error& error) {
-      model.get_problems().flag_thrown(error.what());
+      model.get_problems().flag_thrown(error.what_detailed());
    } catch (const std::exception& error) {
       model.get_problems().flag_thrown(error.what());
    }

--- a/templates/standard_model_spectrum_generator_interface.hpp.in
+++ b/templates/standard_model_spectrum_generator_interface.hpp.in
@@ -150,7 +150,7 @@ void @ModelName@_spectrum_generator_interface<T>::write_running_couplings(
       tmp_model.run_to(start);
    } catch (const Error& error) {
       ERROR("write_running_couplings: running to scale "
-            << start << " failed: " << error.what());
+            << start << " failed: " << error.what_detailed());
       return;
    }
 
@@ -198,15 +198,15 @@ void @ModelName@_spectrum_generator_interface<T>::translate_exception_to_problem
          error.get_scale());
    } catch (const NonPerturbativeRunningQedQcdError& error) {
       model.get_problems().flag_no_perturbative();
-      model.get_problems().flag_thrown(error.what());
+      model.get_problems().flag_thrown(error.what_detailed());
       eft.get_problems().flag_no_perturbative();
-      eft.get_problems().flag_thrown(error.what());
+      eft.get_problems().flag_thrown(error.what_detailed());
    } catch (const NoSinThetaWConvergenceError&) {
       model.get_problems().flag_no_sinThetaW_convergence();
       eft.get_problems().flag_no_sinThetaW_convergence();
    } catch (const Error& error) {
-      model.get_problems().flag_thrown(error.what());
-      eft.get_problems().flag_thrown(error.what());
+      model.get_problems().flag_thrown(error.what_detailed());
+      eft.get_problems().flag_thrown(error.what_detailed());
    } catch (const std::exception& error) {
       model.get_problems().flag_thrown(error.what());
       eft.get_problems().flag_thrown(error.what());

--- a/templates/two_scale_ewsb_solver.hpp.in
+++ b/templates/two_scale_ewsb_solver.hpp.in
@@ -68,8 +68,8 @@ private:
 
    class EEWSBStepFailed : public Error {
    public:
-      virtual ~EEWSBStepFailed() {}
-      virtual std::string what() const { return "Could not perform EWSB step."; }
+      EEWSBStepFailed() : Error("Could not perform EWSB step") {}
+      virtual ~EEWSBStepFailed() = default;
    };
 
    int number_of_iterations{100}; ///< maximum number of iterations

--- a/templates/utilities.cpp.in
+++ b/templates/utilities.cpp.in
@@ -230,7 +230,7 @@ void to_database(
       database::Database db(file_name);
       db.insert("Point", names, values);
    } catch(const flexiblesusy::Error& e) {
-      ERROR(e.what());
+      ERROR(e.what_detailed());
    }
 }
 
@@ -243,7 +243,7 @@ Eigen::ArrayXd extract_entry(const std::string& file_name, long long entry)
    try {
       values = db.extract("Point", entry);
    } catch (const flexiblesusy::Error& e) {
-      ERROR(e.what());
+      ERROR(e.what_detailed());
    }
 
    return values;

--- a/test/SOFTSUSY/diagonalization.hpp
+++ b/test/SOFTSUSY/diagonalization.hpp
@@ -29,11 +29,8 @@ namespace flexiblesusy {
  */
 class DiagonalizationError : public Error {
 public:
-   explicit DiagonalizationError(const std::string& message_) : message(message_) {}
+   explicit DiagonalizationError(const std::string& msg) : Error(msg) {}
    virtual ~DiagonalizationError() {}
-   virtual std::string what() const { return message; }
-private:
-   std::string message;
 };
 
 softsusy::DoubleVector AbsSqrt(const softsusy::DoubleVector&);

--- a/test/SOFTSUSY/numerics_legacy.cpp
+++ b/test/SOFTSUSY/numerics_legacy.cpp
@@ -16,15 +16,9 @@ namespace flexiblesusy {
 
 class SoftsusyNumericsError : public Error {
 public:
-   explicit SoftsusyNumericsError(std::string msg_)
-      : msg(msg_)
-      {}
+   explicit SoftsusyNumericsError(std::string msg)
+      : Error(msg) {}
    virtual ~SoftsusyNumericsError() {}
-   virtual std::string what() const {
-      return msg;
-   }
-private:
-   std::string msg;
 };
 
 } // namespace flexiblesusy

--- a/test/module.mk
+++ b/test/module.mk
@@ -31,6 +31,7 @@ TEST_SRC := \
 		$(DIR)/test_effective_couplings.cpp \
 		$(DIR)/test_eigen_utils.cpp \
 		$(DIR)/test_ewsb_solver.cpp \
+		$(DIR)/test_error.cpp \
 		$(DIR)/test_fixed_point_iterator.cpp \
 		$(DIR)/test_goldstones.cpp \
 		$(DIR)/test_gsl_vector.cpp \

--- a/test/test_CMSSMMassWInput_spectrum.cpp
+++ b/test/test_CMSSMMassWInput_spectrum.cpp
@@ -486,12 +486,9 @@ void CMSSMMassWInput_softsusy_ewsb_susy_scale_constraint::apply()
 
 class SoftSusy_error : public Error {
 public:
-   SoftSusy_error(const std::string& msg_)
-      : msg(msg_) {}
+   SoftSusy_error(const std::string& msg)
+      : Error(msg) {}
    virtual ~SoftSusy_error() {}
-   virtual std::string what() const { return msg; }
-private:
-   std::string msg;
 };
 
 class SoftSusy_NoConvergence_error : public SoftSusy_error {
@@ -499,7 +496,6 @@ public:
    SoftSusy_NoConvergence_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NoConvergence_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_NonPerturbative_error : public SoftSusy_error {
@@ -507,7 +503,6 @@ public:
    SoftSusy_NonPerturbative_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NonPerturbative_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_tester {

--- a/test/test_CMSSM_spectrum.cpp
+++ b/test/test_CMSSM_spectrum.cpp
@@ -49,12 +49,9 @@ using namespace weinberg_angle;
 
 class SoftSusy_error : public Error {
 public:
-   SoftSusy_error(const std::string& msg_)
-      : msg(msg_) {}
+   SoftSusy_error(const std::string& msg)
+      : Error(msg) {}
    virtual ~SoftSusy_error() {}
-   virtual std::string what() const { return msg; }
-private:
-   std::string msg;
 };
 
 class SoftSusy_NoConvergence_error : public SoftSusy_error {
@@ -62,7 +59,6 @@ public:
    SoftSusy_NoConvergence_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NoConvergence_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_NonPerturbative_error : public SoftSusy_error {
@@ -70,7 +66,6 @@ public:
    SoftSusy_NonPerturbative_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NonPerturbative_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_tester {

--- a/test/test_NMSSM_spectrum.cpp
+++ b/test/test_NMSSM_spectrum.cpp
@@ -43,12 +43,9 @@ softsusy::QedQcd convert(const softsusy::QedQcd_legacy& ql)
 
 class SoftSusy_error : public Error {
 public:
-   SoftSusy_error(const std::string& msg_)
-      : msg(msg_) {}
+   SoftSusy_error(const std::string& msg)
+      : Error(msg) {}
    virtual ~SoftSusy_error() {}
-   virtual std::string what() const { return msg; }
-private:
-   std::string msg;
 };
 
 class SoftSusy_NoConvergence_error : public SoftSusy_error {
@@ -56,7 +53,6 @@ public:
    SoftSusy_NoConvergence_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NoConvergence_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_NonPerturbative_error : public SoftSusy_error {
@@ -64,7 +60,6 @@ public:
    SoftSusy_NonPerturbative_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NonPerturbative_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_tester {

--- a/test/test_NUTNMSSM_spectrum.cpp
+++ b/test/test_NUTNMSSM_spectrum.cpp
@@ -43,12 +43,9 @@ softsusy::QedQcd convert(const softsusy::QedQcd_legacy& ql)
 
 class SoftSusy_error : public Error {
 public:
-   SoftSusy_error(const std::string& msg_)
-      : msg(msg_) {}
+   SoftSusy_error(const std::string& msg)
+      : Error(msg) {}
    virtual ~SoftSusy_error() {}
-   virtual std::string what() const { return msg; }
-private:
-   std::string msg;
 };
 
 class SoftSusy_NoConvergence_error : public SoftSusy_error {
@@ -56,7 +53,6 @@ public:
    SoftSusy_NoConvergence_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NoConvergence_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_NonPerturbative_error : public SoftSusy_error {
@@ -64,7 +60,6 @@ public:
    SoftSusy_NonPerturbative_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NonPerturbative_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_tester {

--- a/test/test_error.cpp
+++ b/test/test_error.cpp
@@ -1,0 +1,40 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE test_error
+
+#include <boost/test/unit_test.hpp>
+#include <type_traits>
+#include "error.hpp"
+
+#define THROW(Exception_t,...)                  \
+   do {                                         \
+      throw Exception_t(__VA_ARGS__);           \
+   } while (false)
+
+BOOST_AUTO_TEST_CASE( test_catch_by_std_exception )
+{
+   using namespace flexiblesusy;
+
+   using ET = std::exception;
+
+   BOOST_REQUIRE_THROW(THROW(FatalError)    , ET);
+   BOOST_REQUIRE_THROW(THROW(SetupError, ""), ET);
+   BOOST_REQUIRE_THROW(THROW(NoConvergenceError, 1, ""), ET);
+   BOOST_REQUIRE_THROW(THROW(NoSinThetaWConvergenceError, 1, 0.2), ET);
+   BOOST_REQUIRE_THROW(THROW(NonPerturbativeSinThetaW), ET);
+   BOOST_REQUIRE_THROW(THROW(NonPerturbativeRunningError, 0.), ET);
+   BOOST_REQUIRE_THROW(THROW(NonPerturbativeRunningQedQcdError, ""), ET);
+   BOOST_REQUIRE_THROW(THROW(OutOfMemoryError, ""), ET);
+   BOOST_REQUIRE_THROW(THROW(OutOfBoundsError, ""), ET);
+   BOOST_REQUIRE_THROW(THROW(ReadError, ""), ET);
+   BOOST_REQUIRE_THROW(THROW(PhysicalError, ""), ET);
+   BOOST_REQUIRE_THROW(THROW(HimalayaError, ""), ET);
+}
+
+/*
+BOOST_AUTO_TEST_CASE( test_is_nothrow_constructible )
+{
+   using namespace flexiblesusy;
+
+   BOOST_CHECK(std::is_nothrow_constructible<FatalError>::value);
+}
+*/

--- a/test/test_two_scale_mssm_solver.cpp
+++ b/test/test_two_scale_mssm_solver.cpp
@@ -115,12 +115,9 @@ void test_equality(const sPhysical& a, const sPhysical& b, double tolerance)
 
 class SoftSusy_error : public Error {
 public:
-   SoftSusy_error(const std::string& msg_)
-      : msg(msg_) {}
+   SoftSusy_error(const std::string& msg)
+      : Error(msg) {}
    virtual ~SoftSusy_error() {}
-   virtual std::string what() const { return msg; }
-private:
-   std::string msg;
 };
 
 class SoftSusy_NoConvergence_error : public SoftSusy_error {
@@ -128,7 +125,6 @@ public:
    SoftSusy_NoConvergence_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NoConvergence_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_NonPerturbative_error : public SoftSusy_error {
@@ -136,7 +132,6 @@ public:
    SoftSusy_NonPerturbative_error(const std::string& msg_)
       : SoftSusy_error(msg_) {}
    virtual ~SoftSusy_NonPerturbative_error() {}
-   virtual std::string what() const { return SoftSusy_error::what(); }
 };
 
 class SoftSusy_tester {


### PR DESCRIPTION
and make the exception classes trivially (nothrow) constructible as strongly proposed by the STL and https://www.boost.org/community/error_handling.html .