### PR TITLE
using mass_eigenstates_interface in context

### DIFF
--- a/templates/a_muon.cpp.in
+++ b/templates/a_muon.cpp.in
@@ -45,7 +45,7 @@ namespace {
 
 double get_QED_2L(context_base&, const softsusy::QedQcd&);
 
-double get_MSUSY(const @ModelName@_mass_eigenstates& model)
+double get_MSUSY(const @ModelName@_mass_eigenstates_interface& model)
 {
 @AMuon_GetMSUSY@
 }

--- a/templates/cxx_qft/context_base.hpp.in
+++ b/templates/cxx_qft/context_base.hpp.in
@@ -28,16 +28,14 @@
 #ifndef @ModelName@_CXXQFT_CONTEXT_BASE_H
 #define @ModelName@_CXXQFT_CONTEXT_BASE_H
 
-#include "@ModelName@_mass_eigenstates.hpp"
-
 #include "@ModelName@_fields.hpp"
-#include "@ModelName@_mass_eigenstates.hpp"
+#include "@ModelName@_mass_eigenstates_interface.hpp"
 
 namespace flexiblesusy {
 namespace @ModelName@_cxx_diagrams {
 
    struct context_base {
-      @ModelName@_mass_eigenstates model; ///< The model object.
+      @ModelName@_mass_eigenstates_interface const& model; ///< The model object.
 
       template <class Field>
       double mass(const typename field_indices<Field>::type& indices) const
@@ -47,7 +45,9 @@ namespace @ModelName@_cxx_diagrams {
          return mass_impl<CleanField>(indices);
       }
 
-      context_base(const @ModelName@_mass_eigenstates& m) : model(m) {}
+      context_base(@ModelName@_mass_eigenstates_interface const& m) : model(m) {}
+      context_base(@ModelName@_mass_eigenstates_interface const* const m) : model(*m) {}
+
       context_base(const context_base&) = default;
       context_base(context_base&&) = default;
 

--- a/templates/cxx_qft/npointfunctions.hpp.in
+++ b/templates/cxx_qft/npointfunctions.hpp.in
@@ -193,7 +193,7 @@ struct context_with_vertices : context_base {
       return Vertex<Fields...>::evaluate(indices, model).value();
    }
 
-   double scale(void) const { return model.get_scale(); }
+   double scale(void) const { return dynamic_cast<@ModelName@_mass_eigenstates const&>(model).get_scale(); }
 };
 
 template <int NumberOfExternalIndices, int NumberOfExternalMomenta>

--- a/test/test_SM_cxxdiagrams.cpp.in
+++ b/test/test_SM_cxxdiagrams.cpp.in
@@ -83,7 +83,7 @@ public:
 		return evaluate_impl(
 			boost::fusion::push_front(
 				std::move( boost_indices ),
-				std::cref( context.model )
+				dynamic_cast<model_type const&>(context.model)
 			)
 		);
 	}

--- a/test/test_cxxdiagrams_vertices.hpp
+++ b/test/test_cxxdiagrams_vertices.hpp
@@ -25,6 +25,7 @@
 #include "cxx_qft/SM_qft.hpp"
 
 #include "test_complex_equality.hpp"
+#include "SM_mass_eigenstates.hpp"
 
 namespace flexiblesusy
 {


### PR DESCRIPTION
Since `FlexibleDecay` uses `context` we have to change `context` to operate on `mass_eigenstates_interface`. This means that `context` cannot store a copy of a `model` but only a reference or a pointer. This works fine apart from few place in the code where someone tried to extract back `model` from `context`. That;s why I had to add those down casts. Anyone has a better idea?