### PR TITLE
flag models with CP violating Higgs sector

### DIFF
--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -2700,6 +2700,7 @@ WriteUtilitiesClass[massMatrices_List, betaFun_List, inputParameters_List, extra
                             "@gaugeCouplingNormalizationDefs@" -> IndentText[gaugeCouplingNormalizationDefs],
                             "@numberOfDRbarBlocks@"            -> ToString[numberOfDRbarBlocks],
                             "@drBarBlockNames@"                -> WrapLines[drBarBlockNames],
+                            "@isCPViolatingHiggsSector@"       -> CreateCBoolValue @ SA`CPViolationHiggsSector,
                             Sequence @@ GeneralReplacementRules[]
                           } ];
           ];

--- a/templates/info.hpp.in
+++ b/templates/info.hpp.in
@@ -48,6 +48,7 @@ namespace @ModelName@_info {
    constexpr bool is_low_energy_model = @isLowEnergyModel@;
    constexpr bool is_supersymmetric_model = @isSupersymmetricModel@;
    constexpr bool is_FlexibleEFTHiggs = @isFlexibleEFTHiggs@;
+   constexpr bool is_CP_violating_Higgs_sector {@isCPViolatingHiggsSector@};
 
    void print(std::ostream&);
 

--- a/test/module.mk
+++ b/test/module.mk
@@ -105,6 +105,7 @@ TEST_META := \
 		$(DIR)/test_MSSM_2L_yt.m \
 		$(DIR)/test_MSSM_2L_yt_loopfunction.m \
 		$(DIR)/test_MSSM_2L_yt_softsusy.m \
+		$(DIR)/test_MSSMCPV_SARAH.m \
 		$(DIR)/test_MRSSM_TreeMasses.m \
 		$(DIR)/test_Parameters.m \
 		$(DIR)/test_ReadSLHA.m \

--- a/test/test_MSSMCPV_SARAH.m
+++ b/test/test_MSSMCPV_SARAH.m
@@ -1,0 +1,32 @@
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+AppendTo[$Path, FileNameJoin[{Directory[], "meta"}]];
+
+Needs["SARAH`"];
+Needs["TestSuite`", "TestSuite.m"];
+
+Start["MSSM", "CPV"];
+
+TestEquality[SA`CPViolationHiggsSector, True];
+
+PrintTestSummary[];


### PR DESCRIPTION
This PR adds info whether a model has a CP violating Higgs sector. This information is needed for decays. I called the variable `CPViolationInHiggsSector`. Let me know if you're ok with this.