### PR TITLE
Cheaper test/test_linalg2.cpp

### DIFF
--- a/test/module.mk
+++ b/test/module.mk
@@ -35,7 +35,6 @@ TEST_SRC := \
 		$(DIR)/test_fixed_point_iterator.cpp \
 		$(DIR)/test_goldstones.cpp \
 		$(DIR)/test_gsl_vector.cpp \
-		$(DIR)/test_linalg2.cpp \
 		$(DIR)/test_minimizer.cpp \
 		$(DIR)/test_namespace_collisions.cpp \
 		$(DIR)/test_mssm_twoloop_mb.cpp \
@@ -648,6 +647,15 @@ endif
 
 TEST_OBJ := \
 		$(patsubst %.cpp, %.o, $(filter %.cpp, $(TEST_SRC)))
+
+TEST_OBJ +=	$(foreach i, 1 2 3 4 5 6 7 8, $(DIR)/test_linalg2_part$(i).o)
+
+$(DIR)/test_linalg2_part%.d: $(DIR)/test_linalg2.cpp | $(DEPGEN)
+	$(Q)$(DEPGEN) $(CPPFLAGS) -DTEST_LINALG2_PART$* -MM -MI -o '$@' -MT '$*.o' $^
+
+$(DIR)/test_linalg2_part%.o: $(DIR)/test_linalg2.cpp
+	@$(MSG)
+	$(Q)$(CXX) $(CPPFLAGS) -DTEST_LINALG2_PART$* $(CXXFLAGS) -c $< -o $@
 
 TEST_DEP := \
 		$(TEST_OBJ:.o=.d)

--- a/test/module.mk
+++ b/test/module.mk
@@ -657,6 +657,9 @@ $(DIR)/test_linalg2_part%.o: $(DIR)/test_linalg2.cpp
 	@$(MSG)
 	$(Q)$(CXX) $(CPPFLAGS) -DTEST_LINALG2_PART$* $(CXXFLAGS) -c $< -o $@
 
+$(foreach i, 2 3 4 5 6 7 8, $(eval \
+$(DIR)/test_linalg2_part$(i).o: | $(DIR)/test_linalg2_part$(shell echo $$(($(i)-1))).o))
+
 TEST_DEP := \
 		$(TEST_OBJ:.o=.d)
 

--- a/test/test_linalg2.cpp
+++ b/test/test_linalg2.cpp
@@ -16,9 +16,6 @@
 // <http://www.gnu.org/licenses/>.
 // ====================================================================
 
-#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
-#define BOOST_MPL_LIMIT_LIST_SIZE 30
-
 #include <limits>
 #include <cmath>
 #include <complex>
@@ -72,25 +69,21 @@ typedef boost::mpl::list<
     Test_svd<complex<double>, 1, 1, svd, svd>,
     Test_svd<complex<double>, 2, 2, svd, svd>,
     Test_svd<complex<double>, 3, 3, svd, svd>,
-    Test_svd<complex<double>, 4, 4, svd, svd>,
     Test_svd<complex<double>, 6, 6, svd, svd>,
     Test_svd<double	    , 1, 1, svd, svd>,
     Test_svd<double	    , 2, 2, svd, svd>,
     Test_svd<double	    , 3, 3, svd, svd>,
-    Test_svd<double	    , 4, 4, svd, svd>,
     Test_svd<double	    , 6, 6, svd, svd>,
 
     Test_svd<complex<double>, 1, 1, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 2, 2, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 3, 3, reorder_svd, reorder_svd, true>,
-    Test_svd<complex<double>, 4, 4, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 6, 6, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 4, 6, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 6, 4, reorder_svd, reorder_svd, true>,
     Test_svd<double	    , 1, 1, reorder_svd, reorder_svd, true>,
     Test_svd<double	    , 2, 2, reorder_svd, reorder_svd, true>,
     Test_svd<double	    , 3, 3, reorder_svd, reorder_svd, true>,
-    Test_svd<double	    , 4, 4, reorder_svd, reorder_svd, true>,
     Test_svd<double	    , 6, 6, reorder_svd, reorder_svd, true>,
     Test_svd<double	    , 4, 6, reorder_svd, reorder_svd, true>,
     Test_svd<double	    , 6, 4, reorder_svd, reorder_svd, true>
