### PR TITLE
Reduce compile time by explicit template instantiations

### DIFF
--- a/src/linalg2.cpp
+++ b/src/linalg2.cpp
@@ -20,48 +20,34 @@
 
 namespace flexiblesusy {
 
-template
-void fs_diagonalize_hermitian(const Eigen::Matrix<double, 2, 2>&,
-                              Eigen::Array<double, 2, 1>&,
-                              Eigen::Matrix<double, 2, 2>&);
+#define INSTANTIATE_FS_HERMITIAN(N,Mtype,Ztype)                         \
+   template                                                             \
+   void fs_diagonalize_hermitian(const Eigen::Matrix<Mtype, N, N>&,     \
+                                 Eigen::Array<double, N, 1>&,           \
+                                 Eigen::Matrix<Ztype, N, N>&);
 
-template
-void fs_diagonalize_hermitian(const Eigen::Matrix<double, 3, 3>&,
-                              Eigen::Array<double, 3, 1>&,
-                              Eigen::Matrix<double, 3, 3>&);
+#define INSTANTIATE_FS_SYMMETRIC(N,Mtype,Ztype)                         \
+   template                                                             \
+   void fs_diagonalize_symmetric(const Eigen::Matrix<Mtype, N, N>&,     \
+                                 Eigen::Array<double, N, 1>&,           \
+                                 Eigen::Matrix<Ztype, N, N>&);
 
-template
-void fs_diagonalize_hermitian(const Eigen::Matrix<double, 6, 6>&,
-                              Eigen::Array<double, 6, 1>&,
-                              Eigen::Matrix<double, 6, 6>&);
+#define INSTANTIATE_FS_SVD(N,Mtype,Ztype)                               \
+   template                                                             \
+   void fs_svd(const Eigen::Matrix<Mtype, N, N>&,                       \
+               Eigen::Array<double, N, 1>&,                             \
+               Eigen::Matrix<Ztype, N, N>&,                             \
+               Eigen::Matrix<Ztype, N, N>&);
 
-template
-void fs_diagonalize_symmetric(const Eigen::Matrix<double, 4, 4>&,
-                              Eigen::Array<double, 4, 1>&,
-                              Eigen::Matrix<std::complex<double>, 4, 4>&);
+INSTANTIATE_FS_HERMITIAN(2,double,double)
+INSTANTIATE_FS_HERMITIAN(3,double,double)
+INSTANTIATE_FS_HERMITIAN(6,double,double)
 
-template
-void fs_svd(const Eigen::Matrix<double, 2, 2>&,
-            Eigen::Array<double, 2, 1>&,
-            Eigen::Matrix<double, 2, 2>&,
-            Eigen::Matrix<double, 2, 2>&);
+INSTANTIATE_FS_SYMMETRIC(4,double,std::complex<double>)
 
-template
-void fs_svd(const Eigen::Matrix<double, 2, 2>&,
-            Eigen::Array<double, 2, 1>&,
-            Eigen::Matrix<std::complex<double>, 2, 2>&,
-            Eigen::Matrix<std::complex<double>, 2, 2>&);
-
-template
-void fs_svd(const Eigen::Matrix<double, 3, 3>&,
-            Eigen::Array<double, 3, 1>&,
-            Eigen::Matrix<double, 3, 3>&,
-            Eigen::Matrix<double, 3, 3>&);
-
-template
-void fs_svd(const Eigen::Matrix<double, 3, 3>&,
-            Eigen::Array<double, 3, 1>&,
-            Eigen::Matrix<std::complex<double>, 3, 3>&,
-            Eigen::Matrix<std::complex<double>, 3, 3>&);
+INSTANTIATE_FS_SVD(2,double,double)
+INSTANTIATE_FS_SVD(2,double,std::complex<double>)
+INSTANTIATE_FS_SVD(3,double,double)
+INSTANTIATE_FS_SVD(3,double,std::complex<double>)
 
 } // namespace flexiblesusy

