### PR TITLE
unit test for the TreeMassess module in the MRSSM

### DIFF
--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -224,6 +224,8 @@ GetGluon::usage            = "returns the gluon";
 GetZBoson::usage           = "returns the Z boson";
 GetWBoson::usage           = "returns the W boson";
 GetHiggsBoson::usage       = "return Higgs boson(s)";
+GetPseudoscalarHiggsBoson::usage = "";
+GetChargedHiggsBoson::usage = "";
 
 GetSMTopQuarkMultiplet::usage    = "Returns multiplet containing the top quark, Fu or Ft";
 GetSMBottomQuarkMultiplet::usage = "Returns multiplet containing the bottom quark, Fd or Fb";
@@ -2210,22 +2212,48 @@ CreateMixingArraySetter[masses_List, array_String] :=
            Return[set];
           ];
 
-(* Once Dominik wanted to have functions identifying SM particles.
-   This might be non-trivial in some models.
-   For now, we just have wrappers that return SM particles using SARAH symbols *)
+(*
+   1. Once Dominik wanted to have functions identifying SM particles.
+      This might be non-trivial in some models.
+      For now, we just have wrappers that return SM particles using SARAH symbols
+   2. If a particle does not exist in the model, we don't stop.
+      Instead, we return Null and let the calling code decide how to handle it.
+*)
 
-GetPhoton[] := SARAH`Photon;
-GetGluon[] := SARAH`Gluon;
-GetZBoson[] := SARAH`Zboson;
+GetPhoton[] :=
+   If[ValueQ[SARAH`Photon],
+      SARAH`Photon
+   ];
+
+GetGluon[] :=
+   If[ValueQ[SARAH`Gluon],
+      SARAH`Gluon
+   ];
+
+GetZBoson[] :=
+   If[ValueQ[SARAH`Zboson],
+      SARAH`Zboson
+   ];
+
 GetWBoson[] :=
-   Module[{temp},
-      temp = Select[Unevaluated[{SARAH`Wboson, SARAH`VectorW}], ValueQ];
+   Module[{temp = Select[Unevaluated[{SARAH`Wboson, SARAH`VectorW}], ValueQ]},
       If[Length @ DeleteDuplicates[temp] === 1,
-         temp[[1]],
-         Print["Could not identify the name given to the W-boson"]; Quit[1]
+         temp[[1]]
       ]
    ];
-GetHiggsBoson[] := SARAH`HiggsBoson;
+
+GetHiggsBoson[] :=
+   If[ValueQ[SARAH`HiggsBoson],
+      SARAH`HiggsBoson
+   ];
+
+GetChargedHiggsBoson[] :=
+   If[ValueQ[SARAH`ChargedHiggs],
+      SARAH`ChargedHiggs
+   ];
+
+GetPseudoscalarHiggsBoson[] :=
+   If[ValueQ[SARAH`PseudoScalarBoson], SARAH`PseudoScalarBoson];
 
 End[];
 

--- a/test/module.mk
+++ b/test/module.mk
@@ -76,6 +76,7 @@ TEST_META := \
 		$(DIR)/test_MSSM_2L_yt.m \
 		$(DIR)/test_MSSM_2L_yt_loopfunction.m \
 		$(DIR)/test_MSSM_2L_yt_softsusy.m \
+		$(DIR)/test_MRSSM_TreeMasses.m \
 		$(DIR)/test_Parameters.m \
 		$(DIR)/test_ReadSLHA.m \
 		$(DIR)/test_RGIntegrator.m \

--- a/test/test_MRSSM_TreeMasses.m
+++ b/test/test_MRSSM_TreeMasses.m
@@ -1,0 +1,76 @@
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+Get["utils/load-FlexibleSUSY.m"];
+
+Needs["TestSuite`", "TestSuite.m"];
+Needs["TreeMasses`", "TreeMasses.m"];
+
+Start["MRSSM"];
+
+Print[""];
+
+Print["Testing getters for particle collection..."];
+
+TestEquality[
+   TreeMasses`GetSusyParticles[],
+   {Glu, SRdp, SRum, sigmaO, phiO, Sd, Sv, Su, Se, hh, Ah, Rh, Hpm, Chi, Cha1, Cha2}];
+
+TestEquality[
+   TreeMasses`GetColoredParticles[],
+   {VG, gG, Glu, sigmaO, phiO, Sd, Su, Fd, Fu}
+];
+
+TestEquality[
+   TreeMasses`GetVectorBosons[], {VG, VP, VZ, VWm}
+];
+
+Print["Testing getters for individual particles..."];
+
+TestEquality[TreeMasses`GetPhoton[], VP];
+TestEquality[TreeMasses`GetGluon[], VG];
+TestEquality[TreeMasses`GetZBoson[], VZ];
+TestEquality[TreeMasses`GetWBoson[], VWm];
+TestEquality[TreeMasses`GetHiggsBoson[], hh];
+TestEquality[TreeMasses`GetChargedHiggsBoson[], Hpm];
+TestEquality[TreeMasses`GetPseudoscalarHiggsBoson[], Ah];
+
+Print["Testing particle properties..."];
+
+TestEquality[TreeMasses`IsSMParticle[#], True]& /@ {Fe, Fd, Fu, Fv, gG, VG, gP, VP, VZ, gZ, VWm, gWm, gWmC};
+TestEquality[TreeMasses`IsSMParticle[#], False]& /@ {Glu, SRdp, SRum, sigmaO, phiO, Sd, Sv, Su, Se, hh, Ah, Rh, Hpm, Chi, Cha1, Cha2};
+
+TestEquality[TreeMasses`IsMassless[#], True]& /@ {Fv, gG, VG, gP, VP};
+TestEquality[TreeMasses`IsMassless[#], False]& /@ {
+   gZ, VZ, gWm, gWmC, VWm, SRdp, SRum, sigmaO, phiO, Sd, Sv, Su, Se, hh, Ah, Rh, Hpm, Fe, Fd, Fu, Cha1, Cha2, Chi, Glu};
+
+TestEquality[TreeMasses`IsScalar[#], True]& /@ {SRdp, SRum, sigmaO, phiO, Sd, Sv, Su, Se, hh, Ah, Rh, Hpm};
+TestEquality[TreeMasses`IsFermion[#], True]& /@ {Fe, Fd, Fu, Fv, Cha1, Cha2, Chi, Glu};
+TestEquality[TreeMasses`IsVector[#], True]& /@ {VG, VP, VZ, VWm};
+TestEquality[TreeMasses`IsGhost[#], True]& /@ {gWm, gWmC, gP, gZ, gG};
+TestEquality[TreeMasses`IsGoldstone[#], True]& /@ {Ah[{1}], Hpm[{1}]};
+
+TestEquality[TreeMasses`IsElectricallyCharged[#], True]& /@ {SRdp, SRum, Sd, Su, Se, Fe, Fd, Fu, Hpm, Cha1, Cha2, VWm, gWm, gWmC};
+TestEquality[TreeMasses`ColorChargedQ[#], True]& /@ {Fd, Fu, VG, gG, Su, Sd, Glu, sigmaO, phiO};
+
+Print[""];
+PrintTestSummary[];


### PR DESCRIPTION
There's also one change which might be of (minor) interest to some. The getters for certain particles (like `GetPseudoscalarHiggsBoson`) return `Null` if a given particle does not exist in a model. Not a new, undefined symbol like potentially ```SARAH`PseudoScalarBoson``` could be nor do they quit the kernel. It's up to the caller to decide how to handle it.