### PR TITLE
New function for making definition for manually unhandled input.

### DIFF
--- a/meta/Utils.m
+++ b/meta/Utils.m
@@ -188,6 +188,16 @@ is used for function arguments to avoid any unexpected behavior.";
 MakeUnknownInputDefinition::usage =
 "@brief Creates definition for a given symbol for a case when input is not defined
 explicitly, i.e. creates definition for the pattern symbol[args___].
+@example Step 1) Make all desired definitions for a function (here: foo), like
+foo[a_Integer] := Module[{<...>},<...>];
+foo[c:{__Integer}] := Module[{<...>},<...>];
+Step 2) Secure the usage of foo for specified above cases simply by writing
+foo // Utils`MakeUnknownInputDefinition;
+or
+Utils`MakeUnknownInputDefinition[foo];
+or
+Utils`MakeUnknownInputDefinition@foo;
+somewhere in the scope of the package, where foo is defined.
 @param <Symbol> sym Symbol to make definition for.
 @returns None.
 @note UpValues for symbol[args___] are not cleared.";

--- a/meta/Utils.m
+++ b/meta/Utils.m
@@ -185,6 +185,13 @@ parses \\n symbol.
 @note Internal`HandlerBlock is not documented, this is why System`Dump` prefix
 is used for function arguments to avoid any unexpected behavior.";
 
+MakeUnknownInputDefinition::usage =
+"@brief Creates definition for a given symbol for a case when input is not defined
+explicitly, i.e. creates definition for the pattern symbol[args___].
+@param <Symbol> sym Symbol to make definition for.
+@returns None.
+@note UpValues for symbol[args___] are not cleared.";
+
 ReadLinesInFile::usage = "ReadLinesInFile[fileName_String]:
 Read the entire contents of the file given by fileName and return it
 as a list of Strings representing the lines in the file.
@@ -467,17 +474,42 @@ Module[{nStrokes,controlSubstrings},
 ];
 SetAttributes[internalOrQuitInputCheck,{HoldFirst,Locked,Protected}];
 
+MakeUnknownInputDefinition[sym_Symbol] :=
+Module[{usageString,info,parsedInfo,infoString},
+   (* Maybe some useful definitions already exist*)
+   If[MatchQ[sym::usage,_String],usageString="Usage:\n"<>sym::usage<>"\n\n",usageString=""];
+   info = MakeBoxes@Definition@sym;
+   If[MatchQ[info,InterpretationBox["Null",__]],(* True - No, there is no definitions. *)
+      infoString="",
+      parsedInfo = Flatten@# &/@ (Cases[info[[1,1]],GridBox[{x:{_}..},__]:>Cases[{x},{_RowBox},1],2]~Flatten~2 //. {RowBox[x_]:>x,StyleBox[x_,_]:>x});
+      parsedInfo = MapThread[parsedInfo[[##]]&,{Range@Length@#,First/@#}] &@ (Range@(First@#-1) &@ Position[#,"="|":="|"^="|"^:="] &/@ parsedInfo);
+      parsedInfo = DeleteCases[DeleteDuplicates@parsedInfo,{"Options",__}|{"Attributes",__}];
+      parsedInfo = Array[Join[{ToString@#,") "},parsedInfo[[#]]]&,Length@parsedInfo];
+      infoString = StringJoin@Riffle[StringJoin @@ # & /@ parsedInfo, "\n"];
+      infoString = "The behavior for case"<>If[Length@parsedInfo===1,"\n","s\n"]<>infoString<>"\nis defined only.\n\n";
+   ];
+   sym::errUnknownInput = "`1``2`Call\n"<>ToString@sym<>"[`3`]\nis not supported.";
+   (* Clean existing definitions if they exist for required pattern.. *)
+   Off[Unset::norep];
+   sym[args___] =.;
+   On[Unset::norep];
+   (* Define a new pattern. *)
+   sym[args___] := AssertOrQuit[False,sym::errUnknownInput,usageString,infoString,StringJoin@@Riffle[ToString/@{args},", "]];
+];
+MakeUnknownInputDefinition@MakeUnknownInputDefinition;
+SetAttributes[MakeUnknownInputDefinition,{Locked,Protected,ReadProtected}];
+
 ReadLinesInFile[fileName_String] :=
 	Module[{fileHandle, lines = {}, line},
 		fileHandle = OpenRead[fileName, BinaryFormat -> True];
-		
+
 		While[(line = Read[fileHandle, String]) =!= EndOfFile,
 			AssertWithMessage[line =!= $Failed,
 				"Utils`ReadLinesInFile[]: Unable to read line from file '" <>
 				fileName <> "'"];
 			AppendTo[lines, line];
 			];
-		
+
     Close[fileHandle];
     lines
 	]

