### PR TITLE
nicer Warning and Error printouts

### DIFF
--- a/meta/FFVFormFactors.m
+++ b/meta/FFVFormFactors.m
@@ -81,11 +81,13 @@ IsDiagramSupported[graph_, diagram_] :=
          Return[True]
       ];
 
-      Print["Warning: Diagram with internal particles of type ",
-         StringJoin @@ (ToString /@ SARAH`getType /@ {EmitterL[diagram], EmitterR[diagram], Spectator[diagram]})];
-      Print["         is currently not supported."];
-      Print["         Discarding diagram with particles ",
-         {EmitterL[diagram], EmitterR[diagram], Spectator[diagram]}, "."];
+      Utils`PrintWarningMsg[
+         "Warning: Diagram with internal particles of type " <>
+         StringJoin @@ (ToString /@ SARAH`getType /@ {EmitterL[diagram], EmitterR[diagram], Spectator[diagram]}) <>
+         " is currently not supported. " <>
+         "Discarding diagram with particles " <>
+         StringJoin @@ Riffle[ToString /@{EmitterL[diagram], EmitterR[diagram], Spectator[diagram]}, ", "] <> "."
+      ];
       Return[False];
    ];
 


### PR DESCRIPTION
This is an old piece of code that lived on the decay branch. I wrote it before @uukhas prepared his error handling code. What I wanted is a nice aligned warning printout with blue Warning
```
Warning: Warning: Diagram with internal particles of type FFV is
               currently not supported. Discarding diagram with particles Fm, Fm,VP.
```
I'd want to discuss all this. Should we keep it? Should we ditch it and replace with Vova's code? In my version there is some problem with text adjustment because tags that print "Warning" in blue are counted when calculating when to wrap a line. Also, Vova suggested that "Warning" should be in blue which I'm also fine with.