### PR TITLE
Ensure a main() is generated for all tests that use Boost.Test

### DIFF
--- a/test/test_MSSM_matching_selfenergy_Fd.cpp.in
+++ b/test/test_MSSM_matching_selfenergy_Fd.cpp.in
@@ -16,7 +16,9 @@
 // <http://www.gnu.org/licenses/>.
 // ====================================================================
 
-#define BOOST_TEST_MODULE Test NPointFunctions
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE "Test MSSM matching selfenergy Fd"
+
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 

--- a/test/test_MSSM_npointfunctions.cpp.in
+++ b/test/test_MSSM_npointfunctions.cpp.in
@@ -16,7 +16,9 @@
 // <http://www.gnu.org/licenses/>.
 // ====================================================================
 
-#define BOOST_TEST_MODULE Test NPointFunctions
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE "Test MSSM NPointFunctions"
+
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 

--- a/test/test_SM_cxxdiagrams.cpp.in
+++ b/test/test_SM_cxxdiagrams.cpp.in
@@ -16,7 +16,9 @@
 // <http://www.gnu.org/licenses/>.
 // ====================================================================
 
-#define BOOST_TEST_MODULE Test CXXDiagrams
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE "Test SM CXXDiagrams"
+
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/fusion/include/boost_array.hpp>

--- a/test/test_SM_matching_selfenergy_Fd.cpp.in
+++ b/test/test_SM_matching_selfenergy_Fd.cpp.in
@@ -16,7 +16,9 @@
 // <http://www.gnu.org/licenses/>.
 // ====================================================================
 
-#define BOOST_TEST_MODULE Test NPointFunctions
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE "Test SM matching selfenergy Fd"
+
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 

--- a/test/test_SM_npointfunctions.cpp.in
+++ b/test/test_SM_npointfunctions.cpp.in
@@ -16,7 +16,9 @@
 // <http://www.gnu.org/licenses/>.
 // ====================================================================
 
-#define BOOST_TEST_MODULE Test NPointFunctions
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE "Test SM NPointFunctions"
+
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 

--- a/test/test_looplibrary.cpp.in
+++ b/test/test_looplibrary.cpp.in
@@ -16,6 +16,7 @@
 // <http://www.gnu.org/licenses/>.
 // ====================================================================
 
+#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE looplibrary LIBRARY_TYPE test
 
 #include <complex>


### PR DESCRIPTION
This fixes issues similar to #204 