--- a/meta/Utils.m
+++ b/meta/Utils.m
@@ -476,6 +476,10 @@ SetAttributes[internalOrQuitInputCheck,{HoldFirst,Locked,Protected}];
 
 MakeUnknownInputDefinition[sym_Symbol] :=
 Module[{usageString,info,parsedInfo,infoString},
+   (* Clean existing definitions if they exist for required pattern.. *)
+   Off[Unset::norep];
+   sym[args___] =.;
+   On[Unset::norep];
    (* Maybe some useful definitions already exist*)
    If[MatchQ[sym::usage,_String],usageString="Usage:\n"<>sym::usage<>"\n\n",usageString=""];
    info = MakeBoxes@Definition@sym;
@@ -489,10 +493,6 @@ Module[{usageString,info,parsedInfo,infoString},
       infoString = "The behavior for case"<>If[Length@parsedInfo===1,"\n","s\n"]<>infoString<>"\nis defined only.\n\n";
    ];
    sym::errUnknownInput = "`1``2`Call\n"<>ToString@sym<>"[`3`]\nis not supported.";
-   (* Clean existing definitions if they exist for required pattern.. *)
-   Off[Unset::norep];
-   sym[args___] =.;
-   On[Unset::norep];
    (* Define a new pattern. *)
    sym[args___] := AssertOrQuit[False,sym::errUnknownInput,usageString,infoString,StringJoin@@Riffle[ToString/@{args},", "]];
 ];

--- a/meta/Utils.m
+++ b/meta/Utils.m
@@ -492,7 +492,7 @@ Module[{usageString,info,parsedInfo,infoString},
       infoString = StringJoin@Riffle[StringJoin @@ # & /@ parsedInfo, "\n"];
       infoString = "The behavior for case"<>If[Length@parsedInfo===1,"\n","s\n"]<>infoString<>"\nis defined only.\n\n";
    ];
-   sym::errUnknownInput = "`1``2`Call\n"<>ToString@sym<>"[`3`]\nis not supported.";
+   sym::errUnknownInput = "`1``2`Call\n"<>StringReplace[ToString@sym,"`"->"`.`"]<>"[`3`]\nis not supported.";
    (* Define a new pattern. *)
    sym[args___] := AssertOrQuit[False,sym::errUnknownInput,usageString,infoString,StringJoin@@Riffle[ToString/@{args},", "]];
 ];

--- a/test/module.mk
+++ b/test/module.mk
@@ -90,6 +90,7 @@ TEST_META := \
 		$(DIR)/test_ThresholdCorrections.m \
 		$(DIR)/test_TreeMasses.m \
 		$(DIR)/test_TwoLoopNonQCD.m \
+		$(DIR)/test_Utils.m \
 		$(DIR)/test_Vertices.m \
 		$(DIR)/test_Vertices_SortCp.m \
 		$(DIR)/test_Vertices_colorsum.m

