### PR TITLE
fixed error in SMSU3 particle file

### DIFF
--- a/sarah/SMSU3/SMSU3.m
+++ b/sarah/SMSU3/SMSU3.m
@@ -130,4 +130,3 @@ DEFINITION[EWSB][Phases] = {
     {fR, PhaseFR}
 }; 
 
-

--- a/sarah/SMSU3/particles.m
+++ b/sarah/SMSU3/particles.m
@@ -81,6 +81,7 @@ ParticleDefinitions[GaugeES] = {
       {VWp,  { Description -> "W+ - Boson",
       			Goldstone -> Hp }},         
       {VCo2, { Description -> "F-Boson",
+               PDG -> {1000000},
                ElectricCharge -> 0 }},         
       {gP,   { Description -> "Photon Ghost"}},                                                   
       {gWp,  { Description -> "Positive W+ - Boson Ghost"}}, 


### PR DESCRIPTION
Dylan added a function that checks if PDG number list for particle agrees with the size of the multiplet. This uncovered what I believe is an error in `particle.m` for `SMSU3` model.