### PR TITLE
Fix multitple size getters without Goldstones

### DIFF
--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -683,6 +683,9 @@ GetDimension[sym_Symbol, states_:FlexibleSUSY`FSEigenstates] :=
 GetDimensionStartSkippingGoldstones[sym_[__]] :=
     GetDimensionStartSkippingGoldstones[sym];
 
+GetDimensionStartSkippingGoldstones[(SARAH`bar|Susyno`LieGroups`conj)[sym_]] :=
+    GetDimensionStartSkippingGoldstones[sym];
+
 GetDimensionStartSkippingGoldstones[sym_, goldstoneGhost_] :=
     Module[{goldstones, max = 1},
            goldstones = Transpose[goldstoneGhost][[2]];
@@ -704,6 +707,9 @@ GetDimensionStartSkippingSMGoldstones[sym_] :=
     GetDimensionStartSkippingGoldstones[sym, Cases[SARAH`GoldstoneGhost, {_?IsSMParticle, _}]];
 
 GetDimensionWithoutGoldstones[sym_[__], states_:FlexibleSUSY`FSEigenstates] :=
+    GetDimensionWithoutGoldstones[sym, states];
+
+GetDimensionWithoutGoldstones[(SARAH`bar|Susyno`LieGroups`conj)[sym_], states_:FlexibleSUSY`FSEigenstates] :=
     GetDimensionWithoutGoldstones[sym, states];
 
 GetDimensionWithoutGoldstones[sym_, states_:FlexibleSUSY`FSEigenstates] :=


### PR DESCRIPTION
Currently, in `MSSM` function `GetDimensionStartSkippingGoldstones` incorectly handles conjugations. Example
```mathematica
GetDimensionStartSkippingGoldstones[Hpm] = 2
GetDimensionStartSkippingGoldstones[conj[Hpm]] = 1
```
Similarly for `GetDimensionWithoutGoldstones` which gives
```mathematica
GetDimensionWithoutGoldstones[Hpm] = 1
GetDimensionWithoutGoldstones[conj[Hpm]] = 3
```
This fix makes those function give the same number with and without `conj`.