@@ -263,16 +256,12 @@ struct Test_fs {
 
 typedef boost::mpl::list<
     Test_fs<double, complex<double>, 1>,
-    Test_fs<double, complex<double>, 2>,
     Test_fs<double, complex<double>, 3>,
-    Test_fs<double, complex<double>, 4>,
     Test_fs<double, complex<double>, 6>,
     Test_fs<double, complex<double>, 4, 6>,
     Test_fs<double, complex<double>, 6, 4>,
     Test_fs<double, double	   , 1>,
-    Test_fs<double, double	   , 2>,
     Test_fs<double, double	   , 3>,
-    Test_fs<double, double	   , 4>,
     Test_fs<double, double	   , 6>,
     Test_fs<double, double	   , 4, 6>,
     Test_fs<double, double	   , 6, 4>,

--- a/test/test_linalg2.cpp
+++ b/test/test_linalg2.cpp
@@ -263,23 +263,19 @@ struct Test_fs {
 #ifdef TEST_LINALG2_PART4
 typedef boost::mpl::list<
     Test_fs<double, complex<double>, 1>,
-    Test_fs<double, complex<double>, 3>,
     Test_fs<double, complex<double>, 6>,
     Test_fs<double, complex<double>, 4, 6>,
     Test_fs<double, complex<double>, 6, 4>,
     Test_fs<double, double	   , 1>,
-    Test_fs<double, double	   , 3>,
     Test_fs<double, double	   , 6>,
     Test_fs<double, double	   , 4, 6>,
     Test_fs<double, double	   , 6, 4>,
 
     Test_fs<long double, complex<long double>, 1>,
-    Test_fs<long double, complex<long double>, 3>,
     Test_fs<long double, complex<long double>, 6>,
     Test_fs<long double, complex<long double>, 4, 6>,
     Test_fs<long double, complex<long double>, 6, 4>,
     Test_fs<long double, long double	     , 1>,
-    Test_fs<long double, long double	     , 3>,
     Test_fs<long double, long double	     , 6>,
     Test_fs<long double, long double	     , 4, 6>,
     Test_fs<long double, long double	     , 6, 4>
@@ -320,15 +316,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_fs_svd, T, fs_svd_tests)
 #ifdef TEST_LINALG2_PART5
 typedef boost::mpl::list<
     Test_fs<double, double, 1>,
-    Test_fs<double, double, 2>,
-    Test_fs<double, double, 3>,
-    Test_fs<double, double, 4>,
     Test_fs<double, double, 6>,
     Test_fs<double, double, 4, 6>,
     Test_fs<double, double, 6, 4>,
 
     Test_fs<long double, long double, 1>,
-    Test_fs<long double, long double, 3>,
     Test_fs<long double, long double, 6>,
     Test_fs<long double, long double, 4, 6>,
     Test_fs<long double, long double, 6, 4>
@@ -369,15 +361,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_casting_fs_svd, T, casting_fs_svd_tests)
 typedef boost::mpl::list<
     // use Eigen::JacobiSVD
     Test_fs<double, complex<double>, 1>,
-    Test_fs<double, complex<double>, 2>,
     Test_fs<double, complex<double>, 3>,
-    Test_fs<double, complex<double>, 4>,
     Test_fs<double, complex<double>, 6>,
 
     Test_fs<long double, complex<long double>, 1>,
-    Test_fs<long double, complex<long double>, 2>,
     Test_fs<long double, complex<long double>, 3>,
-    Test_fs<long double, complex<long double>, 4>,
     Test_fs<long double, complex<long double>, 6>,
 
     // use Eigen::SelfAdjointEigenSolver

--- a/test/test_linalg2.cpp
+++ b/test/test_linalg2.cpp
@@ -72,30 +72,24 @@ typedef boost::mpl::list<
     Test_svd<complex<double>, 1, 1, svd, svd>,
     Test_svd<complex<double>, 2, 2, svd, svd>,
     Test_svd<complex<double>, 3, 3, svd, svd>,
+    Test_svd<complex<double>, 4, 4, svd, svd>,
+    Test_svd<complex<double>, 6, 6, svd, svd>,
     Test_svd<double	    , 1, 1, svd, svd>,
     Test_svd<double	    , 2, 2, svd, svd>,
     Test_svd<double	    , 3, 3, svd, svd>,
+    Test_svd<double	    , 4, 4, svd, svd>,
+    Test_svd<double	    , 6, 6, svd, svd>,
 
     Test_svd<complex<double>, 1, 1, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 2, 2, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 3, 3, reorder_svd, reorder_svd, true>,
-    Test_svd<double	    , 1, 1, reorder_svd, reorder_svd, true>,
-    Test_svd<double	    , 2, 2, reorder_svd, reorder_svd, true>,
-    Test_svd<double	    , 3, 3, reorder_svd, reorder_svd, true>,
-
-    // use ZGESVD of LAPACK
-    Test_svd<complex<double>, 4, 4, svd, svd>,
-    Test_svd<complex<double>, 6, 6, svd, svd>,
-
     Test_svd<complex<double>, 4, 4, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 6, 6, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 4, 6, reorder_svd, reorder_svd, true>,
     Test_svd<complex<double>, 6, 4, reorder_svd, reorder_svd, true>,
