### PR TITLE
handle conj/bar in GetPDGCodesForParticle

### DIFF
--- a/meta/Parameters.m
+++ b/meta/Parameters.m
@@ -1627,6 +1627,12 @@ GetParticleFromDescription[multipletName_String, splitNames_List] :=
            DeleteCases[GetParticleFromDescription /@ splitNames, Null]
           ];
 
+GetPDGCodesForParticle[SARAH`bar[particle_]] :=
+    -GetPDGCodesForParticle[particle];
+
+GetPDGCodesForParticle[Susyno`LieGroups`conj[particle_]] :=
+    -GetPDGCodesForParticle[particle];
+
 GetPDGCodesForParticle[particle_] :=
     Module[{pdgList},
             pdgList = SARAH`getPDGList[particle];


### PR DESCRIPTION
This PR makes `GetPDGCodesForParticle` from `Parameters.m` correctly handle `conj` and `bar` heads. Anyone knows why it was never a problem? What is now seems wrong yet somehow no one has ever stumbled upon it?