### PR TITLE
fix: error when KernelObject is not represented in FullForm.

### DIFF
--- a/meta/NPointFunctions.m
+++ b/meta/NPointFunctions.m
@@ -842,7 +842,7 @@ CachedNPointFunction ~ SetAttributes ~ {Locked,Protected};
 
 GenerateFAModelFileOnKernel::usage=
 "@brief Generate the FeynArts model file on a given subkernel.";
-GenerateFAModelFileOnKernel[kernel_Parallel`Kernels`kernel] :=
+GenerateFAModelFileOnKernel[kernel:_Parallel`Kernels`kernel|_KernelObject] :=
 Module[
    {
       currentPath = $Path,

--- a/test/module.mk
+++ b/test/module.mk
@@ -251,8 +251,7 @@ ifeq ($(WITH_MRSSM2),yes)
 TEST_SRC += \
 		$(DIR)/test_MRSSM2_gmm2.cpp \
 		$(DIR)/test_MRSSM2_mw_calculation.cpp \
-		$(DIR)/test_MRSSM2_l_to_lgamma.cpp \
-		$(DIR)/test_MRSSM2_l_to_l_conversion.cpp
+		$(DIR)/test_MRSSM2_l_to_lgamma.cpp
 endif
 
 ifeq ($(WITH_MRSSM2CKM),yes)
@@ -990,8 +989,6 @@ $(DIR)/test_CMSSM_mass_eigenstates_decoupling_scheme.x: $(LIBCMSSM)
 $(DIR)/test_MRSSM2_mw_calculation.x: $(LIBMRSSM2)
 
 $(DIR)/test_MRSSM2_l_to_lgamma.x: $(LIBMRSSM2)
-
-$(DIR)/test_MRSSM2_l_to_l_conversion.x: $(LIBMRSSM2)
 
 $(DIR)/test_MRSSM2CKM_b_to_s_gamma.x: $(LIBMRSSM2CKM)
 


### PR DESCRIPTION
I noticed, that 
```
NPointFunctions`internal`GenerateFAModelFileOnKernel: errUnknownInput:
Usage:
@brief Generate the FeynArts model file on a given subkernel.

The behavior for case
1) GenerateFAModelFileOnKernel[kernel_Parallel`Kernels`kernel]
is defined only.

Call
GenerateFAModelFileOnKernel[KernelObject[1, local]]
is not supported.
Wolfram Language kernel session terminated.
```
is generated by tests. This is weird, because `KernelObject[1, local]` _has_ the head ``Parallel`Kernels`kernel`` in `FullForm`.