### PR TITLE
don't run flexiblesusy-config test if --disable-librarylink

### DIFF
--- a/test/module.mk
+++ b/test/module.mk
@@ -622,7 +622,7 @@ TEST_META += \
 		$(DIR)/test_multiple_librarylinks.m
 endif
 
-ifeq ($(WITH_SM),yes)
+ifeq ($(WITH_SM) $(ENABLE_LIBRARYLINK),yes yes)
 TEST_SH += \
 		$(DIR)/test_flexiblesusy-config.sh
 endif


### PR DESCRIPTION
With `--disable-librarylink` `test_flexiblesusy-config.sh` fails with
```
test/SM/SM_librarylink.cpp:43:10: fatal error: mathlink.h: Nie ma takiego pliku ani katalogu    
   43 | #include <mathlink.h>    
      |          ^~~~~~~~~~~~    
```
I think it should be also secured by `ENABLE_LIBRARYLINK`