### PR TITLE
added function converting array index from mathematica to c++ convention

### DIFF
--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -1104,7 +1104,7 @@ VertexFunctionBodyForFields[fields_List] :=
 			"const " <> GetComplexScalarCType[] <> " result = " <>
 			Parameters`ExpressionToString[expr] <> ";\n\n" <>
 			"return {result, " <> 
-				ToString[Position[indexedFields, incomingGhost, {1}][[1,1]] - 1] <>
+				ToString@Utils`MathIndexToCPP[Position[indexedFields, incomingGhost, {1}][[1,1]]] <>
 			"};",
 			
 			_TripleVectorVertex,
@@ -1174,9 +1174,9 @@ VertexFunctionBodyForFields[fields_List] :=
       expr = Vertices`SortCp[SARAH`Cp @@ fields] /. indexFields /. vertexRules;
       
       "int minuend_index = " <> 
-        ToString[Position[indexedFields, incomingScalar, {1}][[1,1]] - 1] <> ";\n" <>
+        ToString@Utils`MathIndexToCPP[Position[indexedFields, incomingScalar, {1}][[1,1]]] <> ";\n" <>
       "int subtrahend_index = " <>
-        ToString[Position[indexedFields, outgoingScalar, {1}][[1,1]] - 1] <> ";\n\n" <>
+        ToString@Utils`MathIndexToCPP[Position[indexedFields, outgoingScalar, {1}][[1,1]]] <> ";\n\n" <>
       DeclareIndices[StripUnbrokenGaugeIndices /@ indexedFields, "indices"] <>
       Parameters`CreateLocalConstRefs[expr] <> "\n" <>
       "const " <> GetComplexScalarCType[] <> " result = " <>


### PR DESCRIPTION
This pull request brings in a ``Utils`MathIndexToCPP`` function that should be used throughout the code to convert interer literal index from `mathematica` to `c++` convention. This improves the previous way of doing this where we explicitly subtracted 1. The problem with this approach is that in this context, if the index was not an integer, this was obviously an error. Yet it was never checked. `MathIndexToCPP` checks the type of supplied argument. Not only whether the index is an integer but also wheter it's bigger than 0. If not, we call fancy error printout functions from @uukhas. Because of that, this pull request brings in also some updates to those functions from @uukhas.