--- a/src/linalg2.cpp
+++ b/src/linalg2.cpp
@@ -1,0 +1,67 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+#include "linalg2.hpp"
+
+namespace flexiblesusy {
+
+template
+void fs_diagonalize_hermitian(const Eigen::Matrix<double, 2, 2>&,
+                              Eigen::Array<double, 2, 1>&,
+                              Eigen::Matrix<double, 2, 2>&);
+
+template
+void fs_diagonalize_hermitian(const Eigen::Matrix<double, 3, 3>&,
+                              Eigen::Array<double, 3, 1>&,
+                              Eigen::Matrix<double, 3, 3>&);
+
+template
+void fs_diagonalize_hermitian(const Eigen::Matrix<double, 6, 6>&,
+                              Eigen::Array<double, 6, 1>&,
+                              Eigen::Matrix<double, 6, 6>&);
+
+template
+void fs_diagonalize_symmetric(const Eigen::Matrix<double, 4, 4>&,
+                              Eigen::Array<double, 4, 1>&,
+                              Eigen::Matrix<std::complex<double>, 4, 4>&);
+
+template
+void fs_svd(const Eigen::Matrix<double, 2, 2>&,
+            Eigen::Array<double, 2, 1>&,
+            Eigen::Matrix<double, 2, 2>&,
+            Eigen::Matrix<double, 2, 2>&);
+
+template
+void fs_svd(const Eigen::Matrix<double, 2, 2>&,
+            Eigen::Array<double, 2, 1>&,
+            Eigen::Matrix<std::complex<double>, 2, 2>&,
+            Eigen::Matrix<std::complex<double>, 2, 2>&);
+
+template
+void fs_svd(const Eigen::Matrix<double, 3, 3>&,
+            Eigen::Array<double, 3, 1>&,
+            Eigen::Matrix<double, 3, 3>&,
+            Eigen::Matrix<double, 3, 3>&);
+
+template
+void fs_svd(const Eigen::Matrix<double, 3, 3>&,
+            Eigen::Array<double, 3, 1>&,
+            Eigen::Matrix<std::complex<double>, 3, 3>&,
+            Eigen::Matrix<std::complex<double>, 3, 3>&);
+
+} // namespace flexiblesusy

--- a/src/linalg2.hpp
+++ b/src/linalg2.hpp
@@ -1481,6 +1481,52 @@ void fs_diagonalize_hermitian
     fs_diagonalize_hermitian_errbd(m, w, 0, &w_errbd);
 }
 
+// explicit template function instantiations ///////////////////////////
+
+extern template
+void fs_diagonalize_hermitian(const Eigen::Matrix<double, 2, 2>&,
+                              Eigen::Array<double, 2, 1>&,
+                              Eigen::Matrix<double, 2, 2>&);
+
+extern template
+void fs_diagonalize_hermitian(const Eigen::Matrix<double, 3, 3>&,
+                              Eigen::Array<double, 3, 1>&,
+                              Eigen::Matrix<double, 3, 3>&);
+
+extern template
+void fs_diagonalize_hermitian(const Eigen::Matrix<double, 6, 6>&,
+                              Eigen::Array<double, 6, 1>&,
+                              Eigen::Matrix<double, 6, 6>&);
+
+extern template
+void fs_diagonalize_symmetric(const Eigen::Matrix<double, 4, 4>&,
+                              Eigen::Array<double, 4, 1>&,
+                              Eigen::Matrix<std::complex<double>, 4, 4>&);
+
+extern template
+void fs_svd(const Eigen::Matrix<double, 2, 2>&,
+            Eigen::Array<double, 2, 1>&,
+            Eigen::Matrix<double, 2, 2>&,
+            Eigen::Matrix<double, 2, 2>&);
+
+extern template
+void fs_svd(const Eigen::Matrix<double, 2, 2>&,
+            Eigen::Array<double, 2, 1>&,
+            Eigen::Matrix<std::complex<double>, 2, 2>&,
+            Eigen::Matrix<std::complex<double>, 2, 2>&);
+
+extern template
+void fs_svd(const Eigen::Matrix<double, 3, 3>&,
+            Eigen::Array<double, 3, 1>&,
+            Eigen::Matrix<double, 3, 3>&,
+            Eigen::Matrix<double, 3, 3>&);
+
+extern template
+void fs_svd(const Eigen::Matrix<double, 3, 3>&,
+            Eigen::Array<double, 3, 1>&,
+            Eigen::Matrix<std::complex<double>, 3, 3>&,
+            Eigen::Matrix<std::complex<double>, 3, 3>&);
+
 } // namespace flexiblesusy
 
 #endif // LINALG2_H

--- a/src/linalg2.hpp
+++ b/src/linalg2.hpp
@@ -1483,49 +1483,39 @@ void fs_diagonalize_hermitian
 
 // explicit template function instantiations ///////////////////////////
 
