### PR TITLE
less messy sarah output to terminal

### DIFF
--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -3759,7 +3759,7 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
             semiAnalyticBCs, semiAnalyticSolns,
             semiAnalyticHighScaleFiles, semiAnalyticSUSYScaleFiles, semiAnalyticLowScaleFiles,
             semiAnalyticSolnsOutputFile, semiAnalyticEWSBSubstitutions = {}, semiAnalyticInputScale = ""},
-           On[FileByteCount::fdnfnd];
+           TerminalFormatting`onSuppressedMessages[];
 
            Utils`PrintHeadline["Starting FlexibleSUSY"];
            FSDebugOutput["meta code directory: ", $flexiblesusyMetaDir];

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -3759,7 +3759,6 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
             semiAnalyticBCs, semiAnalyticSolns,
             semiAnalyticHighScaleFiles, semiAnalyticSUSYScaleFiles, semiAnalyticLowScaleFiles,
             semiAnalyticSolnsOutputFile, semiAnalyticEWSBSubstitutions = {}, semiAnalyticInputScale = ""},
-           TerminalFormatting`onSuppressedMessages[];
 
            Utils`PrintHeadline["Starting FlexibleSUSY"];
            FSDebugOutput["meta code directory: ", $flexiblesusyMetaDir];

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -46,6 +46,7 @@ BeginPackage["FlexibleSUSY`",
               "References`",
               "SemiAnalytic`",
               "ThreeLoopSM`",
+              "TerminalFormatting`",
               "ThreeLoopMSSM`",
               "Observables`",
               "CXXDiagrams`",
@@ -3758,6 +3759,7 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
             semiAnalyticBCs, semiAnalyticSolns,
             semiAnalyticHighScaleFiles, semiAnalyticSUSYScaleFiles, semiAnalyticLowScaleFiles,
             semiAnalyticSolnsOutputFile, semiAnalyticEWSBSubstitutions = {}, semiAnalyticInputScale = ""},
