### PR TITLE
fixed clang override warning

### DIFF
--- a/meta/FunctionModifiers.m
+++ b/meta/FunctionModifiers.m
@@ -45,8 +45,9 @@ MakeOverride[str_String] :=
     Module[{ws = Whitespace ...},
            StringReplace[str,
                          {
-                             ws ~~ p : Shortest["{" ~~ ___ ~~ "}"] :> " override " <> p, 
-                             ws ~~ ")" ~~ ws ~~ ";" ~~ ws ~~ EndOfLine -> ") override;"
+                             ws ~~ p : Shortest["{" ~~ ___ ~~ "}"] :> " override " <> p,
+                             ")" ~~ ws ~~ "const;" -> ") const override;",
+                             ");" -> ") override;"
                          }]
           ];
 

--- a/templates/mass_eigenstates_decoupling_scheme.hpp.in
+++ b/templates/mass_eigenstates_decoupling_scheme.hpp.in
@@ -82,8 +82,8 @@ public:
    void fill_from(const @ModelName@_mass_eigenstates&);
    void reorder_tree_level_masses();
    void reorder_pole_masses();
-   void print(std::ostream& out = std::cerr) const;
-   void clear();
+   void print(std::ostream& out = std::cerr) const override;
+   void clear() override;
 
    // mass_eigenstates_interface functions
 

--- a/test/module.mk
+++ b/test/module.mk
@@ -68,6 +68,7 @@ TEST_META := \
 		$(DIR)/test_CConversion.m \
 		$(DIR)/test_Constraint.m \
 		$(DIR)/test_EWSB.m \
+		$(DIR)/test_FunctionModifiers.m \
 		$(DIR)/test_LoopFunctions.m \
 		$(DIR)/test_MSSM_2L_analytic.m \
 		$(DIR)/test_MSSM_2L_mt.m \

--- a/test/test_FunctionModifiers.m
+++ b/test/test_FunctionModifiers.m
@@ -1,0 +1,61 @@
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+Needs["TestSuite`", "TestSuite.m"];
+Needs["FunctionModifiers`", "FunctionModifiers.m"];
+
+TestEquality[
+   MakeOverride["double get_ewsb_eq_hh_1() const;"],
+   "double get_ewsb_eq_hh_1() const override;"
+];
+TestEquality[
+   MakeOverride["double get_ewsb_eq_hh_1() const;\n"],
+   "double get_ewsb_eq_hh_1() const override;\n"
+];
+
+
+TestEquality[
+   MakeOverride["double get_ewsb_eq_hh_1();"],
+   "double get_ewsb_eq_hh_1() override;"
+];
+TestEquality[
+   MakeOverride["double get_ewsb_eq_hh_1();\n"],
+   "double get_ewsb_eq_hh_1() override;\n"
+];
+
+TestEquality[
+   MakeOverride["void set_v(double v_) { v = v_; }"],
+   "void set_v(double v_) override { v = v_; }"
+];
+
+TestEquality[
+   MakeOverride[
+      "std::complex<double> CpbarFdFdAhPR(int gI1, int gI2) const;\n" <>
+      "std::complex<double> CpbarFdFdAhPL(int gI1, int gI2) const;\n" <>
+      "std::complex<double> CpbarFeFeAhPR(int gI1, int gI2) const;"
+   ],
+   "std::complex<double> CpbarFdFdAhPR(int gI1, int gI2) const override;\n" <>
+   "std::complex<double> CpbarFdFdAhPL(int gI1, int gI2) const override;\n" <>
+   "std::complex<double> CpbarFeFeAhPR(int gI1, int gI2) const override;"
+];
+
+PrintTestSummary[];


### PR DESCRIPTION
@Expander This pull request fixes warnings about override keywoard generated by clang. I'm not 100% sure what was the logic behind the original  implementation of `MakeOverride` function so would you mind having a look at my changes?