### PR TITLE
parallelize CreateVertices function

### DIFF
--- a/meta/AMuon.m
+++ b/meta/AMuon.m
@@ -39,7 +39,7 @@ GetCXXMuonIndex[] := If[TreeMasses`GetDimension[TreeMasses`GetSMMuonLeptonMultip
 
 GetMinMass[particle_] :=
     Module[{dim = TreeMasses`GetDimension[particle],
-            mStr = CConversion`ToValidCSymbolString[FlexibleSUSY`M[particle]],
+            mStr = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[particle]],
             tail},
            If[dim == 1,
               "model.get_" <> mStr <> "()",

--- a/meta/CConversion.m
+++ b/meta/CConversion.m
@@ -660,6 +660,8 @@ ConvertGreekLetters[text_] :=
        "\[Sampi]"        -> "Sampi"
     }]];
 
+ToValidCSymbol[FlexibleSUSY`FSM[symbol_Symbol]] := Symbol["M" <> ToValidCSymbolString[symbol]];
+
 ToValidCSymbol[symbol_Symbol] := ConvertGreekLetters[symbol];
 
 ToValidCSymbol[symbol_Integer] := symbol;
@@ -886,7 +888,7 @@ RValueToCFormString[expr_] :=
              ];
            result = Block[{Which, If}, expr /. greekSymbolsRules] /.
                     SARAH`sum -> FlexibleSUSY`SUM /.
-                    SARAH`Mass -> FlexibleSUSY`M /.
+                    SARAH`Mass -> FlexibleSUSY`FSM /.
                     SARAH`A0[0]              -> 0 /.
                     SARAH`B0[0,0,0]          -> 0 /.
                     SARAH`B1[0,0,0]          -> 0 /.
@@ -897,11 +899,11 @@ RValueToCFormString[expr_] :=
                     SARAH`B11[0,0,0]         -> 0 /.
                     SARAH`B22[0,0,0]         -> 0 /.
                     SARAH`Mass2[a_?NumberQ]  :> Sqr[a] /.
-                    SARAH`Mass2[a_]          :> Sqr[FlexibleSUSY`M[a]] /.
-                    FlexibleSUSY`M[a_?NumberQ]   :> a /.
-                    FlexibleSUSY`M[SARAH`bar[a_]] :> FlexibleSUSY`M[a] /.
-                    FlexibleSUSY`M[a_[idx_]]     :> ToValidCSymbol[FlexibleSUSY`M[a]][idx] /.
-                    FlexibleSUSY`M[a_]           :> ToValidCSymbol[FlexibleSUSY`M[a]] /.
+                    SARAH`Mass2[a_]          :> Sqr[FlexibleSUSY`FSM[a]] /.
+                    FlexibleSUSY`FSM[a_?NumberQ]   :> a /.
+                    FlexibleSUSY`FSM[SARAH`bar[a_]] :> FlexibleSUSY`FSM[a] /.
+                    FlexibleSUSY`FSM[a_[idx_]]     :> ToValidCSymbol[FlexibleSUSY`FSM[a]][idx] /.
+                    FlexibleSUSY`FSM[a_]           :> ToValidCSymbol[FlexibleSUSY`FSM[a]] /.
                     FlexibleSUSY`BETA[l_,p_]     :> FlexibleSUSY`BETA1[l,p] /.
                     SARAH`Adj[0]                 -> 0 /.
                     SARAH`Conj[0]                -> 0 /.