+           On[FileByteCount::fdnfnd];
 
            Utils`PrintHeadline["Starting FlexibleSUSY"];
            FSDebugOutput["meta code directory: ", $flexiblesusyMetaDir];

--- a/meta/TerminalFormatting.m
+++ b/meta/TerminalFormatting.m
@@ -1,0 +1,127 @@
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+BeginPackage["TerminalFormatting`", {"SARAH`"}];
+
+Off[FileByteCount::fdnfnd];
+
+Begin["`internal`"];
+
+showSingle[] := "done";
+
+showTerms[info:_Integer, add:_Integer:3, pre:_String:""] :=
+   "\033["<>ToString[Length@IntegerDigits@#+add]<>"D"<>
+   pre<>"("<>ToString@#<>" terms"&[info];
+
+If[!$Notebooks,
+
+DynamicCheckModelFiles /: Dynamic[DynamicCheckModelFiles] := showSingle[];
+DynamicInitGaugeG /: Dynamic[DynamicInitGaugeG] := showSingle[];
+DynamicInitFields /: Dynamic[DynamicInitFields] := showSingle[];
+DynamicInitMisc /: Dynamic[DynamicInitMisc] := showSingle[];
+DynamicCheckAnomalies /: Dynamic[DynamicCheckAnomalies] := showSingle[];
+
+
+DynamicTermSuperpotentialNr /: Dynamic[DynamicTermSuperpotentialNr] := "";
+DynamicTermSuperpotential /: Dynamic[DynamicTermSuperpotential] :=
+   showTerms[Length@SuperPotential, 2];
+
+DynamicCheckingCCSup /: Dynamic[DynamicCheckingCCSup] := showSingle[];
+
+DynamicFTermNr /: Dynamic[DynamicFTermNr] := "";
+DynamicFTermName /: Dynamic[DynamicFTermName] := showTerms@Length@SFieldList;
+
+DynamicMatterNr /: Dynamic[DynamicMatterNr] := "";
+DynamicMatterName /: Dynamic[DynamicMatterName] := showTerms[Length[SFieldList]^2];
+
+DynamicSoftTermsCurrent /: Dynamic[DynamicSoftTermsCurrent] := showSingle[];
+
+DynamicDGnr /: Dynamic[DynamicDGnr] := "";
+DynamicDGname /: Dynamic[DynamicDGname] := showTerms@Length@Gauge;
+
+DynamicKineticScalarNr /: Dynamic[DynamicKineticScalarNr] := "";
+DynamicKineticScalarName /: Dynamic[DynamicKineticScalarName] := showTerms@AnzahlChiral;
+
+DynamicKineticFermionNr /: Dynamic[DynamicKineticFermionNr] := "";
+DynamicKineticFermionName /: Dynamic[DynamicKineticFermionName] := showTerms@AnzahlChiral;
+
+DynamicDTermsNr /: Dynamic[DynamicDTermsNr] := "";
+DynamicDTermsName /: Dynamic[DynamicDTermsName] := showTerms[AnzahlGauge*AnzahlChiral];
+
+DynamicGauginoMatter /: Dynamic[DynamicGauginoMatter] := "";
+DynamicGauginoMatterName /: Dynamic[DynamicGauginoMatterName] := showTerms[AnzahlGauge*AnzahlChiral];
+
+DynamicGauginoVector /: Dynamic[DynamicGauginoVector] := "";
+DynamicGauginoVectorName /: Dynamic[DynamicGauginoVectorName] := showTerms@AnzahlGauge;
+
+DynamicVectorNr /: Dynamic[DynamicVectorNr] := "";
+DynamicVectorName /: Dynamic[DynamicVectorName] := showTerms@AnzahlGauge;
+
+DynamicGaugeTNr /: Dynamic[DynamicGaugeTNr] := "";
+DynamicGaugeTName /: Dynamic[DynamicGaugeTName] := showTerms[AnzahlChiral+Length@Gauge];
+
+DynamicStatusAddTerms /: Dynamic[DynamicStatusAddTerms[__]] := "";
+
+DynamicRotateLag /: Dynamic[DynamicRotateLag[_]] := "14";
+
+DynamicGFnr /: Dynamic[DynamicGFnr[_]] := "";
+DynamicGFname /: Dynamic[DynamicGFname[_]] := showTerms@Length@gb;
+
+DynamicSaveInfo /: Dynamic[DynamicSaveInfo[_]] := showSingle[];
+
+DynamicUGT /: Dynamic[DynamicUGT[_]] := "";
+DynamicUGTname /: Dynamic[DynamicUGTname[_]] := showTerms[Length@Particles@Current];
+
+DynamicMMgaugeNr /: Dynamic[DynamicMMgaugeNr[_]] := "";
+DynamicMMgaugeName /: Dynamic[DynamicMMgaugeName[_]] :=
+   showTerms[ Length[DEFINITION[NameOfStates[[rotNr]]][GaugeSector]], 2];
+
+nameMassQ = True;
+DynamicNrMass /: Dynamic[DynamicNrMass[_]] := "";
+DynamicNameMass /: Dynamic[DynamicNameMass[_]] :=
+   showTerms[Length@If[NameMassQ,NameMassQ=False;mixBasis,NameMassQ=True;mixBasisNoFV], 5, ": "];
+
+showProgress[ind:_String:"      "] := "\r\033[K"<>ind<>"(in progress";
+
+DynamicCalcTreeMasses /: Dynamic[DynamicCalcTreeMasses] := "for all eigenstates";
+DynamicSpectrumFileInput /: Dynamic[DynamicSpectrumFileInput] := showSingle[];
+
+DynamicProgressRGE /: Dynamic[DynamicProgressRGE[_]] = "";
+DynamicCoupProgess /: Dynamic[DynamicCoupProgess[trace]] = showProgress["   "]<>")";
+DynamicCoupProgess /: Dynamic[DynamicCoupProgess[_]] = showProgress["   "];
+
+progressNrGV /: Dynamic[progressNrGV[_]] := "";
+progressCurrentGV /: Dynamic[progressCurrentGV[_]] := showProgress[];
+
+DynamicOneLoopNameMM /: Dynamic[DynamicOneLoopNameMM] := "";
+DynamicOneLoopNrMM /: Dynamic[DynamicOneLoopNrMM] := Length@basis;
+
+DynamicOneLoopTadName /: Dynamic[DynamicOneLoopTadName] := "";
+DynamicOneLoopTadNr /: Dynamic[DynamicOneLoopTadNr] := "";
+DynamicOneLoopTadNrAll /: Dynamic[DynamicOneLoopTadNrAll] := showProgress[];
+
+DynamicOneLoopNameNM /: Dynamic[DynamicOneLoopNameNM] := "";
+DynamicOneLoopNrNM /: Dynamic[DynamicOneLoopNrNM] := Length@listNotMixedMasses;
+]; (* !$Notebooks *)
+
+End[];
+EndPackage[];

--- a/meta/TerminalFormatting.m
+++ b/meta/TerminalFormatting.m
@@ -21,20 +21,8 @@
 *)
 
 BeginPackage["TerminalFormatting`", {"SARAH`", "Utils`"}];