-extern template
-void fs_diagonalize_hermitian(const Eigen::Matrix<double, 2, 2>&,
-                              Eigen::Array<double, 2, 1>&,
-                              Eigen::Matrix<double, 2, 2>&);
+#define INSTANTIATE_FS_HERMITIAN(N,Mtype,Ztype)                         \
+   extern template                                                      \
+   void fs_diagonalize_hermitian(const Eigen::Matrix<Mtype, N, N>&,     \
+                                 Eigen::Array<double, N, 1>&,           \
+                                 Eigen::Matrix<Ztype, N, N>&);
 
-extern template
-void fs_diagonalize_hermitian(const Eigen::Matrix<double, 3, 3>&,
-                              Eigen::Array<double, 3, 1>&,
-                              Eigen::Matrix<double, 3, 3>&);
+#define INSTANTIATE_FS_SYMMETRIC(N,Mtype,Ztype)                         \
+   extern template                                                      \
+   void fs_diagonalize_symmetric(const Eigen::Matrix<Mtype, N, N>&,     \
+                                 Eigen::Array<double, N, 1>&,           \
+                                 Eigen::Matrix<Ztype, N, N>&);
 
-extern template
-void fs_diagonalize_hermitian(const Eigen::Matrix<double, 6, 6>&,
-                              Eigen::Array<double, 6, 1>&,
-                              Eigen::Matrix<double, 6, 6>&);
+#define INSTANTIATE_FS_SVD(N,Mtype,Ztype)                               \
+   extern template                                                      \
+   void fs_svd(const Eigen::Matrix<Mtype, N, N>&,                       \
+               Eigen::Array<double, N, 1>&,                             \
+               Eigen::Matrix<Ztype, N, N>&,                             \
+               Eigen::Matrix<Ztype, N, N>&);
 
-extern template
-void fs_diagonalize_symmetric(const Eigen::Matrix<double, 4, 4>&,
-                              Eigen::Array<double, 4, 1>&,
-                              Eigen::Matrix<std::complex<double>, 4, 4>&);
+INSTANTIATE_FS_HERMITIAN(2,double,double)
+INSTANTIATE_FS_HERMITIAN(3,double,double)
+INSTANTIATE_FS_HERMITIAN(6,double,double)
 
-extern template
-void fs_svd(const Eigen::Matrix<double, 2, 2>&,
-            Eigen::Array<double, 2, 1>&,
-            Eigen::Matrix<double, 2, 2>&,
-            Eigen::Matrix<double, 2, 2>&);
+INSTANTIATE_FS_SYMMETRIC(4,double,std::complex<double>)
 
-extern template
-void fs_svd(const Eigen::Matrix<double, 2, 2>&,
-            Eigen::Array<double, 2, 1>&,
-            Eigen::Matrix<std::complex<double>, 2, 2>&,
-            Eigen::Matrix<std::complex<double>, 2, 2>&);
+INSTANTIATE_FS_SVD(2,double,double)
+INSTANTIATE_FS_SVD(2,double,std::complex<double>)
+INSTANTIATE_FS_SVD(3,double,double)
+INSTANTIATE_FS_SVD(3,double,std::complex<double>)
 
-extern template
-void fs_svd(const Eigen::Matrix<double, 3, 3>&,
-            Eigen::Array<double, 3, 1>&,
-            Eigen::Matrix<double, 3, 3>&,
-            Eigen::Matrix<double, 3, 3>&);
-
-extern template
-void fs_svd(const Eigen::Matrix<double, 3, 3>&,
-            Eigen::Array<double, 3, 1>&,
-            Eigen::Matrix<std::complex<double>, 3, 3>&,
-            Eigen::Matrix<std::complex<double>, 3, 3>&);
+#undef INSTANTIATE_FS_HERMITIAN
+#undef INSTANTIATE_FS_SYMMETRIC
+#undef INSTANTIATE_FS_SVD
 
 } // namespace flexiblesusy
 

--- a/src/module.mk
+++ b/src/module.mk
@@ -21,6 +21,7 @@ LIBFLEXI_SRC := \
 		$(DIR)/gsl_vector.cpp \
 		$(DIR)/logger.cpp \
 		$(DIR)/lowe.cpp \
+		$(DIR)/linalg2.cpp \
 		$(DIR)/sfermions.cpp \
 		$(DIR)/mixings.cpp \
 		$(DIR)/numerics.cpp \


### PR DESCRIPTION
I found that the compilation time of `*_mass_eigenstates.cpp` could be reduced by pre-instantiation of often used diagonalization routines.

@wkotlarski if you find the time at some point, would you mind checking if this improves the compile time on your machine?