--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -1090,7 +1090,12 @@ Module[{cxxVertices, vertexPartition,
       such that we get for example SARAH_g1 instead of g1 in
       generated C++ code *)
    ParallelEvaluate[
-      (BeginPackage[#];EndPackage[];)& /@ contextsToDistribute,
+      (BeginPackage[#];EndPackage[];
+       (* prevent shdw warning with Susyno`LieGroups`M: *)
+       Off[Remove::remal];
+       Remove[Susyno`LieGroups`M];
+       On[Remove::remal];
+      )& /@ contextsToDistribute,
       DistributedContexts->Automatic
    ];
    (* without this CForm converts complex numbers using

--- a/meta/Constraint.m
+++ b/meta/Constraint.m
@@ -232,13 +232,13 @@ ApplyConstraints[settings_List, modelPrefix_String:"MODEL->"] :=
                FlexibleSUSY`FSMinimize[__] | \
                FlexibleSUSY`FSFindRoot[__] | \
                FlexibleSUSY`FSSolveEWSBFor[__] | \
-               {FlexibleSUSY`Temporary[_], _} | \
+               {FlexibleSUSY`FSTemporary[_], _} | \
                FlexibleSUSY`FSRestrictParameter[__] | \
                FlexibleSUSY`FSInitialSetting[__]
            ];
            noTemp = DeleteCases[
                settings,
-               {FlexibleSUSY`Temporary[_], _} | \
+               {FlexibleSUSY`FSTemporary[_], _} | \
                FlexibleSUSY`FSRestrictParameter[__] | \
                FlexibleSUSY`FSInitialSetting[__]
            ];
@@ -680,7 +680,7 @@ SaveValue[par_] :=
           ];
 
 SetTemporarily[settings_List] :=
-    Module[{tempSettings = Cases[settings, {FlexibleSUSY`Temporary[p_], v_} :> {p,v}],
+    Module[{tempSettings = Cases[settings, {FlexibleSUSY`FSTemporary[p_], v_} :> {p,v}],
             set, savedVals},
            If[tempSettings === {}, Return[""];];
            set = ApplyConstraints[tempSettings];

--- a/meta/ConvergenceTester.m
+++ b/meta/ConvergenceTester.m
@@ -26,7 +26,7 @@ CreateCompareFunction::usage="";
 
 Begin["`Private`"];
 
-CountNumberOfParameters[FlexibleSUSY`M[particle_]] :=
+CountNumberOfParameters[FlexibleSUSY`FSM[particle_]] :=
     TreeMasses`GetDimension[particle];
 
 CountNumberOfParameters[parameters_List] :=
@@ -46,10 +46,10 @@ IndexMapping[d_List, i_List] :=
     IndexMapping[Take[d,Length[d]-1], Take[i,Length[i]-1]] <>
     " + " <> ToString[Times @@ Take[d,Length[d]-1]] <> "*" <> Last[i];
 
-CalcDifference[FlexibleSUSY`M[particle_], offset_Integer, diff_String] :=
+CalcDifference[FlexibleSUSY`FSM[particle_], offset_Integer, diff_String] :=
     Module[{result, body, dim, dimStart, esStr},
            dim = TreeMasses`GetDimension[particle];
-           esStr = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           esStr = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            If[dim == 1,
               result = diff <> "[" <> ToString[offset] <> "] = " <>
                        "MaxRelDiff(OLD(" <> esStr <> "),NEW(" <> esStr <> "));\n";
@@ -125,7 +125,7 @@ CreateCompareFunction[crit_ /; crit === Automatic] :=
               particles = TreeMasses`GetParticles[];
              ];
            particles = Select[particles, (!TreeMasses`IsMassless[#] && !IsGhost[#] && !IsGoldstone[#])&];
-           particles = FlexibleSUSY`M /@ particles;
+           particles = FlexibleSUSY`FSM /@ particles;
            CreateCompareFunction[particles]
           ];
 

--- a/meta/EffectiveCouplings.m
+++ b/meta/EffectiveCouplings.m
@@ -183,7 +183,7 @@ CalculatePartialWidths[couplings_List] :=
                   functionName = functionName <> "int gO1) const";
                  ];
                couplingName = "eff_Cp" <> particlesStr;
-               massStr = CConversion`ToValidCSymbolString[FlexibleSUSY`M[particle]];
+               massStr = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
                body = "const double mass = PHYSICAL(" <> massStr <> ")";
                If[dim != 1,
                   body = body <> "(gO1)";
@@ -409,7 +409,7 @@ CallEffectiveCouplingCalculation[couplingSymbol_] :=
     Module[{particle, vectorBoson, savedMass, dim, start, idx = "",
             body, couplingName, call = ""},
            {particle, vectorBoson} = GetExternalStates[couplingSymbol];
-           savedMass = CConversion`RValueToCFormString[FlexibleSUSY`M[particle]];
+           savedMass = CConversion`RValueToCFormString[FlexibleSUSY`FSM[particle]];
            dim = TreeMasses`GetDimension[particle];
            start = TreeMasses`GetDimensionStartSkippingGoldstones[particle];
            If[dim != 1 && start <= dim,
@@ -446,7 +446,7 @@ CreateEffectiveCouplingsCalculation[couplings_List] :=
               ];
            For[i = 1, i <= Length[couplingsForParticles], i++,
                particle = couplingsForParticles[[i,1]];
-               mass = CConversion`ToValidCSymbolString[FlexibleSUSY`M[particle]];
+               mass = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
                savedMass = "const auto " <> mass <> " = PHYSICAL(" <> mass <> ");\n";
                dim = TreeMasses`GetDimension[particle];
                start = TreeMasses`GetDimensionStartSkippingGoldstones[particle];
@@ -545,8 +545,8 @@ CreateLocalConstRefsIgnoringMixings[expr_, mixings_List] :=
     Module[{symbols, poleMasses},
            symbols = Parameters`FindAllParameters[expr];
            poleMasses = {
-               Cases[expr, FlexibleSUSY`Pole[FlexibleSUSY`M[a_]]     /; MemberQ[Parameters`GetOutputParameters[],FlexibleSUSY`M[a]] :> FlexibleSUSY`M[a], {0,Infinity}],
-               Cases[expr, FlexibleSUSY`Pole[FlexibleSUSY`M[a_[__]]] /; MemberQ[Parameters`GetOutputParameters[],FlexibleSUSY`M[a]] :> FlexibleSUSY`M[a], {0,Infinity}]
+               Cases[expr, FlexibleSUSY`Pole[FlexibleSUSY`FSM[a_]]     /; MemberQ[Parameters`GetOutputParameters[],FlexibleSUSY`FSM[a]] :> FlexibleSUSY`FSM[a], {0,Infinity}],
+               Cases[expr, FlexibleSUSY`Pole[FlexibleSUSY`FSM[a_[__]]] /; MemberQ[Parameters`GetOutputParameters[],FlexibleSUSY`FSM[a]] :> FlexibleSUSY`FSM[a], {0,Infinity}]
                         };
            symbols = DeleteDuplicates[Flatten[symbols]];
            symbols = Complement[symbols, mixings];
@@ -615,7 +615,7 @@ CreateCouplingContribution[particle_, vectorBoson_, coupling_] :=
                                   p_ /; p === particle, 1];
            internal = First[internal /. {SARAH`bar[p_] :> p, Susyno`LieGroups`conj[p_] :> p}];
            dim = TreeMasses`GetDimension[internal];
-           mass = FlexibleSUSY`M[internal];
+           mass = FlexibleSUSY`FSM[internal];
            massStr = CConversion`ToValidCSymbolString[mass];
            If[dim != 1,
               massStr = massStr <> "(gI1)";
@@ -699,7 +699,7 @@ CreateEffectiveCouplingFunction[coupling_] :=
                  result = result <> "int gO1)\n{\n";
                 ];
 
-              mass = CConversion`ToValidCSymbolString[FlexibleSUSY`M[particle]];
+              mass = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
               savedMass = "const auto decay_mass = PHYSICAL(" <> mass <> ")";
               If[dim == 1,
                  savedMass = savedMass <> ";\n";,

--- a/meta/FSMathLink.m
+++ b/meta/FSMathLink.m
@@ -166,7 +166,7 @@ ToValidWolframSymbolString[par_?CConversion`GreekQ] := ToUTF8String[par];
 ToValidWolframSymbolString[par_] := ToString[par];
 
 ToValidOutputParStr[FlexibleSUSY`Pole[par_]] := ToValidOutputParStr[par]; (* Pole[x] is not a valid parameter name *)
-ToValidOutputParStr[p:FlexibleSUSY`M[_]] := CConversion`ToValidCSymbolString[p];
+ToValidOutputParStr[p:FlexibleSUSY`FSM[_]] := CConversion`ToValidCSymbolString[p];
 ToValidOutputParStr[FlexibleSUSY`SCALE] := "scale";
 ToValidOutputParStr[par_] := CConversion`ToValidCSymbolString[par];
 

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -277,7 +277,7 @@ FSMaximumExpressionSize = 100;
    Example:
 
    FSConvergenceCheck = {
-      M[hh], g3, Yu, Yd[3,3], Ye, B[\[Mu]]
+      FSM[hh], g3, Yu, Yd[3,3], Ye, B[\[Mu]]
    };
 *)
 FSConvergenceCheck = Automatic;
@@ -359,8 +359,8 @@ FSHimalayaInput = {
     Ye -> SARAH`ElectronYukawa,
     M1 -> 0,
     M2 -> 0,
-    M3 -> FlexibleSUSY`M[SARAH`Gluino],
-    mA -> FlexibleSUSY`M[SARAH`PseudoScalar]
+    M3 -> FlexibleSUSY`FSM[SARAH`Gluino],
+    mA -> FlexibleSUSY`FSM[SARAH`PseudoScalar]
 };
 
 FSDebugOutput = False;
@@ -654,7 +654,7 @@ CheckModelFileSettings[] :=
              ];
            CheckEWSBSolvers[FlexibleSUSY`FSEWSBSolvers];
            CheckBVPSolvers[FlexibleSUSY`FSBVPSolvers];
-           ReplaceSymbolsInUserInput[{Susyno`LieGroups`M -> FlexibleSUSY`M}];
+           ReplaceSymbolsInUserInput[{Susyno`LieGroups`M -> FlexibleSUSY`FSM}];
           ];
 
 CheckExtraParametersUsage[parameters_List, boundaryConditions_List] :=
@@ -1736,8 +1736,8 @@ WriteModelClass[massMatrices_List, ewsbEquations_List,
            callAllLoopMassFunctions     = LoopMasses`CallAllPoleMassFunctions[FlexibleSUSY`FSEigenstates, enablePoleMassThreads];
            enablePoleMassThreads = True;
            callAllLoopMassFunctionsInThreads = LoopMasses`CallAllPoleMassFunctions[FlexibleSUSY`FSEigenstates, enablePoleMassThreads];
-           masses                       = Flatten[(FlexibleSUSY`M[TreeMasses`GetMassEigenstate[#]]& /@ massMatrices) /.
-                                                  FlexibleSUSY`M[p_List] :> (FlexibleSUSY`M /@ p)];
+           masses                       = Flatten[(FlexibleSUSY`FSM[TreeMasses`GetMassEigenstate[#]]& /@ massMatrices) /.
+                                                  FlexibleSUSY`FSM[p_List] :> (FlexibleSUSY`FSM /@ p)];
            {lspGetters, lspFunctions}   = LoopMasses`CreateLSPFunctions[FlexibleSUSY`PotentialLSPParticles];
            printMasses                  = WriteOut`PrintParameters[masses, "ostr"];
            getMixings                   = TreeMasses`CreateMixingArrayGetter[massMatrices];
@@ -2504,7 +2504,7 @@ WriteMathLink[inputParameters_List, extraSLHAOutputBlocks_List, files_List] :=
            setInputParameters = FSMathLink`SetInputParametersFromArguments[inputPars];
            setInputParameterDefaultArguments = FSMathLink`SetInputParameterDefaultArguments[inputPars];
            setInputParameterArguments = FSMathLink`SetInputParameterArguments[inputPars];
-           outPars = Parameters`GetOutputParameters[] /. FlexibleSUSY`M[p_List] :> Sequence @@ (FlexibleSUSY`M /@ p);
+           outPars = Parameters`GetOutputParameters[] /. FlexibleSUSY`FSM[p_List] :> Sequence @@ (FlexibleSUSY`FSM /@ p);
            outPars = Join[outPars, FlexibleSUSY`Pole /@ outPars, Parameters`GetModelParameters[],
                           Parameters`GetExtraParameters[], {FlexibleSUSY`SCALE}];
            numberOfSpectrumEntries = FSMathLink`GetNumberOfSpectrumEntries[outPars];
@@ -3704,7 +3704,7 @@ SetupMassMatrices[allParameters_] :=
 
 SetupOutputParameters[massMatrices_] :=
 		Module[{allParticles, allOutputParameters},
-           allParticles = FlexibleSUSY`M[TreeMasses`GetMassEigenstate[#]]& /@ massMatrices;
+           allParticles = FlexibleSUSY`FSM[TreeMasses`GetMassEigenstate[#]]& /@ massMatrices;
            allOutputParameters = DeleteCases[DeleteDuplicates[
                Join[allParticles,
                     Flatten[TreeMasses`GetMixingMatrixSymbol[#]& /@ massMatrices]]], Null];

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -168,7 +168,7 @@ FSRestrictParameter; (* restrict parameter to interval *)
 FSInitialSetting;    (* set parameter before calculating masses *)
 FSSolveEWSBFor;
 FSSolveEWSBTreeLevelFor = {};
-Temporary;
+FSTemporary;
 MZ;
 MT;
 MZDRbar;

--- a/meta/LoopMasses.m
+++ b/meta/LoopMasses.m
@@ -84,7 +84,7 @@ double mst_1, mst_2, theta_t;
 mssm_twoloop_mt::Parameters pars;
 pars.g3 = " <> CConversion`RValueToCFormString[SARAH`strongCoupling /. Parameters`ApplyGUTNormalization[]] <> ";
 pars.mt = " <> CConversion`RValueToCFormString[TreeMasses`GetThirdGenerationMass[TreeMasses`GetSMTopQuarkMultiplet[]]] <> ";
-pars.mg = " <> CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]] <> ";
+pars.mg = " <> CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]] <> ";
 pars.mst1 = mst_1;
 pars.mst2 = mst_2;
 pars.msusy = " <> CConversion`RValueToCFormString[Sqrt[Sqrt[Abs[SARAH`SoftSquark[2,2]] Abs[SARAH`SoftDown[2,2]]]]] <> ";
@@ -167,7 +167,7 @@ if (get_thresholds() > 1 && threshold_corrections.mb > 1) {
    pars.g3 = " <> CConversion`RValueToCFormString[SARAH`strongCoupling /. Parameters`ApplyGUTNormalization[]] <> ";
    pars.mt = " <> CConversion`RValueToCFormString[TreeMasses`GetThirdGenerationMass[TreeMasses`GetSMTopQuarkMultiplet[]]] <> ";
    pars.mb = " <> CConversion`RValueToCFormString[TreeMasses`GetThirdGenerationMass[TreeMasses`GetSMBottomQuarkMultiplet[]]] <> ";
-   pars.mg = " <> CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]] <> ";
+   pars.mg = " <> CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]] <> ";
    pars.mst1 = mst_1;
    pars.mst2 = mst_2;
    pars.msb1 = msb_1;
@@ -205,7 +205,7 @@ Get3LQCDMtRelations[particle_, scale_] :=
     SimpQCD[
         k^3 { Coefficient[MfOvermf, k, 3], Coefficient[mfOverMf, k, 3] } //. {
             L -> Log[mf^2/scale^2],
-            mf -> FlexibleSUSY`M[particle],
+            mf -> FlexibleSUSY`FSM[particle],
             k -> 1/(4Pi)^2,
             NL -> 5,
             NH -> 1,
@@ -222,7 +222,7 @@ Get4LQCDMtRelations[particle_, scale_] :=
     SimpQCD[
         k^4 { Coefficient[MtOvermt, k, 4], Coefficient[mtOverMt, k, 4] } //. {
             L -> Log[mt^2/scale^2],
-            mt -> FlexibleSUSY`M[particle],
+            mt -> FlexibleSUSY`FSM[particle],
             k -> 1/(4Pi)^2,
             g3 -> SARAH`strongCoupling
         }
@@ -259,7 +259,7 @@ Do1DimFermion[particle_, massMatrixName_String, selfEnergyFunctionS_String,
     "const " <> CreateCType[type] <> " self_energy_PR = " <> CastIfReal[selfEnergyFunctionPR <> "(p)",type] <> ";\n" <>
     "const auto M_loop = " <> massMatrixName <>
     " - self_energy_1 - " <> massMatrixName <> " * (self_energy_PL + self_energy_PR);\n" <>
-    "PHYSICAL(" <> ToValidCSymbolString[FlexibleSUSY`M[particle]] <> ") = " <>
+    "PHYSICAL(" <> ToValidCSymbolString[FlexibleSUSY`FSM[particle]] <> ") = " <>
     "calculate_singlet_mass(M_loop);\n";
 
 Do1DimFermion[particle_ /; particle === TreeMasses`GetSMTopQuarkMultiplet[], massMatrixName_String,
@@ -268,7 +268,7 @@ Do1DimFermion[particle_ /; particle === TreeMasses`GetSMTopQuarkMultiplet[], mas
             topSelfEnergyFunctionS, topSelfEnergyFunctionPL, topSelfEnergyFunctionPR,
             qcdOneLoop, qcdTwoLoop, qcdThreeLoop, qcdFourLoop
            },
-           massName = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           massName = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            topSelfEnergyFunctionS  = SelfEnergies`CreateHeavySelfEnergyFunctionName[particle[1], 1];
            topSelfEnergyFunctionPL = SelfEnergies`CreateHeavySelfEnergyFunctionName[particle[PL], 1];
            topSelfEnergyFunctionPR = SelfEnergies`CreateHeavySelfEnergyFunctionName[particle[PR], 1];
@@ -323,7 +323,7 @@ DoFastDiagonalization[particle_Symbol /; IsScalar[particle], tadpoles_List] :=
            dim = GetDimension[particle];
            dimStr = ToString[dim];
            particleName = ToValidCSymbolString[particle];
-           massName = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           massName = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            massNameReordered = massName <> "_reordered";
            mixingMatrix = FindMixingMatrixSymbolFor[particle];
            massMatrixStr = "get_mass_matrix_" <> ToValidCSymbolString[particle];
@@ -388,7 +388,7 @@ DoFastDiagonalization[particle_Symbol /; IsFermion[particle], _] :=
            dim = GetDimension[particle];
            dimStr = ToString[dim];
            particleName = ToValidCSymbolString[particle];
-           massName = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           massName = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            massNameReordered = massName <> "_reordered";
            massMatrixStr = "get_mass_matrix_" <> particleName;
            If[IsUnmixed[particle] && GetMassOfUnmixedParticle[particle] === 0,
@@ -479,7 +479,7 @@ DoFastDiagonalization[particle_Symbol /; IsVector[particle], _] :=
            dim = GetDimension[particle];
            dimStr = ToString[dim];
            particleName = ToValidCSymbolString[particle];
-           massName = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           massName = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            mixingMatrix = ToValidCSymbolString[FindMixingMatrixSymbolFor[particle]];
            selfEnergyFunction = SelfEnergies`CreateSelfEnergyFunctionName[particle, 1];
            selfEnergyMatrixType = TreeMasses`GetMassMatrixType[particle];
@@ -513,7 +513,7 @@ DoMediumDiagonalization[particle_Symbol /; IsScalar[particle], inputMomentum_, t
            dim = GetDimension[particle];
            dimStr = ToString[dim];
            particleName = ToValidCSymbolString[particle];
-           massName = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           massName = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            If[inputMomentum == "", momentum = massName];
            mixingMatrix = FindMixingMatrixSymbolFor[particle];
            mixingMatrixType = TreeMasses`GetMassMatrixType[particle];
@@ -605,7 +605,7 @@ DoMediumDiagonalization[particle_Symbol /; IsFermion[particle], inputMomentum_, 
            dim = GetDimension[particle];
            dimStr = ToString[dim];
            particleName = ToValidCSymbolString[particle];
-           massName = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           massName = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            If[inputMomentum == "", momentum = massName];
            If[IsUnmixed[particle] && GetMassOfUnmixedParticle[particle] === 0,
               If[dim == 1,
@@ -638,10 +638,10 @@ DoMediumDiagonalization[particle_Symbol /; IsFermion[particle], inputMomentum_, 
                                 (* contribution to self-energy => neg. sign *)
                                 N @ SimpQCD[-Get4LQCDMtOvermt[particle, Global`currentScale]],
                                 0];
-              qcdCorrections = AddMtPoleQCDCorrections[1, qcdOneLoop /. FlexibleSUSY`M[particle] -> thirdGenMass] <> "\n" <>
-                               AddMtPoleQCDCorrections[2, qcdTwoLoop /. FlexibleSUSY`M[particle] -> thirdGenMass] <> "\n" <>
-                               AddMtPoleQCDCorrections[3, qcdThreeLoop /. FlexibleSUSY`M[particle] -> thirdGenMass] <> "\n" <>
-                               AddMtPoleQCDCorrections[4, qcdFourLoop /. FlexibleSUSY`M[particle] -> thirdGenMass] <> "\n";
+              qcdCorrections = AddMtPoleQCDCorrections[1, qcdOneLoop /. FlexibleSUSY`FSM[particle] -> thirdGenMass] <> "\n" <>
+                               AddMtPoleQCDCorrections[2, qcdTwoLoop /. FlexibleSUSY`FSM[particle] -> thirdGenMass] <> "\n" <>
+                               AddMtPoleQCDCorrections[3, qcdThreeLoop /. FlexibleSUSY`FSM[particle] -> thirdGenMass] <> "\n" <>
+                               AddMtPoleQCDCorrections[4, qcdFourLoop /. FlexibleSUSY`FSM[particle] -> thirdGenMass] <> "\n";
              ];
            selfEnergyFunctionS  = SelfEnergies`CreateSelfEnergyFunctionName[particle[1], 1];
            selfEnergyFunctionPL = SelfEnergies`CreateSelfEnergyFunctionName[particle[PL], 1];
@@ -761,7 +761,7 @@ DoMediumDiagonalization[particle_Symbol /; IsVector[particle], inputMomentum_, _
            dim = GetDimension[particle];
            dimStr = ToString[dim];
            particleName = ToValidCSymbolString[particle];
-           massName = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           massName = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            If[inputMomentum == "", momentum = massName];
            mixingMatrix = ToValidCSymbolString[FindMixingMatrixSymbolFor[particle]];
            selfEnergyFunction = SelfEnergies`CreateSelfEnergyFunctionName[particle, 1];
@@ -837,7 +837,7 @@ DoSlowDiagonalization[particle_Symbol, tadpole_] :=
            dim = GetDimension[particle];
            dimStr = ToString[dim];
            particleStr = CConversion`ToValidCSymbolString[particle];
-           massName = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           massName = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            inputMomenta = "old_" <> massName;
            outputMomenta = "new_" <> massName;
            If[dim > 1 &&
@@ -888,7 +888,7 @@ DoDiagonalization[particle_Symbol, FlexibleSUSY`HighPrecision, tadpole_] :=
     "// diagonalization with high precision\n" <> DoSlowDiagonalization[particle, tadpole];
 
 CreateLoopMassFunctionName[particle_Symbol] :=
-    "calculate_" <> ToValidCSymbolString[FlexibleSUSY`M[particle]] <> "_pole";
+    "calculate_" <> ToValidCSymbolString[FlexibleSUSY`FSM[particle]] <> "_pole";
 
 CallPoleMassFunction[particle_Symbol, obj_:""] :=
     obj <> CreateLoopMassFunctionName[particle] <> "();\n";
@@ -934,14 +934,14 @@ Create1DimPoleMassFunction[particle_Symbol] :=
              ];
            If[!IsMassless[particle],
                particleName = ToValidCSymbolString[particle];
-               massName = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+               massName = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
                selfEnergyFunction = SelfEnergies`CreateSelfEnergyFunctionName[particle, 1];
                (* vector bosons are always unmixed -> make sure the
                   right mass eigenvalue is used.  The mass matrix might
                   contain mixing matrix elements, which can result in
                   the wrong mass eigenstate. *)
                If[IsVector[particle],
-                  mTree = "Sqr(" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[particle]] <> ")",
+                  mTree = "Sqr(" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[particle]] <> ")",
                   mTree = "get_mass_matrix_" <> particleName <> "()";
                  ];
                body = body <>
@@ -1071,11 +1071,11 @@ CallCalculateDRbarMass[splitName_String, multipletName_String, index_Integer, re
           ];
 
 CreateRunningDRbarMassPrototype[particle_ /; IsFermion[particle]] :=
-    "double calculate_" <> ToValidCSymbolString[FlexibleSUSY`M[particle]] <>
+    "double calculate_" <> ToValidCSymbolString[FlexibleSUSY`FSM[particle]] <>
     "_DRbar(double" <> If[TreeMasses`GetDimension[particle] > 1, ", int", ""] <> ") const;\n";
 
 CreateRunningDRbarMassPrototype[particle_] :=
-    "double calculate_" <> ToValidCSymbolString[FlexibleSUSY`M[particle]] <>
+    "double calculate_" <> ToValidCSymbolString[FlexibleSUSY`FSM[particle]] <>
     "_DRbar(double) const;\n";
 
 CreateRunningDRbarMassPrototypes[] :=
@@ -1094,7 +1094,7 @@ CreateRunningDRbarMassFunction[particle_ /; particle === TreeMasses`GetSMBottomQ
            selfEnergyFunctionS  = SelfEnergies`CreateHeavyRotatedSelfEnergyFunctionName[particle[1], 1];
            selfEnergyFunctionPL = SelfEnergies`CreateHeavyRotatedSelfEnergyFunctionName[particle[PL], 1];
            selfEnergyFunctionPR = SelfEnergies`CreateHeavyRotatedSelfEnergyFunctionName[particle[PR], 1];
-           name = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           name = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            If[IsMassless[particle],
               If[dimParticle == 1,
                  result = "double CLASSNAME::calculate_" <> name <> "_DRbar(double) const\n{\n";,
@@ -1140,7 +1140,7 @@ CreateRunningDRbarMassFunction[particle_ /; TreeMasses`IsSMChargedLepton[particl
            selfEnergyFunctionS  = SelfEnergies`CreateHeavyRotatedSelfEnergyFunctionName[particle[1], 1];
            selfEnergyFunctionPL = SelfEnergies`CreateHeavyRotatedSelfEnergyFunctionName[particle[PL], 1];
            selfEnergyFunctionPR = SelfEnergies`CreateHeavyRotatedSelfEnergyFunctionName[particle[PR], 1];
-           name = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           name = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            If[IsMassless[particle],
               If[dimParticle == 1,
                  result = "double CLASSNAME::calculate_" <> name <> "_DRbar(double) const\n{\n";,
@@ -1192,13 +1192,13 @@ const double q_2l = mssm_twoloop_mt::dMt_over_mt_2loop(pars);
    Eq. (4.7) of arxiv:1312.5220
  *)
 GetMtPoleOverMtMSbarSplitMSSM2L[particle_, scale_] :=
-    Module[{mg = FlexibleSUSY`M[SARAH`Gluino]},
+    Module[{mg = FlexibleSUSY`FSM[SARAH`Gluino]},
            SARAH`strongCoupling^4/(4 Pi)^4 (
                89/9
                + 4 Log[mg^2/scale^2] (
                    13/3
                    + Log[mg^2/scale^2]
-                   - 2 Log[FlexibleSUSY`M[particle]^2/scale^2]
+                   - 2 Log[FlexibleSUSY`FSM[particle]^2/scale^2]
                )
            )
           ];
@@ -1212,7 +1212,7 @@ CreateRunningDRbarMassFunction[particle_ /; particle === TreeMasses`GetSMTopQuar
            selfEnergyFunctionS  = SelfEnergies`CreateHeavyRotatedSelfEnergyFunctionName[particle[1], 1];
            selfEnergyFunctionPL = SelfEnergies`CreateHeavyRotatedSelfEnergyFunctionName[particle[PL], 1];
            selfEnergyFunctionPR = SelfEnergies`CreateHeavyRotatedSelfEnergyFunctionName[particle[PR], 1];
-           name = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           name = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            If[IsMassless[particle],
               If[dimParticle == 1,
                  result = "double CLASSNAME::calculate_" <> name <> "_DRbar(double) const\n{\n";,
@@ -1267,14 +1267,14 @@ CreateRunningDRbarMassFunction[particle_ /; particle === TreeMasses`GetSMTopQuar
               "double atas_S_2l = 0., atas_LR_2l = 0., atat_S_2l = 0., atat_LR_2l = 0.;\n\n" <>
                   If[FlexibleSUSY`UseMSSMYukawa2Loop === True,
                      CreateMSSM1LoopSQCDContributions[],
-                     "qcd_1l = " <> CConversion`RValueToCFormString[qcdOneLoop /. FlexibleSUSY`M[particle] -> treeLevelMass] <> ";"
+                     "qcd_1l = " <> CConversion`RValueToCFormString[qcdOneLoop /. FlexibleSUSY`FSM[particle] -> treeLevelMass] <> ";"
                     ] <>
               "\n\n" <>
               "if (get_thresholds() > 1 && threshold_corrections.mt > 1) {\n" <>
               IndentText[
                   If[FlexibleSUSY`UseMSSMYukawa2Loop === True,
                      CreateMSSM2LoopSQCDContributions[],
-                     "const double q_2l = " <> CConversion`RValueToCFormString[qcdTwoLoop /. FlexibleSUSY`M[particle] -> treeLevelMass] <> ";\n\n" <>
+                     "const double q_2l = " <> CConversion`RValueToCFormString[qcdTwoLoop /. FlexibleSUSY`FSM[particle] -> treeLevelMass] <> ";\n\n" <>
                      "qcd_2l = -q_2l + qcd_1l * qcd_1l;"
                   ] <>
                   If[FlexibleSUSY`UseSMYukawa2Loop === True,
@@ -1297,11 +1297,11 @@ atat_LR_2l = sm_twoloop_mt::delta_mt_2loop_at_at_LR_flexiblesusy(yt, t, h, s, qq
               "}\n\n" <>
               If[qcdThreeLoop =!= 0,
               "if (get_thresholds() > 2 && threshold_corrections.mt > 2) {\n" <>
-                  IndentText["qcd_3l = " <> CConversion`RValueToCFormString[qcdThreeLoop /. FlexibleSUSY`M[particle] -> treeLevelMass] <> ";"] <> "\n" <>
+                  IndentText["qcd_3l = " <> CConversion`RValueToCFormString[qcdThreeLoop /. FlexibleSUSY`FSM[particle] -> treeLevelMass] <> ";"] <> "\n" <>
               "}\n\n", ""] <>
               If[qcdFourLoop =!= 0,
               "if (get_thresholds() > 3 && threshold_corrections.mt > 3) {\n" <>
-                  IndentText["qcd_4l = " <> CConversion`RValueToCFormString[qcdFourLoop /. FlexibleSUSY`M[particle] -> treeLevelMass] <> ";"] <> "\n" <>
+                  IndentText["qcd_4l = " <> CConversion`RValueToCFormString[qcdFourLoop /. FlexibleSUSY`FSM[particle] -> treeLevelMass] <> ";"] <> "\n" <>
               "}\n\n", ""] <>
               "const double m_susy_drbar = m_pole + self_energy_1 + atas_S_2l + atat_S_2l " <>
               "+ m_pole * (self_energy_PL + self_energy_PR + qcd_1l + qcd_2l + qcd_3l + qcd_4l + atas_LR_2l + atat_LR_2l);\n\n" <>
@@ -1317,7 +1317,7 @@ CreateRunningDRbarMassFunction[particle_ /; IsFermion[particle], _] :=
            selfEnergyFunctionS  = SelfEnergies`CreateSelfEnergyFunctionName[particle[1], 1];
            selfEnergyFunctionPL = SelfEnergies`CreateSelfEnergyFunctionName[particle[PL], 1];
            selfEnergyFunctionPR = SelfEnergies`CreateSelfEnergyFunctionName[particle[PR], 1];
-           name = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           name = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            If[IsMassless[particle],
               If[dimParticle == 1,
                  result = "double CLASSNAME::calculate_" <> name <> "_DRbar(double) const\n{\n";,
@@ -1350,7 +1350,7 @@ CreateRunningDRbarMassFunction[particle_, _] :=
     Module[{result, body, selfEnergyFunction, name, particleName},
            selfEnergyFunction = SelfEnergies`CreateSelfEnergyFunctionName[particle, 1];
            particleName = ToValidCSymbolString[particle];
-           name = ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           name = ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            If[IsMassless[particle],
               result = "double CLASSNAME::calculate_" <> name <> "_DRbar(double) const\n{\n";
               body = "return 0.0;\n";
@@ -1374,13 +1374,13 @@ CreateRunningDRbarMassFunctions[renormalizationScheme_:FlexibleSUSY`DRbar] :=
            Return[result];
           ];
 
-GetLightestMassEigenstate[FlexibleSUSY`M[mass_]] :=
+GetLightestMassEigenstate[FlexibleSUSY`FSM[mass_]] :=
     GetLightestMassEigenstate[mass];
 
 GetLightestMassEigenstate[mass_] :=
     If[GetDimension[mass] == 1,
-       FlexibleSUSY`M[mass],
-       FlexibleSUSY`M[mass][GetDimensionStartSkippingGoldstones[mass] - 1]];
+       FlexibleSUSY`FSM[mass],
+       FlexibleSUSY`FSM[mass][GetDimensionStartSkippingGoldstones[mass] - 1]];
 
 CreateLSPFunctions[{}] := {"", ""};
 
@@ -1404,7 +1404,7 @@ if (tmp_mass < lsp_mass) {
 " <> IndentText["\
 lsp_mass = tmp_mass;
 particle_type = " <> info <> "::" <>
-CConversion`ToValidCSymbolString[mass /. FlexibleSUSY`M -> Identity] <>
+CConversion`ToValidCSymbolString[mass /. FlexibleSUSY`FSM -> Identity] <>
 ";"] <>
 "
 }

--- a/meta/Observables.m
+++ b/meta/Observables.m
@@ -499,7 +499,7 @@ FillGM2CalcInterfaceData[struct_String] :=
               Quit[1];
            ];
 
-           mwStr         = "MODEL.get_physical()." <> CConversion`RValueToCFormString[FlexibleSUSY`M[w]];
+           mwStr         = "MODEL.get_physical()." <> CConversion`RValueToCFormString[FlexibleSUSY`FSM[w]];
            filling = \
            struct <> ".alpha_s_MZ = ALPHA_S_MZ;\n" <>
            struct <> ".MZ    = MZPole;\n" <>
@@ -512,15 +512,15 @@ FillGM2CalcInterfaceData[struct_String] :=
            struct <> ".MTau  = MTauPole;\n" <>
            struct <> ".MM    = MMPole;\n" <>
            struct <> ".MA0   = MODEL.get_physical()." <>
-           CConversion`RValueToCFormString[FlexibleSUSY`M[pseudoscalar][1]] <> ";\n" <>
+           CConversion`RValueToCFormString[FlexibleSUSY`FSM[pseudoscalar][1]] <> ";\n" <>
            struct <> ".MSvm  = MODEL.get_physical()." <>
-           CConversion`RValueToCFormString[FlexibleSUSY`M[muonsneutrino]] <> ";\n" <>
+           CConversion`RValueToCFormString[FlexibleSUSY`FSM[muonsneutrino]] <> ";\n" <>
            struct <> ".MSm   = MODEL.get_physical()." <>
-           CConversion`RValueToCFormString[FlexibleSUSY`M[smuon]] <> ";\n" <>
+           CConversion`RValueToCFormString[FlexibleSUSY`FSM[smuon]] <> ";\n" <>
            struct <> ".MCha  = MODEL.get_physical()." <>
-           CConversion`RValueToCFormString[FlexibleSUSY`M[chargino]] <> ";\n" <>
+           CConversion`RValueToCFormString[FlexibleSUSY`FSM[chargino]] <> ";\n" <>
            struct <> ".MChi  = MODEL.get_physical()." <>
-           CConversion`RValueToCFormString[FlexibleSUSY`M[neutralino]] <> ";\n" <>
+           CConversion`RValueToCFormString[FlexibleSUSY`FSM[neutralino]] <> ";\n" <>
            struct <> ".scale = MODEL.get_scale();\n" <>
            struct <> ".TB    = MODEL.get_" <> CConversion`RValueToCFormString[SARAH`VEVSM2] <> "() / " <>
                               "MODEL.get_" <> CConversion`RValueToCFormString[SARAH`VEVSM1] <> "();\n" <>

--- a/meta/Parameters.m
+++ b/meta/Parameters.m
@@ -703,7 +703,7 @@ IsPhase[parameter_] := MemberQ[Phases`GetArg /@ allPhases, Phases`GetArg[paramet
 IsModelParameter[parameter_] := MemberQ[allModelParameters, parameter];
 IsModelParameter[Re[parameter_]] := IsModelParameter[parameter];
 IsModelParameter[Im[parameter_]] := IsModelParameter[parameter];
-IsModelParameter[FlexibleSUSY`Temporary[parameter_]] := IsModelParameter[parameter];
+IsModelParameter[FlexibleSUSY`FSTemporary[parameter_]] := IsModelParameter[parameter];
 
 IsModelParameter[parameter_[indices__] /; And @@ (IsIndex /@ {indices})] :=
     IsModelParameter[parameter];

--- a/meta/Parameters.m
+++ b/meta/Parameters.m
@@ -569,8 +569,8 @@ FindAllParametersFromList[expr_, parameters_List] :=
            symbols = Join[symbols,
                { Cases[compactExpr, a_Symbol /; MemberQ[parameters,a], {0,Infinity}],
                  Cases[compactExpr, a_[__] /; MemberQ[parameters,a] :> a, {0,Infinity}],
-                 Cases[compactExpr, FlexibleSUSY`M[a_]     /; MemberQ[parameters,FlexibleSUSY`M[a]], {0,Infinity}],
-                 Cases[compactExpr, FlexibleSUSY`M[a_[__]] /; MemberQ[parameters,FlexibleSUSY`M[a]] :> FlexibleSUSY`M[a], {0,Infinity}]
+                 Cases[compactExpr, FlexibleSUSY`FSM[a_]     /; MemberQ[parameters,FlexibleSUSY`FSM[a]], {0,Infinity}],
+                 Cases[compactExpr, FlexibleSUSY`FSM[a_[__]] /; MemberQ[parameters,FlexibleSUSY`FSM[a]] :> FlexibleSUSY`FSM[a], {0,Infinity}]
                }];
            DeleteDuplicates[Flatten[symbols]]
           ];
@@ -580,8 +580,8 @@ FindAllParameters[expr_, exceptions_:{}] :=
     Module[{allParameters, allOutPars},
            allOutPars = DeleteDuplicates[Flatten[
                Join[allOutputParameters,
-                    allOutputParameters /. FlexibleSUSY`M[{a__}] :> FlexibleSUSY`M[a],
-                    allOutputParameters /. FlexibleSUSY`M[{a__}] :> (FlexibleSUSY`M /@ {a})
+                    allOutputParameters /. FlexibleSUSY`FSM[{a__}] :> FlexibleSUSY`FSM[a],
+                    allOutputParameters /. FlexibleSUSY`FSM[{a__}] :> (FlexibleSUSY`FSM /@ {a})
                    ]]];
            allParameters = DeleteDuplicates[
                Join[allModelParameters, allOutPars,
@@ -597,12 +597,12 @@ FindAllParametersClassified[expr_, exceptions_:{}] :=
             poleMasses, phases, depNum, allOutPars},
            allOutPars = DeleteDuplicates[Flatten[
                Join[allOutputParameters,
-                    allOutputParameters /. FlexibleSUSY`M[{a__}] :> FlexibleSUSY`M[a],
-                    allOutputParameters /. FlexibleSUSY`M[{a__}] :> (FlexibleSUSY`M /@ {a})
+                    allOutputParameters /. FlexibleSUSY`FSM[{a__}] :> FlexibleSUSY`FSM[a],
+                    allOutputParameters /. FlexibleSUSY`FSM[{a__}] :> (FlexibleSUSY`FSM /@ {a})
                    ]]];
            poleMasses = {
-               Cases[expr, FlexibleSUSY`Pole[FlexibleSUSY`M[a_]]     /; MemberQ[allOutputParameters,FlexibleSUSY`M[a]] :> FlexibleSUSY`M[a], {0,Infinity}],
-               Cases[expr, FlexibleSUSY`Pole[FlexibleSUSY`M[a_[__]]] /; MemberQ[allOutputParameters,FlexibleSUSY`M[a]] :> FlexibleSUSY`M[a], {0,Infinity}]
+               Cases[expr, FlexibleSUSY`Pole[FlexibleSUSY`FSM[a_]]     /; MemberQ[allOutputParameters,FlexibleSUSY`FSM[a]] :> FlexibleSUSY`FSM[a], {0,Infinity}],
+               Cases[expr, FlexibleSUSY`Pole[FlexibleSUSY`FSM[a_[__]]] /; MemberQ[allOutputParameters,FlexibleSUSY`FSM[a]] :> FlexibleSUSY`FSM[a], {0,Infinity}]
                         };
            poleMasses   = DeleteDuplicates[Flatten[poleMasses]];
            inputPars    = DeleteDuplicates[Select[symbols, (MemberQ[GetInputParameters[],#])&]];
@@ -729,7 +729,7 @@ IsParameter[sym_] :=
 
 IsRealParameter[Re[sym_]] := True;
 IsRealParameter[Im[sym_]] := True;
-IsRealParameter[FlexibleSUSY`M[_]] := True;
+IsRealParameter[FlexibleSUSY`FSM[_]] := True;
 
 IsRealParameter[sym_] :=
     (IsModelParameter[sym] && AllModelParametersAreReal[]) ||
@@ -922,7 +922,7 @@ GetType[sym_[indices__] /; And @@ (IsIndex /@ {indices})] :=
 
 GetType[FlexibleSUSY`SCALE] := GetRealTypeFromDimension[{}];
 
-GetType[FlexibleSUSY`M[sym_]] :=
+GetType[FlexibleSUSY`FSM[sym_]] :=
     GetRealTypeFromDimension[{SARAH`getGen[sym, FlexibleSUSY`FSEigenstates]}];
 
 GetType[sym_?IsInputParameter] :=
@@ -1381,8 +1381,8 @@ RemoveProtectedHeads[expr_] :=
     expr /. { FlexibleSUSY`LowEnergyConstant[__] -> FlexibleSUSY`LowEnergyConstant[],
               FlexibleSUSY`Pole[__]  -> FlexibleSUSY`Pole[],
               FlexibleSUSY`BETA[__] -> FlexibleSUSY`BETA[],
-              SARAH`Mass  -> FlexibleSUSY`M,
-              SARAH`Mass2 -> FlexibleSUSY`M };
+              SARAH`Mass  -> FlexibleSUSY`FSM,
+              SARAH`Mass2 -> FlexibleSUSY`FSM };
 
 CreateRulesForProtectedHead[expr_, protectedHead_Symbol] :=
     Cases[expr, protectedHead[p__] :> Rule[protectedHead[p],Symbol["x$" <> ToString[Hash[p]]]], {0, Infinity}];
@@ -1409,7 +1409,7 @@ WrapPreprocessorMacroAround[expr_, protectedHeads_List:{FlexibleSUSY`Pole, SARAH
            replacements = Join[
                RuleDelayed[#     , FindMacro[#][#]   ]& /@ allPars,
                RuleDelayed[#[i__], FindMacro[#][#][i]]& /@ allPars,
-               {RuleDelayed[FlexibleSUSY`M[p_[i__]], FindMacro[FlexibleSUSY`M[p]][FlexibleSUSY`M[p]][i]]}
+               {RuleDelayed[FlexibleSUSY`FSM[p_[i__]], FindMacro[FlexibleSUSY`FSM[p]][FlexibleSUSY`FSM[p]][i]]}
            ];
            protectionRules = CreateRulesForProtectedHead[expr, protectedHeads];
            exprWithoutProtectedSymbols = expr /. protectionRules;
@@ -1421,8 +1421,8 @@ DefineLocalConstCopy[parameter_, macro_String, prefix_String:""] :=
     "const auto " <> prefix <> CConversion`ToValidCSymbolString[parameter] <> " = " <>
     macro <> "(" <> CConversion`ToValidCSymbolString[parameter] <> ");\n";
 
-PrivateCallLoopMassFunction[FlexibleSUSY`M[particle_Symbol]] :=
-    "calculate_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[particle]] <> "_pole();\n";
+PrivateCallLoopMassFunction[FlexibleSUSY`FSM[particle_Symbol]] :=
+    "calculate_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[particle]] <> "_pole();\n";
 
 CalculateLocalPoleMasses[parameter_] :=
     "MODEL->" <> PrivateCallLoopMassFunction[parameter];
@@ -1527,7 +1527,7 @@ IncreaseIndexLiterals[expr_, num_Integer] :=
 
 IncreaseIndexLiterals[expr_, num_Integer, heads_List] :=
     Module[{indexedSymbols, rules, allHeads},
-           allHeads = Join[heads /. FlexibleSUSY`M -> Identity, {SARAH`Delta, SARAH`ThetaStep}];
+           allHeads = Join[heads /. FlexibleSUSY`FSM -> Identity, {SARAH`Delta, SARAH`ThetaStep}];
            indexedSymbols = Extract[{expr}, Position[{expr}, s_[__] /; MemberQ[allHeads, s], Infinity]];
            rules = Rule[#, IncreaseIndices[#,num]] & /@ indexedSymbols;
            expr /. rules

--- a/meta/SM/mf_3loop_qcd.m
+++ b/meta/SM/mf_3loop_qcd.m
@@ -10,7 +10,7 @@ Get["meta/ThreeLoopQCD.m"];
 
 MfOvermf = Collect[
    GetMTopPoleOverMTopMSbar[{1,h^1,h^2,h^3}, TopQuark, Q, NH, NL] //. {
-      FlexibleSUSY`M[Fu] -> mf,
+      FlexibleSUSY`FSM[Fu] -> mf,
       h -> (4Pi)^2 k,
       Log[mf^2/Q^2] -> L,
       Log[Q^2/mf^2] -> -L
@@ -20,7 +20,7 @@ MfOvermf = Collect[
 
 mfOverMf = Collect[
    GetMTopMSbarOverMTopPole[{1,h^1,h^2,h^3}, TopQuark, Q, NH, NL] //. {
-      FlexibleSUSY`M[Fu] -> mf,
+      FlexibleSUSY`FSM[Fu] -> mf,
       h -> (4Pi)^2 k,
       Log[mf^2/Q^2] -> L,
       Log[Q^2/mf^2] -> -L

--- a/meta/SelfEnergies.m
+++ b/meta/SelfEnergies.m
@@ -259,7 +259,7 @@ ConvertSarahTadpoles[tadpoles_List] :=
     Module[{result},
            result = (SelfEnergies`Tadpole @@@ tadpoles) /. CreateMassEigenstateReplacements[];
            result = AppendFieldIndices[result, SARAH`gO1];
-           result /. SARAH`Mass -> FlexibleSUSY`M
+           result /. SARAH`Mass -> FlexibleSUSY`FSM
           ];
 
 ConvertSarahSelfEnergies[selfEnergies_List] :=
@@ -299,7 +299,7 @@ ConvertSarahSelfEnergies[selfEnergies_List] :=
                                                    SARAH`VectorG
                                                   ]
                                                ]& /@ heavySE];
-           result /. SARAH`Mass -> FlexibleSUSY`M
+           result /. SARAH`Mass -> FlexibleSUSY`FSM
           ];
 
 GetParticleIndicesInCoupling[Cp[a__]] := Flatten[Cases[{a}, List[__], Infinity]];
@@ -682,7 +682,7 @@ GetTwoLoopTadpoleCorrections[model_String /; model === "MSSM"] :=
            vev2Str = CConversion`RValueToCFormString[SARAH`VEVSM1^2 + SARAH`VEVSM2^2];
            tanbStr = CConversion`RValueToCFormString[SARAH`VEVSM2 / SARAH`VEVSM1];
            muStr   = CConversion`RValueToCFormString[-Parameters`GetEffectiveMu[]];
-           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]];
+           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]];
            mA0Str  = TreeMasses`CallPseudoscalarHiggsMassGetterFunction[] <> "(0)";
 "\
 using namespace flexiblesusy::mssm_twoloophiggs;
@@ -768,7 +768,7 @@ GetTwoLoopTadpoleCorrections[model_String /; model === "NMSSM"] :=
            vev2Str = CConversion`RValueToCFormString[SARAH`VEVSM1^2 + SARAH`VEVSM2^2];
            tanbStr = CConversion`RValueToCFormString[SARAH`VEVSM2 / SARAH`VEVSM1];
            muStr   = CConversion`RValueToCFormString[-Parameters`GetEffectiveMu[]];
-           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]];
+           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]];
            mA0Str  = CConversion`RValueToCFormString[Parameters`GetEffectiveMASqr[]];
            svevStr = CConversion`RValueToCFormString[Parameters`GetParameterFromDescription["Singlet-VEV"]];
            lambdaStr = CConversion`RValueToCFormString[Parameters`GetParameterFromDescription["Singlet-Higgs-Interaction"]];
@@ -1029,7 +1029,7 @@ GetNLoopSelfEnergyCorrections[particle_ /; particle === SARAH`HiggsBoson,
            vuStr   = CConversion`RValueToCFormString[SARAH`VEVSM2];
            tanbStr = CConversion`RValueToCFormString[SARAH`VEVSM2 / SARAH`VEVSM1];
            muStr   = CConversion`RValueToCFormString[-Parameters`GetEffectiveMu[]];
-           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]];
+           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]];
            mA0Str  = TreeMasses`CallPseudoscalarHiggsMassGetterFunction[] <> "(0)";
 "\
 using namespace flexiblesusy::mssm_twoloophiggs;
@@ -1115,7 +1115,7 @@ GetNLoopSelfEnergyCorrections[particle_ /; particle === SARAH`PseudoScalar,
            vuStr   = CConversion`RValueToCFormString[SARAH`VEVSM2];
            tanbStr = CConversion`RValueToCFormString[SARAH`VEVSM2 / SARAH`VEVSM1];
            muStr   = CConversion`RValueToCFormString[-Parameters`GetEffectiveMu[]];
-           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]];
+           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]];
            mA0Str  = TreeMasses`CallPseudoscalarHiggsMassGetterFunction[] <> "(0)";
 "\
 using namespace flexiblesusy::mssm_twoloophiggs;
@@ -1202,7 +1202,7 @@ GetNLoopSelfEnergyCorrections[particle_ /; particle === SARAH`HiggsBoson,
            vuStr   = CConversion`RValueToCFormString[SARAH`VEVSM2];
            tanbStr = CConversion`RValueToCFormString[SARAH`VEVSM2 / SARAH`VEVSM1];
            muStr   = CConversion`RValueToCFormString[-Parameters`GetEffectiveMu[]];
-           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]];
+           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]];
            mA0Str  = CConversion`RValueToCFormString[Parameters`GetEffectiveMASqr[]];
            vsStr   = CConversion`RValueToCFormString[Parameters`GetParameterFromDescription["Singlet-VEV"]];
            lambdaStr = CConversion`RValueToCFormString[Parameters`GetParameterFromDescription["Singlet-Higgs-Interaction"]];
@@ -1300,7 +1300,7 @@ GetNLoopSelfEnergyCorrections[particle_ /; particle === SARAH`PseudoScalar,
            vuStr   = CConversion`RValueToCFormString[SARAH`VEVSM2];
            tanbStr = CConversion`RValueToCFormString[SARAH`VEVSM2 / SARAH`VEVSM1];
            muStr   = CConversion`RValueToCFormString[-Parameters`GetEffectiveMu[]];
-           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]];
+           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]];
            mA0Str  = CConversion`RValueToCFormString[Parameters`GetEffectiveMASqr[]];
            vsStr   = CConversion`RValueToCFormString[Parameters`GetParameterFromDescription["Singlet-VEV"]];
            lambdaStr = CConversion`RValueToCFormString[Parameters`GetParameterFromDescription["Singlet-Higgs-Interaction"]];
@@ -1396,13 +1396,13 @@ GetNLoopSelfEnergyCorrections[particle_ /; particle === SARAH`HiggsBoson,
            vdStr   = CConversion`RValueToCFormString[SARAH`VEVSM1];
            vuStr   = CConversion`RValueToCFormString[SARAH`VEVSM2];
            muStr   = CConversion`RValueToCFormString[Parameters`GetEffectiveMu[]];
-           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]];
+           m3Str   = CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]];
            mA0Str  = TreeMasses`CallPseudoscalarHiggsMassGetterFunction[] <> "(0)";
            AtStr   = CConversion`RValueToCFormString[SARAH`TrilinearUp[2,2] / SARAH`UpYukawa[2,2]];
            AbStr   = CConversion`RValueToCFormString[SARAH`TrilinearDown[2,2] / SARAH`DownYukawa[2,2]];
            AeStr   = CConversion`RValueToCFormString[SARAH`TrilinearLepton[2,2] / SARAH`ElectronYukawa[2,2]];
-           mWStr   = CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`VectorW]];
-           mZStr   = CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`VectorZ]];
+           mWStr   = CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`VectorW]];
+           mZStr   = CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`VectorZ]];
            mq2Str  = CConversion`RValueToCFormString[SARAH`SoftSquark];
            mu2Str  = CConversion`RValueToCFormString[SARAH`SoftUp];
            md2Str  = CConversion`RValueToCFormString[SARAH`SoftDown];

--- a/meta/SemiAnalytic.m
+++ b/meta/SemiAnalytic.m
@@ -303,7 +303,7 @@ GetPlaceholders[FlexibleSUSY`FSSolveEWSBFor[parameters_List]] :=
 *)
 GetBoundaryValueSubstitutions[settings_List] :=
     Module[{i, noTemp, test, fixedPars, boundaryValues, rules, finalRules = {}},
-           noTemp = DeleteCases[settings, {FlexibleSUSY`Temporary[_], _}];
+           noTemp = DeleteCases[settings, {FlexibleSUSY`FSTemporary[_], _}];
            test = Function[{first, second}, first[[1]] === second[[1]]];
            For[i = 1, i <= Length[noTemp], i++,
                Switch[noTemp[[i]],
@@ -685,7 +685,7 @@ ApplySemiAnalyticBoundaryConditions[settings_List, solutions_List, modelPrefix_S
            (* replace implicit constraints with placeholder values *)
            noMacros = ReplaceImplicitConstraints[settings];
            (* @todo handle temporary settings properly *)
-           noMacros = DeleteCases[noMacros, {FlexibleSUSY`Temporary[_], _}];
+           noMacros = DeleteCases[noMacros, {FlexibleSUSY`FSTemporary[_], _}];
            boundaryValues = GetBoundaryValueParameters[solutions];
            parameters = Select[Parameters`FindAllParameters[#[[2]]& /@ noMacros], !MemberQ[boundaryValues, #]&];
            (* in SUSY models, boundary values for the dimensionful SUSY parameters should also be set *)

--- a/meta/ThreeLoopQCD.m
+++ b/meta/ThreeLoopQCD.m
@@ -72,7 +72,7 @@ GetMTopMSbarOverMTopPole1L[Q_, quark_] :=
            colorPosition = Position[SARAH`Gauge, SARAH`color][[1,1]];
            CF = SA`Casimir[quark, colorPosition];
            as = SARAH`strongCoupling^2 / (4 Pi);
-           CF as / Pi (-1 + 3/4 Log[FlexibleSUSY`Pole[FlexibleSUSY`M[quark]]^2/Q^2])
+           CF as / Pi (-1 + 3/4 Log[FlexibleSUSY`Pole[FlexibleSUSY`FSM[quark]]^2/Q^2])
           ];
 
 (* 2-loop coefficients *)
@@ -131,7 +131,7 @@ GetMTopMSbarOverMTopPole2L[Q_, quark_, NH_, NL_] :=
            as = SARAH`strongCoupling^2 / (4 Pi);
            CF (as/Pi)^2 (
                CF d12 + CA d22 + TR NL d32 + TR NH d42 +
-               Get2LLogs[FlexibleSUSY`Pole[FlexibleSUSY`M[quark]], Q, CF, CA]
+               Get2LLogs[FlexibleSUSY`Pole[FlexibleSUSY`FSM[quark]], Q, CF, CA]
            )
           ];
 
@@ -247,7 +247,7 @@ GetMTopMSbarOverMTopPole3L[Q_, quark_, NH_, NL_] :=
                    CA TR NH d73 + TR^2 NL NH d83 + TR^2 NH^2 d93 +
                    TR^2 NL^2 d103
                   ) +
-               Get3LLogs[FlexibleSUSY`M[quark], Q, CF, CA, TR, NL]
+               Get3LLogs[FlexibleSUSY`FSM[quark], Q, CF, CA, TR, NL]
            )
           ];
 
@@ -261,11 +261,11 @@ GetMTopMSbarOverMTopPole[loopOrder_List:{1,1,1,1}, quark_:SARAH`TopQuark, Q_:Q, 
                h^3 GetMTopMSbarOverMTopPole3L[Q, quark, NH, NL]
            );
            (* rewrite in terms of the running mass *)
-           Mpole = FlexibleSUSY`M[quark] / result;
+           Mpole = FlexibleSUSY`FSM[quark] / result;
            result = Normal @ Series[
-               result /. FlexibleSUSY`Pole[FlexibleSUSY`M[quark]] -> Mpole /.
-                         FlexibleSUSY`Pole[FlexibleSUSY`M[quark]] -> Mpole /.
-                         FlexibleSUSY`Pole[FlexibleSUSY`M[quark]] -> FlexibleSUSY`M[quark],
+               result /. FlexibleSUSY`Pole[FlexibleSUSY`FSM[quark]] -> Mpole /.
+                         FlexibleSUSY`Pole[FlexibleSUSY`FSM[quark]] -> Mpole /.
+                         FlexibleSUSY`Pole[FlexibleSUSY`FSM[quark]] -> FlexibleSUSY`FSM[quark],
                {h,0,3}];
            (
                loopOrder[[1]] Coefficient[result, h, 0] +

--- a/meta/ThresholdCorrections.m
+++ b/meta/ThresholdCorrections.m
@@ -93,8 +93,8 @@ CalculateCoupling[{coupling_, name_, group_}, scheme_] :=
                If[!NumericQ[prefactor], prefactor = 0];
                (* sum over generations *)
                If[GetDimension[particle] == 1,
-                  result -= prefactor Global`FiniteLog[Abs[FlexibleSUSY`M[particle]/Global`currentScale]];,
-                  result -= Sum[prefactor Global`FiniteLog[Abs[FlexibleSUSY`M[particle][i-1]/Global`currentScale]],
+                  result -= prefactor Global`FiniteLog[Abs[FlexibleSUSY`FSM[particle]/Global`currentScale]];,
+                  result -= Sum[prefactor Global`FiniteLog[Abs[FlexibleSUSY`FSM[particle][i-1]/Global`currentScale]],
                                 {i,TreeMasses`GetDimensionStartSkippingSMGoldstones[particle],GetDimension[particle]}];
                  ];
               ];
@@ -194,7 +194,7 @@ pars.yt   = model->get_" <> CConversion`RValueToCFormString[Parameters`GetThirdG
 pars.yb   = model->get_" <> CConversion`RValueToCFormString[Parameters`GetThirdGeneration[SARAH`DownYukawa]] <> ";
 pars.mt   = model->get_" <> CConversion`RValueToCFormString[TreeMasses`GetThirdGenerationMass[TreeMasses`GetSMTopQuarkMultiplet[],True,True]] <> ";
 pars.mb   = model->get_" <> CConversion`RValueToCFormString[TreeMasses`GetThirdGenerationMass[TreeMasses`GetSMBottomQuarkMultiplet[],True,True]] <> ";
-pars.mg   = model->get_" <> CConversion`RValueToCFormString[FlexibleSUSY`M[SARAH`Gluino]] <> "();
+pars.mg   = model->get_" <> CConversion`RValueToCFormString[FlexibleSUSY`FSM[SARAH`Gluino]] <> "();
 pars.mst1 = mst_1;
 pars.mst2 = mst_2;
 pars.msb1 = msb_1;
@@ -203,13 +203,13 @@ pars.msd1 = msd_1;
 pars.msd2 = msd_2;
 pars.xt   = Sin(2*theta_t) * (Sqr(mst_1) - Sqr(mst_2)) / (2. * pars.mt);
 pars.xb   = Sin(2*theta_b) * (Sqr(msb_1) - Sqr(msb_2)) / (2. * pars.mb);
-pars.mw   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[SARAH`VectorW]] <> "();
-pars.mz   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[SARAH`VectorZ]] <> "();
-pars.mh   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[SARAH`HiggsBoson]] <>"(0);
-pars.mH   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[SARAH`HiggsBoson]] <> "(1);
-pars.mC   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[SARAH`ChargedHiggs]] <>
+pars.mw   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[SARAH`VectorW]] <> "();
+pars.mz   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[SARAH`VectorZ]] <> "();
+pars.mh   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[SARAH`HiggsBoson]] <>"(0);
+pars.mH   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[SARAH`HiggsBoson]] <> "(1);
+pars.mC   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[SARAH`ChargedHiggs]] <>
    "(" <> ToString[TreeMasses`GetDimensionStartSkippingGoldstones[SARAH`ChargedHiggs]-1] <> ");
-pars.mA   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[SARAH`PseudoScalar]] <>
+pars.mA   = model->get_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[SARAH`PseudoScalar]] <>
    "(" <> ToString[TreeMasses`GetDimensionStartSkippingGoldstones[SARAH`PseudoScalar]-1] <> ");
 pars.mu   = " <> CConversion`RValueToCFormString[Parameters`GetEffectiveMu[]] <> ";
 pars.tb   = model->get_" <> CConversion`RValueToCFormString[SARAH`VEVSM2] <>
@@ -463,8 +463,8 @@ GetParameter[par_[idx1_,idx2_], factor_:1] :=
     CConversion`RValueToCFormString[idx2] <> ")" <>
     MultiplyBy[factor];
 
-GetParameter[FlexibleSUSY`M[par_], factor_:1] :=
-    "MODEL->get_" <> CConversion`RValueToCFormString[FlexibleSUSY`M[par]] <> "()" <>
+GetParameter[FlexibleSUSY`FSM[par_], factor_:1] :=
+    "MODEL->get_" <> CConversion`RValueToCFormString[FlexibleSUSY`FSM[par]] <> "()" <>
     MultiplyBy[factor];
 
 GetParameter[par_[idx_], factor_:1] :=

--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -624,7 +624,7 @@ GetSMMuonLeptonMultiplet[]     := GetDownLepton[2] /. head_[_] :> head;
 GetSMTauLeptonMultiplet[]      := GetDownLepton[3] /. head_[_] :> head;
 
 GetMass[particle_[idx__]] := GetMass[particle][idx];
-GetMass[particle_Symbol] := FlexibleSUSY`M[particle];
+GetMass[particle_Symbol] := FlexibleSUSY`FSM[particle];
 
 GetElectricCharge[p_] :=
     Module[{charge},
@@ -735,11 +735,11 @@ DimOf[CConversion`ScalarType[CConversion`realScalarCType]] := 1;
 DimOf[CConversion`VectorType[CConversion`realScalarCType, dim]] := dim;
 DimOf[t_] := (Print["Unknown type: ", t]; Quit[1]);
 
-GetMassType[FlexibleSUSY`M[particles_List]] :=
+GetMassType[FlexibleSUSY`FSM[particles_List]] :=
     CConversion`VectorType[CConversion`realScalarCType,
                            Plus @@ (DimOf /@ (GetMassType /@ particles))];
 
-GetMassType[FlexibleSUSY`M[particle_]] := GetMassType[particle];
+GetMassType[FlexibleSUSY`FSM[particle_]] := GetMassType[particle];
 
 GetMassType[particle_] :=
     Module[{dim = GetDimension[particle]},
@@ -1011,7 +1011,7 @@ GetMassEigenstate[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[2]];
 GetMassMatrix[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[1]];
 
 MakeESSymbol[p_List] := Symbol[StringJoin[ToString /@ p]];
-MakeESSymbol[FlexibleSUSY`M[p_List]] := FlexibleSUSY`M[MakeESSymbol[p]];
+MakeESSymbol[FlexibleSUSY`FSM[p_List]] := FlexibleSUSY`FSM[MakeESSymbol[p]];
 MakeESSymbol[p_] := p;
 
 CreateMassGetter[p:TreeMasses`FSMassMatrix[_,massESSymbols_List,_], postFix_String:"", wrapper_String:""] :=
@@ -1023,7 +1023,7 @@ CreateMassGetter[p:TreeMasses`FSMassMatrix[_,massESSymbols_List,_], postFix_Stri
 CreateMassGetter[massMatrix_TreeMasses`FSMassMatrix, postFix_String:"", wrapper_String:""] :=
     Module[{massESSymbol, returnType, dim, dimStr, massESSymbolStr},
            massESSymbol = GetMassEigenstate[massMatrix];
-           massESSymbolStr = CConversion`ToValidCSymbolString[FlexibleSUSY`M[MakeESSymbol[massESSymbol]]];
+           massESSymbolStr = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[MakeESSymbol[massESSymbol]]];
            dim = GetDimension[massESSymbol];
            dimStr = ToString[dim];
            If[dim == 1,
@@ -1137,7 +1137,7 @@ FillSpectrumVector[particles_List] :=
            For[i = 1, i <= Length[particles], i++,
                par = particles[[i]];
                parStr = CConversion`ToValidCSymbolString[par];
-               massStr = CConversion`ToValidCSymbolString[FlexibleSUSY`M[par]];
+               massStr = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[par]];
                latexName = StringReplace[SARAH`getLaTeXField[par], "\\" -> "\\\\"];
                result = result <> "spectrum.emplace_back(TParticle(\"" <> parStr <>
                         "\", \"" <> latexName <> "\", to_valarray(PHYSICAL(" <>
@@ -1207,7 +1207,7 @@ CreateFSMassMatrixForUnmixedParticle[TreeMasses`FSMassMatrix[expr_, massESSymbol
           ];
 
 CreateMassCalculationPrototype[m:TreeMasses`FSMassMatrix[expr_, massESSymbol_, Null]] :=
-    Module[{result, ev = CConversion`ToValidCSymbolString[FlexibleSUSY`M[massESSymbol]],
+    Module[{result, ev = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[massESSymbol]],
             massMatrix},
            result = "void calculate_" <> ev <> "();\n";
            massMatrix = CreateFSMassMatrixForUnmixedParticle[m];
@@ -1220,7 +1220,7 @@ CreateMassCalculationPrototype[massMatrix_TreeMasses`FSMassMatrix] :=
     Module[{result = "", massESSymbol},
            massESSymbol = GetMassEigenstate[massMatrix];
            result = CreateMassMatrixGetterPrototype[massMatrix] <>
-                    "void calculate_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[MakeESSymbol[massESSymbol]]] <>
+                    "void calculate_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[MakeESSymbol[massESSymbol]]] <>
                     "();\n";
            Return[result];
           ];
@@ -1285,7 +1285,7 @@ CallMassCalculationFunctions[massMatrices_List] :=
 CallMassCalculationFunction[massMatrix_TreeMasses`FSMassMatrix] :=
     Module[{result = "", k, massESSymbol},
            massESSymbol = GetMassEigenstate[massMatrix];
-           result = "calculate_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`M[MakeESSymbol[massESSymbol]]]
+           result = "calculate_" <> CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[MakeESSymbol[massESSymbol]]]
                     <> "();\n";
            Return[result];
           ];
@@ -1428,8 +1428,8 @@ WrapMacro[sym_String, macro_String] := macro <> "(" <> sym <> ")";
 
 CreateReorderingFunctionCalls[{idx_Integer, vector_, higgs_, mixingMatrix_}, macro_String:""] :=
     "move_goldstone_to(" <> ToString[idx-1] <> ", " <>
-    WrapMacro[CConversion`ToValidCSymbolString[FlexibleSUSY`M[vector]], ""] <> ", " <>
-    WrapMacro[CConversion`ToValidCSymbolString[FlexibleSUSY`M[higgs]], macro] <> ", " <>
+    WrapMacro[CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[vector]], ""] <> ", " <>
+    WrapMacro[CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[higgs]], macro] <> ", " <>
     WrapMacro[CConversion`ToValidCSymbolString[mixingMatrix], macro] <> ");\n";
 
 CreateReorderingFunctionCalls[___] := "";
@@ -1470,7 +1470,7 @@ CheckPoleMassesForTachyons[particle_, macro_String] :=
               Return[""];
              ];
            "if (" <>
-           WrapMacro[CConversion`ToValidCSymbolString[FlexibleSUSY`M[particle]],macro] <>
+           WrapMacro[CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[particle]],macro] <>
            If[dimEnd > 1, ".tail<" <> ToString[dimEnd - dimStart + 1] <> ">().minCoeff()", ""]<>
            " < 0.) { " <> FlagPoleTachyon[particleName] <> " }"
           ];
@@ -1497,7 +1497,7 @@ FillGoldstoneMassVector[targetVector_String, vectorList_List] :=
     Module[{i, result = ""},
            For[i = 0, i < Length[vectorList], i++,
                result = result <> targetVector <> "(" <> ToString[i] <> ") = " <>
-                        CConversion`ToValidCSymbolString[FlexibleSUSY`M[vectorList[[i+1]]]] <>
+                        CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[vectorList[[i+1]]]] <>
                         ";\n";
               ];
            result
@@ -1512,7 +1512,7 @@ CreateHiggsMassGetters[particle_, macro_String] :=
             typeHiggs, typeGoldstone, body, name,
             dim, dimGoldstone, dimHiggs},
            name                 = GetHiggsName[particle];
-           particleStr          = CConversion`ToValidCSymbolString[FlexibleSUSY`M[particle]];
+           particleStr          = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[particle]];
            particleHiggsStr     = particleStr <> "_" <> name;
            particleGoldstoneStr = particleStr <> "_goldstone";
            vectorList = Cases[SARAH`GoldstoneGhost,
@@ -1621,10 +1621,10 @@ CallDiagonalizeHermitianFunction[particle_, matrix_String, eigenvector_String, U
 
 AssignVectorBosonMassesFrom[eigenVector_List] :=
     Module[{i, ev, result = ""},
-           ev = CConversion`ToValidCSymbolString[FlexibleSUSY`M[CConversion`GetHead[MakeESSymbol[eigenVector]]]];
+           ev = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[CConversion`GetHead[MakeESSymbol[eigenVector]]]];
            For[i = 1, i <= Length[eigenVector], i++,
                result = result <>
-                        CConversion`ToValidCSymbolString[FlexibleSUSY`M[eigenVector[[i]]]] <>
+                        CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[eigenVector[[i]]]] <>
                         " = " <>
                         If[IsMassless[eigenVector[[i]]],
                            "0.;\n",
@@ -1644,7 +1644,7 @@ CreateDiagonalizationFunction[matrix_List, eigenVector_, mixingMatrixSymbol_] :=
            dimStr = ToString[dim];
            particle = CConversion`ToValidCSymbolString[CConversion`GetHead[MakeESSymbol[eigenVector]]];
            matrixSymbol = "mass_matrix_" <> particle;
-           ev = CConversion`ToValidCSymbolString[FlexibleSUSY`M[CConversion`GetHead[MakeESSymbol[eigenVector]]]];
+           ev = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[CConversion`GetHead[MakeESSymbol[eigenVector]]]];
            evMap = ev;
            result = "void CLASSNAME::calculate_" <> ev <> "()\n{\n";
            body = IndentText["const auto " <> matrixSymbol <> "(get_" <> matrixSymbol <> "());\n"];
@@ -1708,7 +1708,7 @@ CreateDiagonalizationFunction[matrix_List, eigenVector_, mixingMatrixSymbol_] :=
           ];
 
 CreateMassCalculationFunction[m:TreeMasses`FSMassMatrix[mass_, massESSymbol_, Null]] :=
-    Module[{result, ev = CConversion`ToValidCSymbolString[FlexibleSUSY`M[massESSymbol]], body,
+    Module[{result, ev = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[massESSymbol]], body,
             inputParsDecl, expr, particle, dim, dimStr, phase, massMatrix,
             massMatrixStr},
            result = "void CLASSNAME::calculate_" <> ev <> "()\n{\n";
@@ -1802,7 +1802,7 @@ CreatePhysicalMassDefinition[massMatrix_TreeMasses`FSMassMatrix] :=
               type = CConversion`ArrayType[CConversion`realScalarCType, dim];
              ];
            Parameters`CreateParameterDefinitionAndDefaultInitialize[
-               {CConversion`ToValidCSymbolString[FlexibleSUSY`M[MakeESSymbol[massESSymbol]]], type}
+               {CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[MakeESSymbol[massESSymbol]]], type}
            ]
           ];
 
@@ -1834,7 +1834,7 @@ ClearOutputParameters[massMatrix_TreeMasses`FSMassMatrix] :=
            mixingMatrixSymbol = GetMixingMatrixSymbol[massMatrix];
            dim = GetDimension[massESSymbol];
            massESType = Parameters`GetRealTypeFromDimension[{dim}];
-           result = CConversion`SetToDefault[CConversion`ToValidCSymbolString[FlexibleSUSY`M[MakeESSymbol[massESSymbol]]],
+           result = CConversion`SetToDefault[CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[MakeESSymbol[massESSymbol]]],
                                              massESType];
            If[mixingMatrixSymbol =!= Null,
               matrixType = GetMixingMatrixType[massMatrix];
@@ -1867,7 +1867,7 @@ CopyRunningMassesFromTo[massMatrix_TreeMasses`FSMassMatrix, from_String, to_Stri
            dimStr = ToString[dim];
            (* copy mass *)
            If[massESSymbol =!= Null,
-              massStr = CConversion`ToValidCSymbolString[FlexibleSUSY`M[MakeESSymbol[massESSymbol]]];
+              massStr = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[MakeESSymbol[massESSymbol]]];
               result = WrapMacro[massStr, to] <> " = " <> WrapMacro[massStr, from] <> ";\n";
            ];
            (* copy mixings *)
@@ -1990,17 +1990,17 @@ ReplaceDependenciesReverse[expr_] :=
 
 CallGenerationHelperFunctionName[gen_, fermion_, msf1_String, msf2_String, theta_] :=
     "calculate_" <>
-    CConversion`ToValidCSymbolString[FlexibleSUSY`M[fermion]] <>
+    CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[fermion]] <>
     "_" <> NiceGenNum[gen] <> "_generation(" <> msf1 <> ", " <> msf2 <> ", " <> theta <> ")";
 
 CreateGenerationHelperPrototype[gen_, fermion_] :=
     "void calculate_" <>
-    CConversion`ToValidCSymbolString[FlexibleSUSY`M[fermion]] <>
+    CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[fermion]] <>
     "_" <> NiceGenNum[gen] <> "_generation(double&, double&, double&) const;\n";
 
 CreateGenerationHelperFunction[gen_, fermion_ /; fermion === SARAH`TopSquark] :=
     "void CLASSNAME::calculate_" <>
-    CConversion`ToValidCSymbolString[FlexibleSUSY`M[fermion]] <>
+    CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[fermion]] <>
     "_" <> NiceGenNum[gen] <> "_generation(double& msf1, double& msf2, double& theta) const {
    sfermions::Mass_data sf_data;
    sf_data.ml2 = Re(" <> CConversion`RValueToCFormString[SARAH`SoftSquark[gen-1,gen-1]] <> ");
@@ -2030,7 +2030,7 @@ CreateGenerationHelperFunction[gen_, fermion_ /; fermion === SARAH`TopSquark] :=
 
 CreateGenerationHelperFunction[gen_, fermion_ /; fermion === SARAH`BottomSquark] :=
     "void CLASSNAME::calculate_" <>
-    CConversion`ToValidCSymbolString[FlexibleSUSY`M[fermion]] <>
+    CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[fermion]] <>
     "_" <> NiceGenNum[gen] <> "_generation(double& msf1, double& msf2, double& theta) const {
    sfermions::Mass_data sf_data;
    sf_data.ml2 = Re(" <> CConversion`RValueToCFormString[SARAH`SoftSquark[gen-1,gen-1]] <> ");
@@ -2060,7 +2060,7 @@ CreateGenerationHelperFunction[gen_, fermion_ /; fermion === SARAH`BottomSquark]
 
 CreateGenerationHelperFunction[gen_, fermion_ /; fermion === SARAH`Selectron] :=
     "void CLASSNAME::calculate_" <>
-    CConversion`ToValidCSymbolString[FlexibleSUSY`M[fermion]] <>
+    CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[fermion]] <>
     "_" <> NiceGenNum[gen] <> "_generation(double& msf1, double& msf2, double& theta) const {
    sfermions::Mass_data sf_data;
    sf_data.ml2 = Re(" <> CConversion`RValueToCFormString[SARAH`SoftLeftLepton[gen-1,gen-1]] <> ");
@@ -2090,7 +2090,7 @@ CreateGenerationHelperFunction[gen_, fermion_ /; fermion === SARAH`Selectron] :=
 
 CreateGenerationHelperFunction[gen_, fermion_ /; fermion === SARAH`Sneutrino] :=
     "void CLASSNAME::calculate_" <>
-    CConversion`ToValidCSymbolString[FlexibleSUSY`M[fermion]] <>
+    CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[fermion]] <>
     "_" <> NiceGenNum[gen] <> "_generation(double& msf1, double& msf2, double& theta) const {
    sfermions::Mass_data sf_data;
    sf_data.ml2 = Re(" <> CConversion`RValueToCFormString[SARAH`SoftLeftLepton[gen-1,gen-1]] <> ");
@@ -2131,7 +2131,7 @@ CreateGenerationHelperFunction[gen_, fermion_] :=
            Print["Error: ", fermion, " does not seem to be a", gen, "th"
                  " generation SM fermion."];
            "void CLASSNAME::calculate_" <>
-           CConversion`ToValidCSymbolString[FlexibleSUSY`M[fermion]] <>
+           CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[fermion]] <>
            "_" <> NiceGenNum[gen] <> "_generation(double& msf1, double& msf2, double& theta) const {}"
           ];
 
@@ -2151,19 +2151,19 @@ CreateGenerationHelpers[gen_] :=
 GetThirdGenerationMass[fermion_, cConvention_:True, bracket_:False] :=
     If[GetDimension[fermion] == 1,
        If[bracket,
-          FlexibleSUSY`M[fermion][],
-          FlexibleSUSY`M[fermion]
+          FlexibleSUSY`FSM[fermion][],
+          FlexibleSUSY`FSM[fermion]
          ]
        ,
-       FlexibleSUSY`M[fermion][3 - If[cConvention === True, 1, 0]]
+       FlexibleSUSY`FSM[fermion][3 - If[cConvention === True, 1, 0]]
       ];
 
 GetLightestMass[par_] :=
     Module[{dim, mass},
            dim = GetDimension[par];
            If[dim == 1,
-              mass = FlexibleSUSY`M[par];,
-              mass = FlexibleSUSY`M[par][0];
+              mass = FlexibleSUSY`FSM[par];,
+              mass = FlexibleSUSY`FSM[par][0];
              ];
            Return[mass];
           ];
@@ -2211,14 +2211,14 @@ CreateMassArrayGetter[masses_List] :=
                If[Head[GetMassEigenstate[masses[[i]]]] === List,
                   mes = DeleteDuplicates[GetMassEigenstate[masses[[i]]]];
                   For[v = 1, v <= Length[mes], v++,
-                      mass = FlexibleSUSY`M[mes[[v]]];
+                      mass = FlexibleSUSY`FSM[mes[[v]]];
                       type = GetMassType[mass];
                       {assignment, nAssignments} = Parameters`CreateDisplayAssignment[mass, paramCount, type];
                       display = display <> assignment;
                       paramCount += nAssignments;
                      ];
                   ,
-                  mass = FlexibleSUSY`M[GetMassEigenstate[masses[[i]]]];
+                  mass = FlexibleSUSY`FSM[GetMassEigenstate[masses[[i]]]];
                   type = GetMassType[mass];
                   {assignment, nAssignments} = Parameters`CreateDisplayAssignment[mass, paramCount, type];
                   display = display <> assignment;
@@ -2249,7 +2249,7 @@ CreateMassArraySetter[masses_List, array_String] :=
                If[Head[GetMassEigenstate[masses[[i]]]] === List,
                   mes = DeleteDuplicates[GetMassEigenstate[masses[[i]]]];
                   For[v = 1, v <= Length[mes], v++,
-                      mass = FlexibleSUSY`M[mes[[v]]];
+                      mass = FlexibleSUSY`FSM[mes[[v]]];
                       type = GetMassType[mass];
                       name = CConversion`ToValidCSymbolString[mass];
                       {assignment, nAssignments} = Parameters`CreateSetAssignment[name, paramCount, type];
@@ -2257,7 +2257,7 @@ CreateMassArraySetter[masses_List, array_String] :=
                       paramCount += nAssignments;
                      ];
                   ,
-                  mass = FlexibleSUSY`M[GetMassEigenstate[masses[[i]]]];
+                  mass = FlexibleSUSY`FSM[GetMassEigenstate[masses[[i]]]];
                   type = GetMassType[mass];
                   name = CConversion`ToValidCSymbolString[mass];
                   {assignment, nAssignments} = Parameters`CreateSetAssignment[name, paramCount, type];

--- a/meta/TwoLoopQCD.m
+++ b/meta/TwoLoopQCD.m
@@ -71,7 +71,7 @@ GetDeltaMPoleOverMRunningQCDTwoLoopDRbar[quark_ /; quark === TreeMasses`GetSMTop
            CF = SA`Casimir[quark, colorPosition];
            CA = SA`Casimir[SARAH`VectorG, colorPosition];
            alphaStrong = SARAH`strongCoupling^2 / (4 Pi);
-           mf = FlexibleSUSY`M[quark];
+           mf = FlexibleSUSY`FSM[quark];
            log = Log[(mf / renScale)^2];
            result = CF (alphaStrong / (4 Pi))^2 (
                -43 - 12 Zeta[2] + 26 log - 6 log^2
@@ -88,8 +88,8 @@ GetDeltaMPoleOverMRunningQCDTwoLoopDRbar[quark_ /; quark === TreeMasses`GetSMBot
            CF = SA`Casimir[quark, colorPosition];
            CA = SA`Casimir[SARAH`VectorG, colorPosition];
            alphaStrong = SARAH`strongCoupling^2 / (4 Pi);
-           mf = FlexibleSUSY`M[quark];
-           mt = FlexibleSUSY`M[TreeMasses`GetSMTopQuarkMultiplet[]];
+           mf = FlexibleSUSY`FSM[quark];
+           mt = FlexibleSUSY`FSM[TreeMasses`GetSMTopQuarkMultiplet[]];
            log = Log[(mf / renScale)^2];
            logMt = Log[(mf / mt)^2];
            result = CF (alphaStrong / (4 Pi))^2 (
@@ -111,7 +111,7 @@ GetDeltaMPoleOverMRunningQCDTwoLoopMSbar[quark_, renScale_] :=
            CF = SA`Casimir[quark, colorPosition];
            CA = SA`Casimir[SARAH`VectorG, colorPosition];
            alphaStrong = SARAH`strongCoupling^2 / (4 Pi);
-           mf = FlexibleSUSY`M[quark];
+           mf = FlexibleSUSY`FSM[quark];
            log = Log[(renScale / mf)^2];
            I31 = 3/2 Zeta[3] - 6 Zeta[2] Log[2];
            result = (alphaStrong / (4 Pi))^2 (
@@ -137,7 +137,7 @@ GetDeltaMPoleOverMRunningQCDOneLoopDRbar[quark_, renScale_] :=
            colorPosition = Position[SARAH`Gauge, SARAH`color][[1,1]];
            CF = SA`Casimir[quark, colorPosition];
            alphaStrong = SARAH`strongCoupling^2 / (4 Pi);
-           mf = FlexibleSUSY`M[quark];
+           mf = FlexibleSUSY`FSM[quark];
            result = CF alphaStrong / (4 Pi) (5 - 3 Log[(mf / renScale)^2]);
            result
           ];
@@ -147,7 +147,7 @@ GetDeltaMPoleOverMRunningQCDOneLoopMSbar[quark_, renScale_] :=
            colorPosition = Position[SARAH`Gauge, SARAH`color][[1,1]];
            CF = SA`Casimir[quark, colorPosition];
            alphaStrong = SARAH`strongCoupling^2 / (4 Pi);
-           mf = FlexibleSUSY`M[quark];
+           mf = FlexibleSUSY`FSM[quark];
            result = CF alphaStrong / (4 Pi) (4 - 3 Log[(mf / renScale)^2]);
            result
           ];

--- a/meta/WeinbergAngle.m
+++ b/meta/WeinbergAngle.m
@@ -332,7 +332,7 @@ HiggsContributions2LoopSM[] :=
               MuonDecayWorks = False;
               DebugPrint["Error: SM like Higgs vev does not exist"];
               Return[0]];
-           higgsDep = (Abs[#[[2]]]^2 - Abs[#[[3]]]^2) RHO2[FlexibleSUSY`M[#[[1]]]/MT] &;
+           higgsDep = (Abs[#[[2]]]^2 - Abs[#[[3]]]^2) RHO2[FlexibleSUSY`FSM[#[[1]]]/MT] &;
            Simplify[3 (GFERMI MT higgsVEV / (8 Pi^2 Sqrt[2]))^2 *
                     (Plus @@ (higgsDep /@ Join[HiggsTopVertices[SARAH`HiggsBoson],
                                                HiggsTopVertices[SARAH`PseudoScalar]]))]
@@ -611,7 +611,7 @@ VertexResultFFS[diagr_List, includeGoldstones_] :=
            intfermions = Select[intparticles, TreeMasses`IsFermion];
            intscalar = Select[intparticles, TreeMasses`IsScalar][[1]];
            result = couplFFSout couplFFSin *
-                    (-couplFFVPL FlexibleSUSY`M[intfermions[[1]]] FlexibleSUSY`M[intfermions[[2]]] *
+                    (-couplFFVPL FlexibleSUSY`FSM[intfermions[[1]]] FlexibleSUSY`FSM[intfermions[[2]]] *
                         SARAH`C0[SARAH`Mass2[intscalar], SARAH`Mass2[intfermions[[1]]],
                                  SARAH`Mass2[intfermions[[2]]]] +
                      1/2 couplFFVPR *
@@ -779,10 +779,10 @@ BoxResult[diagr_List, includeGoldstones_] :=
            If[toponr == 2 && TreeMasses`IsFermion[intparticles[[1]]],
               result = result * (-1) * SARAH`D27[Sequence @@ SARAH`Mass2 /@ intparticles]];
            If[toponr == 2 && TreeMasses`IsScalar[intparticles[[1]]],
-              result = result * 1/2 * FlexibleSUSY`M[intfermions[[1]]] FlexibleSUSY`M[intfermions[[2]]] *
+              result = result * 1/2 * FlexibleSUSY`FSM[intfermions[[1]]] FlexibleSUSY`FSM[intfermions[[2]]] *
                        SARAH`D0[Sequence @@ SARAH`Mass2 /@ intparticles]];
            If[toponr == 3 && TreeMasses`IsFermion[intparticles[[1]]],
-              result = result * 1/2 * FlexibleSUSY`M[intfermions[[1]]] FlexibleSUSY`M[intfermions[[2]]] *
+              result = result * 1/2 * FlexibleSUSY`FSM[intfermions[[1]]] FlexibleSUSY`FSM[intfermions[[2]]] *
                        SARAH`D0[Sequence @@ SARAH`Mass2 /@ intparticles]];
            If[toponr == 3 && TreeMasses`IsScalar[intparticles[[1]]],
               result = result * (-1) * SARAH`D27[Sequence @@ SARAH`Mass2 /@ intparticles]];

--- a/meta/WriteOut.m
+++ b/meta/WriteOut.m
@@ -204,7 +204,7 @@ WriteSLHAMass[massMatrix_TreeMasses`FSMassMatrix] :=
               pdg = Abs[pdgList[[1]]];
               If[pdg != 0,
                  eigenstateNameStr = CConversion`RValueToCFormString[eigenstateName];
-                 massNameStr = CConversion`RValueToCFormString[FlexibleSUSY`M[eigenstateName]];
+                 massNameStr = CConversion`RValueToCFormString[FlexibleSUSY`FSM[eigenstateName]];
                  result = "<< FORMAT_MASS(" <> ToString[pdg] <>
                           ", LOCALPHYSICAL(" <> massNameStr <> "), \"" <> eigenstateNameStr <> "\")\n";
                 ];
@@ -213,7 +213,7 @@ WriteSLHAMass[massMatrix_TreeMasses`FSMassMatrix] :=
                   pdg = Abs[pdgList[[i]]];
                   If[pdg != 0,
                      eigenstateNameStr = CConversion`RValueToCFormString[eigenstateName] <> "(" <> ToString[i] <> ")";
-                     massNameStr = CConversion`RValueToCFormString[FlexibleSUSY`M[eigenstateName[i-1]]];
+                     massNameStr = CConversion`RValueToCFormString[FlexibleSUSY`FSM[eigenstateName[i-1]]];
                      result = result <> "<< FORMAT_MASS(" <> ToString[pdg] <>
                               ", LOCALPHYSICAL(" <> massNameStr <> "), \"" <> eigenstateNameStr <> "\")\n";
                     ];
@@ -750,7 +750,7 @@ ReadSLHAPhysicalMixingMatrixBlock[{parameter_, blockName_}, struct_String:"PHYSI
 
 ReadSLHAPhysicalMass[particle_,struct_String:"PHYSICAL"] :=
     Module[{result = "", mass, massStr, dim, pdgList, pdg, pdgStr, i},
-           mass = FlexibleSUSY`M[particle];
+           mass = FlexibleSUSY`FSM[particle];
            massStr = CConversion`ToValidCSymbolString[mass];
            dim = TreeMasses`GetDimension[particle];
            pdgList = SARAH`getPDGList[particle];
@@ -829,7 +829,7 @@ ConvertMixingsToConvention[massMatrices_List, convention_String] :=
                eigenstateName = TreeMasses`GetMassEigenstate[massMatrices[[i]]];
                mixingMatrixSym = TreeMasses`GetMixingMatrixSymbol[massMatrices[[i]]];
                If[IsMajoranaFermion[eigenstateName] && mixingMatrixSym =!= Null,
-                  eigenstateNameStr  = CConversion`ToValidCSymbolString[FlexibleSUSY`M[eigenstateName]];
+                  eigenstateNameStr  = CConversion`ToValidCSymbolString[FlexibleSUSY`FSM[eigenstateName]];
                   mixingMatrixSymStr = CConversion`ToValidCSymbolString[mixingMatrixSym];
                   result = result <>
                            "convert_symmetric_fermion_mixings_to_" <> convention <> "(LOCALPHYSICAL(" <>


### PR DESCRIPTION
It's ugly but works. The speedup is not very impressive. For MSSM with decays, where single thread call of `CreateVertices` takes 35s we are down on 4 cores to 15-16s. In the MRSSM, where I'm testing calculation of decays of `{hh, Ah, Hpm, Se, Sv, phiO, sigmaO, Rh}` we're down from 278 to 67s.

**Stuff to fix**:
```
From KernelObject[1, local]:
M::shdw: Symbol M appears in multiple contexts 
    {FlexibleSUSY`, Susyno`LieGroups`}; definitions in context FlexibleSUSY`
     may shadow or be shadowed by other definitions.
From KernelObject[1, local]:
Temporary::shdw: 
   Symbol Temporary appears in multiple contexts {FlexibleSUSY`, System`}
    ; definitions in context FlexibleSUSY`
     may shadow or be shadowed by other definitions.
From KernelObject[2, local]:
```
Also, the `CreateVertex` gives
```
Part::pkspec1: The expression a cannot be used as a part specification.
```
It doesn't seem to break anything though.