### PR TITLE
bulletprooferd TestEquality function

### DIFF
--- a/meta/TestSuite.m
+++ b/meta/TestSuite.m
@@ -20,7 +20,7 @@
 
 *)
 
-BeginPackage["TestSuite`"];
+BeginPackage["TestSuite`", {"Utils`"}];
 
 TestEquality::usage="tests equality of two expressions";
 TestCloseRel::usage="tests relative numerical difference."
@@ -48,6 +48,10 @@ TestEquality[val_, expr_, msg_:""] :=
        numberOfPassedTests++;
        Return[True];
       ];
+TestEquality::wrongArgs =
+"Wrong arguments. Received '`1`'.";
+TestEquality[args___] :=
+   Utils`AssertOrQuit[False, TestEquality::wrongArgs, StringJoin@@Riffle[ToString/@{args},", "]];
 
 TestNonEquality[val_, expr_, msg_:""] :=
     If[val === expr,


### PR DESCRIPTION
@Expander I'm not sure if not quiting from `TestEquality` is conceptually justified. It's not a failing test. It's a wrongly formatted test. But If I understand correctly we need it because of the way how tests works. Ps. Do we test a test framework? :)