### PR TITLE
physical mass getter from context

### DIFF
--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -41,6 +41,8 @@ NumberOfFieldIndices::usage="Return the number of indices a field has as would b
 determined by inspecting the result of TreeMasses`FieldInfo[].";
 CreateMassFunctions::usage="Creates c++ code that makes functions available that \
 return tree-level masses of given fields.";
+CreatePhysicalMassFunctions::usage="Creates c++ code that makes functions available that \
+return physical masses of given fields.";
 LorentzIndexOfField::usage="Returns the Lorentz index of a given indexed field.";
 ColourIndexOfField::usage="Returns the colour index of a given indexed field.";
 
@@ -1265,7 +1267,30 @@ CreateMassFunctions[] :=
              "{ return model.get_M" <> CXXNameOfField[# /. ghostMappings] <>
              If[TreeMasses`GetDimension[#] === 1, "()", "(indices[0])"] <> "; }"
             ] & /@ massiveFields, "\n\n"]
-        ]
+        ];
+
+(** \brief Creates c++ code that makes functions available that
+ * return physical masses of given fields.
+ * \returns the corresponding c++ code as a string.
+ **)
+CreatePhysicalMassFunctions[fieldsNamespace_:""] :=
+  Module[{massiveFields,
+          ghostMappings = SelfEnergies`ReplaceGhosts[FlexibleSUSY`FSEigenstates]},
+    massiveFields = TreeMasses`GetParticles[];
+
+    StringJoin @ Riffle[
+      Module[{fieldInfo = TreeMasses`FieldInfo[#], numberOfIndices},
+             numberOfIndices = Length @ fieldInfo[[5]];
+
+             "template<> inline\n" <>
+             "double context_base::physical_mass_impl<" <>
+               CXXNameOfField[#, prefixNamespace -> "fields"] <>
+             ">(const std::array<int, " <> ToString @ numberOfIndices <>
+             ">& indices) const\n" <>
+             "{ return model.get_physical().M" <> CXXNameOfField[# /. ghostMappings] <>
+             If[TreeMasses`GetDimension[#] === 1, "", "[indices[0]]"] <> "; }"
+            ] & /@ massiveFields, "\n\n"]
+        ];
 
 (** \brief Creates the c++ code for a function that returns the
  * numerical value of the electrical charge of the electron.

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -2086,12 +2086,15 @@ WriteObservables[extraSLHAOutputBlocks_, files_List] :=
 WriteCXXDiagramClass[vertices_List, files_List,
     cxxQFTVerticesTemplate_, cxxQFTVerticesOutputDirectory_,
     cxxQFTVerticesMakefileTemplates_] :=
-    Module[{fields = "", cxxVerticesParts = {}, massFunctions, unitCharge,
+    Module[{fields = "", cxxVerticesParts = {},
+            massFunctions, physicalMassFunctions,
+            unitCharge,
             sarahOutputDir = SARAH`$sarahCurrentOutputMainDir,
             outputDir, cxxDiagramsDir, createdVerticesFile, fileHandle,
             cxxQFTVerticesFiles},
 
         massFunctions = CXXDiagrams`CreateMassFunctions[];
+        physicalMassFunctions = CXXDiagrams`CreatePhysicalMassFunctions[];
         fields = CXXDiagrams`CreateFields[];
 
         If[vertices =!= {},
@@ -2115,11 +2118,12 @@ WriteCXXDiagramClass[vertices_List, files_List,
         ];
 
         unitCharge = CXXDiagrams`CreateUnitCharge[];
-        AppendTo[cxxVerticesParts, {"", CXXDiagrams`CreateUnitCharge[]}];
+        AppendTo[cxxVerticesParts, {"", unitCharge}];
 
         WriteOut`ReplaceInFiles[files,
-                            {"@CXXDiagrams_Fields@"            -> fields,
-                             "@CXXDiagrams_MassFunctions@"     -> massFunctions,
+                            {"@CXXDiagrams_Fields@"                -> fields,
+                             "@CXXDiagrams_MassFunctions@"         -> massFunctions,
+                             "@CXXDiagrams_PhysicalMassFunctions@" -> physicalMassFunctions,
                              "@CXXDiagrams_VertexPrototypes@"  ->
                                 StringJoin[Riffle[cxxVerticesParts[[All, 1]], "\n\n"]],
                              Sequence @@ GeneralReplacementRules[]

--- a/templates/cxx_qft/context_base.hpp.in
+++ b/templates/cxx_qft/context_base.hpp.in
@@ -44,6 +44,13 @@ namespace @ModelName@_cxx_diagrams {
             typename fields::remove_lorentz_conjugation<Field>::type;
          return mass_impl<CleanField>(indices);
       }
+      template<class Field>
+      double physical_mass(const typename field_indices<Field>::type& indices) const
+      {
+         using CleanField =
+            typename fields::remove_lorentz_conjugation<Field>::type;
+         return physical_mass_impl<CleanField>(indices);
+      }
 
       context_base(@ModelName@_mass_eigenstates_interface const& m) : model(m) {}
       context_base(@ModelName@_mass_eigenstates_interface const* const m) : model(*m) {}
@@ -60,9 +67,13 @@ namespace @ModelName@_cxx_diagrams {
       template <class Field>
       double
       mass_impl(const typename field_indices<Field>::type& indices) const;
+      template<class Field>
+      double physical_mass_impl(const typename field_indices<Field>::type& indices) const;
    };
 
-   @CXXDiagrams_MassFunctions@
+@CXXDiagrams_MassFunctions@
+
+@CXXDiagrams_PhysicalMassFunctions@
 
 } // namespace @ModelName@_cxx_diagrams
 } // namespace flexiblesusy

--- a/templates/mass_eigenstates_interface.hpp.in
+++ b/templates/mass_eigenstates_interface.hpp.in
@@ -36,10 +36,11 @@
 
 #include <Eigen/Core>
 
+#include "@ModelName@_physical.hpp"
+
 namespace flexiblesusy {
 
 class Problems;
-class @ModelName@_physical;
 
 /**
  * @class @ModelName@_mass_eigenstates_interface


### PR DESCRIPTION
This PR adds the function that gets physical mass of particle from `context`. It's an analogue of already existing function that gives a tree-level mass. The only tricky point is that `get_physical()` which is used in `context_base.hpp`  doesn't seem to work with a forward declaration of `@ModelName@_physical` so I had to include `@ModelName@_physical.hpp` in `@ModelName@_mass_eigenstates_interface.hpp`.