-
-Off[FileByteCount::fdnfnd];
-
-onSuppressedMessages::usage =
-"Turns on corresponding warning messages";
-onFileByteCount[] := On[FileByteCount::fdnfnd];
-onFileByteCount // Utils`MakeUnknownInputDefinition;
-onFileByteCount ~ SetAttributes ~ {Protected, Locked};
-
 Begin["`internal`"];
-
-showSingle[] := "done";
-showSingle // Utils`MakeUnknownInputDefinition;
-showSingle ~ SetAttributes ~ {Protected, Locked};
+If[!$Notebooks,
 
 showTerms[info:_Integer, add:_Integer:3, pre:_String:""] :=
    "\033["<>ToString[Length@IntegerDigits@#+add]<>"D"<>
@@ -46,93 +34,51 @@ showProgress[ind:_String:"      "] := "\r\033[K"<>ind<>"(in progress";
 showProgress // Utils`MakeUnknownInputDefinition;
 showProgress ~ SetAttributes ~ {Protected, Locked};
 
-If[!$Notebooks,
-
-DynamicCheckModelFiles /: Dynamic[DynamicCheckModelFiles] := showSingle[];
-DynamicInitGaugeG /: Dynamic[DynamicInitGaugeG] := showSingle[];
-DynamicInitFields /: Dynamic[DynamicInitFields] := showSingle[];
-DynamicInitMisc /: Dynamic[DynamicInitMisc] := showSingle[];
-DynamicCheckAnomalies /: Dynamic[DynamicCheckAnomalies] := showSingle[];
-
-DynamicTermSuperpotentialNr /: Dynamic[DynamicTermSuperpotentialNr] := "";
-DynamicTermSuperpotential /: Dynamic[DynamicTermSuperpotential] :=
-   showTerms[Length@SuperPotential, 2];
-
-DynamicCheckingCCSup /: Dynamic[DynamicCheckingCCSup] := showSingle[];
-
-DynamicFTermNr /: Dynamic[DynamicFTermNr] := "";
-DynamicFTermName /: Dynamic[DynamicFTermName] := showTerms@Length@SFieldList;
-
-DynamicMatterNr /: Dynamic[DynamicMatterNr] := "";
-DynamicMatterName /: Dynamic[DynamicMatterName] := showTerms[Length[SFieldList]^2];
-
-DynamicSoftTermsCurrent /: Dynamic[DynamicSoftTermsCurrent] := showSingle[];
-
-DynamicDGnr /: Dynamic[DynamicDGnr] := "";
-DynamicDGname /: Dynamic[DynamicDGname] := showTerms@Length@Gauge;
-
-DynamicKineticScalarNr /: Dynamic[DynamicKineticScalarNr] := "";
-DynamicKineticScalarName /: Dynamic[DynamicKineticScalarName] := showTerms@AnzahlChiral;
-
-DynamicKineticFermionNr /: Dynamic[DynamicKineticFermionNr] := "";
-DynamicKineticFermionName /: Dynamic[DynamicKineticFermionName] := showTerms@AnzahlChiral;
-
-DynamicDTermsNr /: Dynamic[DynamicDTermsNr] := "";
-DynamicDTermsName /: Dynamic[DynamicDTermsName] := showTerms[AnzahlGauge*AnzahlChiral];
-
-DynamicGauginoMatter /: Dynamic[DynamicGauginoMatter] := "";
-DynamicGauginoMatterName /: Dynamic[DynamicGauginoMatterName] := showTerms[AnzahlGauge*AnzahlChiral];
-
-DynamicGauginoVector /: Dynamic[DynamicGauginoVector] := "";
-DynamicGauginoVectorName /: Dynamic[DynamicGauginoVectorName] := showTerms@AnzahlGauge;
-
-DynamicVectorNr /: Dynamic[DynamicVectorNr] := "";
-DynamicVectorName /: Dynamic[DynamicVectorName] := showTerms@AnzahlGauge;
-
-DynamicGaugeTNr /: Dynamic[DynamicGaugeTNr] := "";
-DynamicGaugeTName /: Dynamic[DynamicGaugeTName] := showTerms[AnzahlChiral+Length@Gauge];
-
-DynamicStatusAddTerms /: Dynamic[DynamicStatusAddTerms[__]] := "";
-
-DynamicRotateLag /: Dynamic[DynamicRotateLag[_]] := "14";
-
-DynamicGFnr /: Dynamic[DynamicGFnr[_]] := "";
-DynamicGFname /: Dynamic[DynamicGFname[_]] := showTerms@Length@gb;
-
-DynamicSaveInfo /: Dynamic[DynamicSaveInfo[_]] := showSingle[];
-
-DynamicUGT /: Dynamic[DynamicUGT[_]] := "";
-DynamicUGTname /: Dynamic[DynamicUGTname[_]] := showTerms[Length@Particles@Current];
-
-DynamicMMgaugeNr /: Dynamic[DynamicMMgaugeNr[_]] := "";
-DynamicMMgaugeName /: Dynamic[DynamicMMgaugeName[_]] :=
-   showTerms[ Length[DEFINITION[NameOfStates[[rotNr]]][GaugeSector]], 2];
+define[s:_Symbol] := TagSetDelayed[s, Dynamic@s, ""];
+define[(s:_Symbol)["done"]] := TagSetDelayed[s, Dynamic@s, "done"];
+define[(s:_Symbol)[p:_]] := TagSetDelayed[s, Dynamic@s@p, ""];
+define[RuleDelayed[s:_Symbol, what:_ ]] := TagSetDelayed[s, Dynamic@s, what];
+define[RuleDelayed[(s:_Symbol)[p:_], what:_ ]] := TagSetDelayed[s, Dynamic@s@p, what];
+define // Utils`MakeUnknownInputDefinition;
+define ~ SetAttributes ~ {Protected, Locked};
 
 nameMassQ = True;
-DynamicNrMass /: Dynamic[DynamicNrMass[_]] := "";
-DynamicNameMass /: Dynamic[DynamicNameMass[_]] :=
-   showTerms[Length@If[nameMassQ,nameMassQ=False;mixBasis,nameMassQ=True;mixBasisNoFV], 5, ": "];
 
-DynamicCalcTreeMasses /: Dynamic[DynamicCalcTreeMasses] := "for all eigenstates";
-DynamicSpectrumFileInput /: Dynamic[DynamicSpectrumFileInput] := showSingle[];
+define /@ {
+   DynamicTermSuperpotentialNr, DynamicFTermNr, DynamicDTermsNr,
+   DynamicMatterNr, DynamicDGnr, DynamicKineticScalarNr, DynamicKineticFermionNr,
+   DynamicGauginoMatter, DynamicGauginoVector, DynamicVectorNr, DynamicGaugeTNr,
+   DynamicOneLoopNrMM, DynamicOneLoopTadName, DynamicOneLoopTadNr, DynamicOneLoopNrNM,
+   DynamicCheckModelFiles["done"], DynamicInitGaugeG["done"], DynamicInitFields["done"],
+   DynamicInitMisc["done"], DynamicCheckAnomalies["done"], DynamicCheckingCCSup["done"],
+   DynamicSoftTermsCurrent["done"], DynamicSpectrumFileInput["done"],
+   DynamicCalcTreeMasses :> "for all eigenstates",
+   DynamicStatusAddTerms[_], DynamicGFnr[_], DynamicUGT[_], DynamicStatusAddTerms[_],
+   DynamicMMgaugeNr[_], DynamicNrMass[_], DynamicProgressRGE[_], progressNrGV[_],
+   DynamicSaveInfo[_] :> "done", DynamicRotateLag[_] :> "14",
+   DynamicTermSuperpotential :> showTerms[Length@SuperPotential, 2],
+   DynamicFTermName :> showTerms@Length@SFieldList,
+   DynamicMatterName :> showTerms[Length[SFieldList]^2],
+   DynamicDGname :> showTerms@Length@Gauge,
+   DynamicKineticScalarName :> showTerms@AnzahlChiral,
+   DynamicKineticFermionName :> showTerms@AnzahlChiral,
+   DynamicDTermsName :> showTerms[AnzahlGauge*AnzahlChiral],
+   DynamicGauginoMatterName :> showTerms[AnzahlGauge*AnzahlChiral],
+   DynamicGauginoVectorName :> showTerms@AnzahlGauge,
+   DynamicVectorName :> showTerms@AnzahlGauge,
+   DynamicGaugeTName :> showTerms[AnzahlChiral+Length@Gauge],
+   DynamicOneLoopNrMM :> Length@basis,
+   DynamicOneLoopTadNrAll :> showProgress[],
+   DynamicOneLoopNrNM :> Length@listNotMixedMasses,
+   DynamicGFname[_] :> showTerms@Length@gb,
+   DynamicUGTname[_] :> showTerms@Length@Particles@Current,
+   DynamicCoupProgess@trace :> showProgress["   "]<>")",
+   DynamicCoupProgess[_] :> showProgress["   "],
+   progressCurrentGV[_] :> showProgress[],
+   DynamicMMgaugeName[_] :> showTerms[ Length[DEFINITION[NameOfStates[[rotNr]]][GaugeSector]], 2],
+   DynamicNameMass[_] :> showTerms[Length@If[nameMassQ,nameMassQ=False;mixBasis,nameMassQ=True;mixBasisNoFV], 5, ": "]
+}
 
-DynamicProgressRGE /: Dynamic[DynamicProgressRGE[_]] = "";
-DynamicCoupProgess /: Dynamic[DynamicCoupProgess[trace]] = showProgress["   "]<>")";
-DynamicCoupProgess /: Dynamic[DynamicCoupProgess[_]] = showProgress["   "];
-
-progressNrGV /: Dynamic[progressNrGV[_]] := "";
-progressCurrentGV /: Dynamic[progressCurrentGV[_]] := showProgress[];
-
-DynamicOneLoopNameMM /: Dynamic[DynamicOneLoopNameMM] := "";
-DynamicOneLoopNrMM /: Dynamic[DynamicOneLoopNrMM] := Length@basis;
-
-DynamicOneLoopTadName /: Dynamic[DynamicOneLoopTadName] := "";
-DynamicOneLoopTadNr /: Dynamic[DynamicOneLoopTadNr] := "";
-DynamicOneLoopTadNrAll /: Dynamic[DynamicOneLoopTadNrAll] := showProgress[];
-
-DynamicOneLoopNameNM /: Dynamic[DynamicOneLoopNameNM] := "";
-DynamicOneLoopNrNM /: Dynamic[DynamicOneLoopNrNM] := Length@listNotMixedMasses;
 ]; (* !$Notebooks *)
-
 End[];
 EndPackage[];

--- a/meta/TerminalFormatting.m
+++ b/meta/TerminalFormatting.m
@@ -35,7 +35,6 @@ showProgress // Utils`MakeUnknownInputDefinition;
 showProgress ~ SetAttributes ~ {Protected, Locked};
 
 define[s:_Symbol] := TagSetDelayed[s, Dynamic@s, ""];
-define[(s:_Symbol)["done"]] := TagSetDelayed[s, Dynamic@s, "done"];
 define[(s:_Symbol)[p:_]] := TagSetDelayed[s, Dynamic@s@p, ""];
 define[RuleDelayed[s:_Symbol, what:_ ]] := TagSetDelayed[s, Dynamic@s, what];
 define[RuleDelayed[(s:_Symbol)[p:_], what:_ ]] := TagSetDelayed[s, Dynamic@s@p, what];
@@ -49,9 +48,9 @@ define /@ {
    DynamicMatterNr, DynamicDGnr, DynamicKineticScalarNr, DynamicKineticFermionNr,
    DynamicGauginoMatter, DynamicGauginoVector, DynamicVectorNr, DynamicGaugeTNr,
    DynamicOneLoopNrMM, DynamicOneLoopTadName, DynamicOneLoopTadNr, DynamicOneLoopNrNM,
-   DynamicCheckModelFiles["done"], DynamicInitGaugeG["done"], DynamicInitFields["done"],
-   DynamicInitMisc["done"], DynamicCheckAnomalies["done"], DynamicCheckingCCSup["done"],
-   DynamicSoftTermsCurrent["done"], DynamicSpectrumFileInput["done"],
+   DynamicCheckModelFiles :> "done", DynamicInitGaugeG :> "done", DynamicInitFields :> "done",
+   DynamicInitMisc :> "done", DynamicCheckAnomalies :> "done", DynamicCheckingCCSup :> "done",
+   DynamicSoftTermsCurrent :> "done", DynamicSpectrumFileInput :> "done",
    DynamicCalcTreeMasses :> "for all eigenstates",
    DynamicStatusAddTerms[_], DynamicGFnr[_], DynamicUGT[_], DynamicStatusAddTerms[_],
    DynamicMMgaugeNr[_], DynamicNrMass[_], DynamicProgressRGE[_], progressNrGV[_],

--- a/meta/TerminalFormatting.m
+++ b/meta/TerminalFormatting.m
@@ -20,17 +20,31 @@
 
 *)
 
-BeginPackage["TerminalFormatting`", {"SARAH`"}];
+BeginPackage["TerminalFormatting`", {"SARAH`", "Utils`"}];
 
 Off[FileByteCount::fdnfnd];
+
+onSuppressedMessages::usage =
+"Turns on corresponding warning messages";
+onFileByteCount[] := On[FileByteCount::fdnfnd];
+onFileByteCount // Utils`MakeUnknownInputDefinition;
+onFileByteCount ~ SetAttributes ~ {Protected, Locked};
 
 Begin["`internal`"];
 
 showSingle[] := "done";
+showSingle // Utils`MakeUnknownInputDefinition;
+showSingle ~ SetAttributes ~ {Protected, Locked};
 
 showTerms[info:_Integer, add:_Integer:3, pre:_String:""] :=
    "\033["<>ToString[Length@IntegerDigits@#+add]<>"D"<>
    pre<>"("<>ToString@#<>" terms"&[info];
+showTerms // Utils`MakeUnknownInputDefinition;
+showTerms ~ SetAttributes ~ {Protected, Locked};
+
+showProgress[ind:_String:"      "] := "\r\033[K"<>ind<>"(in progress";
+showProgress // Utils`MakeUnknownInputDefinition;
+showProgress ~ SetAttributes ~ {Protected, Locked};
 
 If[!$Notebooks,
 
@@ -39,7 +53,6 @@ DynamicInitGaugeG /: Dynamic[DynamicInitGaugeG] := showSingle[];
 DynamicInitFields /: Dynamic[DynamicInitFields] := showSingle[];
 DynamicInitMisc /: Dynamic[DynamicInitMisc] := showSingle[];
 DynamicCheckAnomalies /: Dynamic[DynamicCheckAnomalies] := showSingle[];
-
 
 DynamicTermSuperpotentialNr /: Dynamic[DynamicTermSuperpotentialNr] := "";
 DynamicTermSuperpotential /: Dynamic[DynamicTermSuperpotential] :=
@@ -98,9 +111,7 @@ DynamicMMgaugeName /: Dynamic[DynamicMMgaugeName[_]] :=
 nameMassQ = True;
 DynamicNrMass /: Dynamic[DynamicNrMass[_]] := "";
 DynamicNameMass /: Dynamic[DynamicNameMass[_]] :=
-   showTerms[Length@If[NameMassQ,NameMassQ=False;mixBasis,NameMassQ=True;mixBasisNoFV], 5, ": "];
-
-showProgress[ind:_String:"      "] := "\r\033[K"<>ind<>"(in progress";
+   showTerms[Length@If[nameMassQ,nameMassQ=False;mixBasis,nameMassQ=True;mixBasisNoFV], 5, ": "];
 
 DynamicCalcTreeMasses /: Dynamic[DynamicCalcTreeMasses] := "for all eigenstates";
 DynamicSpectrumFileInput /: Dynamic[DynamicSpectrumFileInput] := showSingle[];

--- a/meta/module.mk
+++ b/meta/module.mk
@@ -98,6 +98,7 @@ META_SRC     := \
 		$(DIR)/SemiAnalytic.m \
 		$(DIR)/TestSuite.m \
 		$(DIR)/TextFormatting.m \
+		$(DIR)/TerminalFormatting.m \
 		$(DIR)/ThreeLoopMSSM.m \
 		$(DIR)/ThreeLoopQCD.m \
 		$(DIR)/ThreeLoopSM.m \


### PR DESCRIPTION
Allows to have cleaner terminal output of `SARAH`.

In this package some `Dynamic` were upvalued, so that inside terminal there is no "broken" output from `SARAH`.