### PR TITLE
search for field in vertex only at level 1

### DIFF
--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -1174,9 +1174,9 @@ VertexFunctionBodyForFields[fields_List] :=
       expr = Vertices`SortCp[SARAH`Cp @@ fields] /. indexFields /. vertexRules;
       
       "int minuend_index = " <> 
-        ToString[Position[indexedFields, incomingScalar][[1,1]] - 1] <> ";\n" <>
+        ToString[Position[indexedFields, incomingScalar, {1}][[1,1]] - 1] <> ";\n" <>
       "int subtrahend_index = " <>
-        ToString[Position[indexedFields, outgoingScalar][[1,1]] - 1] <> ";\n\n" <>
+        ToString[Position[indexedFields, outgoingScalar, {1}][[1,1]] - 1] <> ";\n\n" <>
       DeclareIndices[StripUnbrokenGaugeIndices /@ indexedFields, "indices"] <>
       Parameters`CreateLocalConstRefs[expr] <> "\n" <>
       "const " <> GetComplexScalarCType[] <> " result = " <>


### PR DESCRIPTION
This solves the problem raised by @dhjjacob in #115. You might accept this pull request as is. Alternativelly, I also wrote a function called `MathIndexToCPP` that secures the conversion of array indices from `mathematica` convention to `c++`. Such conversion is done in few places in the code. I can also add it in this pull request as it goes well with this previous fix.