-
-    // use DGESVD of LAPACK
-    Test_svd<double	    , 4, 4, svd, svd>,
-    Test_svd<double	    , 6, 6, svd, svd>,
-
+    Test_svd<double	    , 1, 1, reorder_svd, reorder_svd, true>,
+    Test_svd<double	    , 2, 2, reorder_svd, reorder_svd, true>,
+    Test_svd<double	    , 3, 3, reorder_svd, reorder_svd, true>,
     Test_svd<double	    , 4, 4, reorder_svd, reorder_svd, true>,
     Test_svd<double	    , 6, 6, reorder_svd, reorder_svd, true>,
     Test_svd<double	    , 4, 6, reorder_svd, reorder_svd, true>,
@@ -158,6 +152,10 @@ typedef boost::mpl::list<
 	<complex<double>, 2, diagonalize_symmetric, diagonalize_symmetric>,
     Test_diagonalize_symmetric
 	<complex<double>, 3, diagonalize_symmetric, diagonalize_symmetric>,
+    Test_diagonalize_symmetric
+	<complex<double>, 4, diagonalize_symmetric, diagonalize_symmetric>,
+    Test_diagonalize_symmetric
+	<complex<double>, 6, diagonalize_symmetric, diagonalize_symmetric>,
 
     Test_diagonalize_symmetric
 	<complex<double>, 1,
@@ -168,6 +166,12 @@ typedef boost::mpl::list<
     Test_diagonalize_symmetric
 	<complex<double>, 3,
 	 reorder_diagonalize_symmetric, reorder_diagonalize_symmetric, true>,
+    Test_diagonalize_symmetric
+	<complex<double>, 4,
+	 reorder_diagonalize_symmetric, reorder_diagonalize_symmetric, true>,
+    Test_diagonalize_symmetric
+	<complex<double>, 6,
+	 reorder_diagonalize_symmetric, reorder_diagonalize_symmetric, true>,
 
     // use Eigen::SelfAdjointEigenSolver
     Test_diagonalize_symmetric
@@ -175,18 +179,7 @@ typedef boost::mpl::list<
 
     Test_diagonalize_symmetric
 	<double, 6,
-	 reorder_diagonalize_symmetric, reorder_diagonalize_symmetric, true>,
-
-    // use ZGESVD of LAPACK
-    Test_diagonalize_symmetric
-	<complex<double>, 4, diagonalize_symmetric, diagonalize_symmetric>,
-    Test_diagonalize_symmetric
-	<complex<double>, 6, diagonalize_symmetric, diagonalize_symmetric>,
-
-    Test_diagonalize_symmetric<complex<double>, 4,
-	reorder_diagonalize_symmetric, reorder_diagonalize_symmetric, true>,
-    Test_diagonalize_symmetric<complex<double>, 6,
-	reorder_diagonalize_symmetric, reorder_diagonalize_symmetric, true>
+	 reorder_diagonalize_symmetric, reorder_diagonalize_symmetric, true>
 > diagonalize_symmetric_tests;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE
@@ -236,14 +229,6 @@ typedef boost::mpl::list<
     // use Eigen::SelfAdjointEigenSolver
     Test_diagonalize_hermitian<complex<double>, 6, hermitian_eigen>,
     Test_diagonalize_hermitian<double	      , 6, hermitian_eigen>
-
-#ifdef ENABLE_LAPACK
-    ,
-    // use ZHEEV of LAPACK
-    Test_diagonalize_hermitian<complex<double>, 6, hermitian_lapack>,
-    // use DSYEV of LAPACK
-    Test_diagonalize_hermitian<double	      , 6, hermitian_lapack>
-#endif
 > diagonalize_hermitian_tests;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE
@@ -386,16 +371,14 @@ typedef boost::mpl::list<
     Test_fs<double, complex<double>, 1>,
     Test_fs<double, complex<double>, 2>,
     Test_fs<double, complex<double>, 3>,
+    Test_fs<double, complex<double>, 4>,
+    Test_fs<double, complex<double>, 6>,
 
     Test_fs<long double, complex<long double>, 1>,
     Test_fs<long double, complex<long double>, 2>,
     Test_fs<long double, complex<long double>, 3>,
     Test_fs<long double, complex<long double>, 4>,
     Test_fs<long double, complex<long double>, 6>,
-
-    // use ZGESVD of LAPACK
-    Test_fs<double, complex<double>, 4>,
-    Test_fs<double, complex<double>, 6>,
 
     // use Eigen::SelfAdjointEigenSolver
     Test_fs<double, double, 6>,

--- a/test/test_linalg2.cpp
+++ b/test/test_linalg2.cpp
@@ -64,6 +64,7 @@ struct Test_svd {
     { svs_(m, s); }
 };
 
