### PR TITLE
compute observables only if spectrum was generated

### DIFF
--- a/templates/run.cpp.in
+++ b/templates/run.cpp.in
@@ -85,10 +85,6 @@ int run_solver(flexiblesusy::@ModelName@_slha_io& slha_io,
    scales.LowScale  = spectrum_generator.get_low_scale();
    scales.pole_mass_scale = spectrum_generator.get_pole_mass_scale();
 
-   @ModelName@_observables observables;
-   if (spectrum_generator_settings.get(Spectrum_generator_settings::calculate_observables))
-      observables = calculate_observables(std::get<0>(models), qedqcd, physical_input, scales.pole_mass_scale);
-
    const bool show_result = !problems.have_problem() ||
       spectrum_generator_settings.get(Spectrum_generator_settings::force_output);
    // SLHA output
@@ -100,16 +96,22 @@ int run_solver(flexiblesusy::@ModelName@_slha_io& slha_io,
             spectrum_generator_settings.get(
                Spectrum_generator_settings::force_positive_masses));
          slha_io.set_spectrum(models);
-         slha_io.set_extra(std::get<0>(models), scales, observables);
+         if (spectrum_generator_settings.get(Spectrum_generator_settings::force_output)
+            || (!problems.have_problem()
+                && spectrum_generator_settings.get(Spectrum_generator_settings::calculate_sm_masses)
+                && spectrum_generator_settings.get(Spectrum_generator_settings::calculate_bsm_masses)
+                && spectrum_generator_settings.get(Spectrum_generator_settings::calculate_observables))
+            ) {
+            @ModelName@_observables observables = calculate_observables(std::get<0>(models), qedqcd, physical_input, scales.pole_mass_scale);
+            slha_io.set_extra(std::get<0>(models), scales, observables);
+            if (!database_output_file.empty() && show_result) {
+               @ModelName@_database::to_database(
+                  database_output_file, std::get<0>(models), &qedqcd,
+                  &physical_input, &observables);
+            }
+         }
       }
-
       slha_io.write_to(slha_output_file);
-   }
-
-   if (!database_output_file.empty() && show_result) {
-      @ModelName@_database::to_database(
-         database_output_file, std::get<0>(models), &qedqcd,
-         &physical_input, &observables);
    }
 
    if (!spectrum_file.empty())

--- a/templates/run.cpp.in
+++ b/templates/run.cpp.in
@@ -86,6 +86,12 @@ int run_solver(flexiblesusy::@ModelName@_slha_io& slha_io,
    scales.pole_mass_scale = spectrum_generator.get_pole_mass_scale();
 
    @ModelName@_observables observables;
+   if (spectrum_generator_settings.get(Spectrum_generator_settings::calculate_observables)) {
+      if (spectrum_generator_settings.get(Spectrum_generator_settings::force_output) ||
+         !problems.have_problem()) {
+         observables = calculate_observables(std::get<0>(models), qedqcd, physical_input, scales.pole_mass_scale);
+      }
+   }
 
    const bool show_result = !problems.have_problem() ||
       spectrum_generator_settings.get(Spectrum_generator_settings::force_output);
@@ -98,14 +104,7 @@ int run_solver(flexiblesusy::@ModelName@_slha_io& slha_io,
             spectrum_generator_settings.get(
                Spectrum_generator_settings::force_positive_masses));
          slha_io.set_spectrum(models);
-         if (spectrum_generator_settings.get(Spectrum_generator_settings::force_output)
-            || (!problems.have_problem()
-                && spectrum_generator_settings.get(Spectrum_generator_settings::calculate_sm_masses)
-                && spectrum_generator_settings.get(Spectrum_generator_settings::calculate_bsm_masses)
-                && spectrum_generator_settings.get(Spectrum_generator_settings::calculate_observables))
-            ) {
-            observables = calculate_observables(std::get<0>(models), qedqcd, physical_input, scales.pole_mass_scale);
-         }
+         slha_io.set_extra(std::get<0>(models), scales, observables);
       }
       slha_io.write_to(slha_output_file);
    }

--- a/templates/run.cpp.in
+++ b/templates/run.cpp.in
@@ -85,6 +85,8 @@ int run_solver(flexiblesusy::@ModelName@_slha_io& slha_io,
    scales.LowScale  = spectrum_generator.get_low_scale();
    scales.pole_mass_scale = spectrum_generator.get_pole_mass_scale();
 
+   @ModelName@_observables observables;
+
    const bool show_result = !problems.have_problem() ||
       spectrum_generator_settings.get(Spectrum_generator_settings::force_output);
    // SLHA output
@@ -102,16 +104,16 @@ int run_solver(flexiblesusy::@ModelName@_slha_io& slha_io,
                 && spectrum_generator_settings.get(Spectrum_generator_settings::calculate_bsm_masses)
                 && spectrum_generator_settings.get(Spectrum_generator_settings::calculate_observables))
             ) {
-            @ModelName@_observables observables = calculate_observables(std::get<0>(models), qedqcd, physical_input, scales.pole_mass_scale);
-            slha_io.set_extra(std::get<0>(models), scales, observables);
-            if (!database_output_file.empty() && show_result) {
-               @ModelName@_database::to_database(
-                  database_output_file, std::get<0>(models), &qedqcd,
-                  &physical_input, &observables);
-            }
+            observables = calculate_observables(std::get<0>(models), qedqcd, physical_input, scales.pole_mass_scale);
          }
       }
       slha_io.write_to(slha_output_file);
+   }
+
+   if (!database_output_file.empty() && show_result) {
+      @ModelName@_database::to_database(
+         database_output_file, std::get<0>(models), &qedqcd,
+         &physical_input, &observables);
    }
 
    if (!spectrum_file.empty())


### PR DESCRIPTION
Now the observable block is not printed unless we calculate observables. This messes up with some tests.