### PR TITLE
Fix make install-src

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,3 @@ script:
   - make showbuild
   - make
   - make -k all-test
-  - test/test_threshold_loop_functions.x

--- a/configure
+++ b/configure
@@ -3454,7 +3454,9 @@ sed -e "s|@MATH@|$MATH|" \
     -e "s|@OPERATING_SYSTEM@|$operating_system|" \
     < $SARAH_DEP_GEN_TMPL > $SARAH_DEP_GEN
 
-add_metaflags
+if test "x${enable_meta}" = "xyes"; then
+    add_metaflags
+fi
 
 echo "$FLEXIBLESUSY_VERSION" > ${CONFIGDIR}/version
 echo "$GIT_COMMIT" > ${CONFIGDIR}/git_commit


### PR DESCRIPTION
This branch aims to fix the `make install-src` command, see issue #171.

The following should work:
~~~
for i in 1 2 3
do
   ./configure --with-models=SM --with-install-dir=install
   make
   make install-src
   cd install
done

~~~