### PR TITLE
validate content of PoleMassPrecision variables

### DIFF
--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -441,6 +441,16 @@ ReplaceSymbolsInUserInput[rules_] :=
            FlexibleSUSY`FSSelfEnergyRules       = FlexibleSUSY`FSSelfEnergyRules         /. rules;
            FlexibleSUSY`FSVertexRules           = FlexibleSUSY`FSVertexRules             /. rules;
            FlexibleSUSY`FSBetaFunctionRules     = FlexibleSUSY`FSBetaFunctionRules       /. rules;
+           SetAttributes[CheckParticleInPrecision, HoldFirst];
+           CheckParticleInPrecision[precision_] :=
+              If[!SubsetQ[TreeMasses`GetParticles[], precision],
+                 Print["Warning: Particle(s) ", Complement[precision, TreeMasses`GetParticles[]],
+                 " cannot be used in ", HoldForm@precision, " as it is not part of ", FSModelName, ". Removing it/them."];
+                 Intersection[precision, TreeMasses`GetParticles[]]
+              ];
+           With[{list = Unevaluated@{FlexibleSUSY`HighPoleMassPrecision, FlexibleSUSY`MediumPoleMassPrecision, FlexibleSUSY`LowPoleMassPrecision}},
+              Thread[list = CheckParticleInPrecision /@ list]
+           ];
           ];
 
 CheckSARAHVersion[] :=

--- a/model_files/THDMII/FlexibleSUSY.m.in
+++ b/model_files/THDMII/FlexibleSUSY.m.in
@@ -61,7 +61,7 @@ InitialGuessAtLowScale = {
 };
 
 DefaultPoleMassPrecision = MediumPrecision;
-HighPoleMassPrecision    = {hh, Ah, Hpm};
+HighPoleMassPrecision    = {hh, Ah, Hm};
 MediumPoleMassPrecision  = {};
 LowPoleMassPrecision     = {};
 


### PR DESCRIPTION
@Expander, I noticed by accident that there is an error in setup of `THDMII` model. In `FlexibleSUSY.m.in` there's a line that says
```
HighPoleMassPrecision    = {hh, Ah, Hpm};
```
But there is no `Hpm` in this model. It should say `Hm`. This PR introduces a fix for this and a function that check `HighPoleMassPrecision` and similar variables. Are you ok with that and do you have a suggestion where such function should be used? Right now I'm checking
```
{HighPoleMassPrecision, MediumPoleMassPrecision, LowPoleMassPrecision}
```