+#ifdef TEST_LINALG2_PART1
 typedef boost::mpl::list<
     // use Eigen::JacobiSVD
     Test_svd<complex<double>, 1, 1, svd, svd>,
@@ -118,6 +119,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_svd, T, svd_tests)
 	for (size_t j = 0; j < sigma.cols(); j++)
 	    BOOST_CHECK_SMALL(abs(sigma(i,j) - (i==j ? s(i) : 0)), 1e-13);
 }
+#endif // TEST_LINALG2_PART1
 
 template<class S_, int N_,
 	 void fxn_(const Matrix<S_, N_, N_>&,
@@ -137,6 +139,7 @@ struct Test_diagonalize_symmetric {
     { svs_(m, s); }
 };
 
+#ifdef TEST_LINALG2_PART2
 typedef boost::mpl::list<
     // use Eigen::JacobiSVD
     Test_diagonalize_symmetric
@@ -204,6 +207,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE
 	for (size_t j = 0; j < N; j++)
 	    BOOST_CHECK_SMALL(abs(diag(i,j) - (i==j ? s(i) : 0)), 1e-12);
 }
+#endif // TEST_LINALG2_PART2
 
 template<class S_, int N_,
 	 void fxn_(const Matrix<S_, N_, N_>&,
@@ -218,6 +222,7 @@ struct Test_diagonalize_hermitian {
     { fxn_(m, w, z); }
 };
 
+#ifdef TEST_LINALG2_PART3
 typedef boost::mpl::list<
     // use Eigen::SelfAdjointEigenSolver
     Test_diagonalize_hermitian<complex<double>, 6, hermitian_eigen>,
@@ -245,6 +250,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE
     for (size_t i = 0; i < N-1; i++)
 	BOOST_CHECK(w[i] <= w[i+1]);
 }
+#endif // TEST_LINALG2_PART3
 
 template<class R_, class S_, int M_, int N_ = M_>
 struct Test_fs {
@@ -254,6 +260,7 @@ struct Test_fs {
     enum { N = N_ };
 };
 
+#ifdef TEST_LINALG2_PART4
 typedef boost::mpl::list<
     Test_fs<double, complex<double>, 1>,
     Test_fs<double, complex<double>, 3>,
@@ -308,7 +315,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_fs_svd, T, fs_svd_tests)
 	for (size_t j = 0; j < sigma.cols(); j++)
 	    BOOST_CHECK_SMALL(abs(sigma(i,j) - (i==j ? s(i) : 0)), 50*eps);
 }
+#endif // TEST_LINALG2_PART4
 
+#ifdef TEST_LINALG2_PART5
 typedef boost::mpl::list<
     Test_fs<double, double, 1>,
     Test_fs<double, double, 2>,
@@ -354,7 +363,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_casting_fs_svd, T, casting_fs_svd_tests)
 	for (size_t j = 0; j < sigma.cols(); j++)
 	    BOOST_CHECK_SMALL(abs(sigma(i,j) - (i==j ? s(i) : 0)), 50*eps);
 }
+#endif // TEST_LINALG2_PART5
 
+#ifdef TEST_LINALG2_PART6
 typedef boost::mpl::list<
     // use Eigen::JacobiSVD
     Test_fs<double, complex<double>, 1>,
@@ -485,7 +496,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE
     m = u.transpose() * s.matrix().asDiagonal() * u;
     check_fs_diagonalize_symmetric<R, S, N>(m);
 }
+#endif // TEST_LINALG2_PART6
 
+#ifdef TEST_LINALG2_PART7
 using namespace boost::mpl::placeholders;
 
 typedef boost::mpl::fold<
@@ -531,7 +544,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE
 	for (size_t j = 0; j < N; j++)
 	    BOOST_CHECK_SMALL(abs(diag(i,j) - (i==j ? w(i) : 0)), 50000*eps);
 }
+#endif // TEST_LINALG2_PART7
 
+#ifdef TEST_LINALG2_PART8
 template<int N>
 double angle(const Matrix<double, 1, N>& u, const Matrix<double, 1, N>& v)
 {
@@ -702,3 +717,4 @@ BOOST_AUTO_TEST_CASE(test_fs_diagonalize_hermitian_errbd)
 	BOOST_CHECK_LE(z_error, z_errbd[i] * 10);
     }
 }
+#endif // TEST_LINALG2_PART8


### PR DESCRIPTION
This pull request addresses issue #110 by reducing the maximal amount of resources (i.e. memory) that `test/test_linalg2.cpp` takes to compile.  The source file is split into 8 parts which are compiled into separate object files.  In the development branch, g++-7.3.1 consumes about 7GB of vsize to compile `test/test_linalg2.cpp`.  In this branch, the compilation of each part takes about 3GB or less.