--- a/test/test_Utils.m
+++ b/test/test_Utils.m
@@ -1,0 +1,195 @@
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+Global`time = AbsoluteTime[];
+
+(* THERE IS A NEED TO CHANGE BEHAVIOR OF LOCKED FILE **************************)
+fileName = FileNameJoin@{Directory[],"test","test_Utils.temp"};
+Off[Syntax::sntufn];
+subKernel = LaunchKernels[1];
+DistributeDefinitions[fileName];
+ParallelEvaluate[
+   Needs["Utils`",FileNameJoin@{Directory[],"meta","Utils.m"}];
+   Put[Definition@Utils`Private`internalAssertOrQuit,fileName];
+   code = StringJoin@Riffle[Drop[Utils`ReadLinesInFile@fileName,2],"\n"];
+   code=StringReplace[code,
+      {
+         "\\[Raw"~~Shortest@__~~"m"->"",
+         "Quit[1];"->"","FSFancyLine[];"->"",
+         "WriteString"~~__~~x:"StringJoin[Utils`Private`str]"~~"]":>
+            "(`test`out = `test`out<>"<>x<>")",
+         "\\nWolfram Language kernel session "->""
+      }
+   ];
+   fileHandle = OpenWrite@fileName;
+   fileHandle ~ WriteString ~ code;
+   Close@fileHandle;
+];
+CloseKernels@subKernel;
+On[Syntax::sntufn];
+(* LOAD TEST DEFINITIONS ******************************************************)
+`test`out="";
+Get@fileName;
+Attributes[Utils`Private`internalAssertOrQuit] = {HoldAll,Protected,Locked};
+DeleteFile@fileName;
+
+Off[SetDelayed::write,Attributes::locked];
+Needs["TestSuite`", "TestSuite.m"];
+Needs["Utils`", "Utils.m"];
+On[SetDelayed::write,Attributes::locked];
+
+(* TEST MULTIDIMENSIONAL CONTEXT***********************************************)
+a;
+a//Utils`MakeUnknownInputDefinition;
+a[1];
+TestEquality[`test`out,
+"Global`a: errUnknownInput:
+Call
+a[1]
+is not supported.terminated.\n"
+];
+`test`out="";
+
+`subcontext`b;
+`subcontext`b//Utils`MakeUnknownInputDefinition;
+`subcontext`b[1];
+TestEquality[`test`out,
+"Global`subcontext`b: errUnknownInput:
+Call
+Global`subcontext`b[1]
+is not supported.terminated.\n"
+];
+`test`out="";
+
+`subcontext`subcontext`c;
+`subcontext`subcontext`c//Utils`MakeUnknownInputDefinition;
+`subcontext`subcontext`c[1];
+TestEquality[`test`out,
+"Global`subcontext`subcontext`c: errUnknownInput:
+Call
+Global`subcontext`subcontext`c[1]
+is not supported.terminated.\n"
+];
+`test`out="";
+
+d; d::usage="some text";
+d//Utils`MakeUnknownInputDefinition;
+d[1];
+TestEquality[`test`out,
+"Global`d: errUnknownInput:
+Usage:
+some text
+
+Call
+d[1]
+is not supported.terminated.\n"
+];
+`test`out="";
+
+(* TEST INPUT TYPES ***********************************************************)
+
+e[x_,y_] = 3;
+e//Utils`MakeUnknownInputDefinition;
+e[1];
+TestEquality[`test`out,
+"Global`e: errUnknownInput:
+The behavior for case
+1) e[x_,y_]
+is defined only.
+
+Call
+e[1]
+is not supported.terminated.\n"
+];
+`test`out="";
+
+f[x_Integer,y:{_String}:"`"] := Sin[345*x];
+f//Utils`MakeUnknownInputDefinition;
+f[];
+TestEquality[`test`out,
+"Global`f: errUnknownInput:
+The behavior for case
+1) f[x_Integer,y:{_String}:\"`\"]
+is defined only.
+
+Call
+f[]
+is not supported.terminated.\n"
+];
+`test`out="";
+
+g[a_,3] := g[a,3] = 17;
+g//Utils`MakeUnknownInputDefinition;
+g["monkey"];
+TestEquality[`test`out,
+"Global`g: errUnknownInput:
+The behavior for case
+1) g[a_,3]
+is defined only.
+
+Call
+g[monkey]
+is not supported.terminated.\n"
+];
+`test`out="";
+
+h /: Dot[h[2,x_,t:String:"34"], somethingelse] = "works";
+h//Utils`MakeUnknownInputDefinition;
+h[1,4];
+TestEquality[`test`out,
+"Global`h: errUnknownInput:
+The behavior for case
+1) h/:h[2,x_,t:String:\"34\"].somethingelse
+is defined only.
+
+Call
+h[1, 4]
+is not supported.terminated.\n"
+];
+`test`out="";
+
+i /: Print[i[n_], i[m_]] := "";
+i//Utils`MakeUnknownInputDefinition;
+Print[i[n_], i[m_,1]];
+TestEquality[`test`out,
+"Global`i: errUnknownInput:
+The behavior for case
+1) Print[i[n_],i[m_]]
+is defined only.
+
+Call
+i[n_]
+is not supported.terminated.
+Global`i: errUnknownInput:
+The behavior for case
+1) Print[i[n_],i[m_]]
+is defined only.
+
+Call
+i[m_, 1]
+is not supported.terminated.\n"
+];
+`test`out="";
+
+Print[StringJoin[">>test>> done in ",ToString@N[AbsoluteTime[]-Global`time,{Infinity,3}]," seconds.\n"]];
+
+PrintTestSummary[];


### PR DESCRIPTION
It is possible using Mathematica to specify the input of functions in absolutely concrete way.
The bad side of this is that for all functions one has to write func[args___] case, which leads to
terminating of mathematica session (or some other behavior). Plus, one would like to get some relevant output before termination
telling about details of an error. It is possible to do this manually for all functions, but it requieres
a lot of time and slows down code implementation and leads to wish of writing a code in a "cowboy" style.

This is why I suggest to add and use MakeUnknownInputDefinition function (the current name is just a suggestion) to
speed this up and make Mathematica part of evaluation **safer**.

It should be used in the following way:
```
myFunc::usage = "text";
more messages
myFunc[f_] := some lines of code;
myFunc[some patterns] := some lines of code;
more definitions for myFunc

Utils`MakeUnknownInputDefinition[myFunc];
```

The last line creates a new definition for myFunc:
```
myFunc[args___]
```
which is evaluated if none of manually specified cases can be applied.

If this last definition is evaluated, then error message is generated and it contains information about:

- myFunc::usage (if it is defined; if not - skips this step),
- definitions of myFunc specified manually (if they exist),
- evaluated form of args.