### PR TITLE
fixed permutation of VVV vertices

### DIFF
--- a/meta/Utils.m
+++ b/meta/Utils.m
@@ -213,7 +213,6 @@ Warning: This function may ignore empty lines.";
 FSReIm::usage = "FS replacement for the mathematica's function ReIm";
 FSBooleanQ::usage = "FS replacement for the mathematica's function BooleanQ";
 MathIndexToCPP::usage = "Converts integer-literal index from mathematica to c/c++ convention";
-
 FSPermutationSign::usage = "Returns the sign of a permutation given in a Cycles form";
 
 Begin["`Private`"];

--- a/meta/Vertices.m
+++ b/meta/Vertices.m
@@ -107,6 +107,11 @@ SortCp[SARAH`Cp[fields__]] :=
 
 SortCp[SARAH`Cp[fields__][lor_]] := SortCp[SARAH`Cp[fields]][lor];
 
+SortCp[SARAH`Cp[vectors__]] /; CpType[SARAH`Cp[vectors]] === VVV := Module[
+	{sortedVectors = SortFieldsInCp[{vectors}]},
+	Utils`FSPermutationSign[FindPermutation[{vectors}, sortedVectors]] * SARAH`Cp @@ sortedVectors
+];
+
 (* see OrderVVVV[] in SARAH/Package/SPheno/SPhenoFunc.m *)
 SortCp[cp : SARAH`Cp[vectors__][lor_Integer]] /; CpType[cp] === VVVV :=
 Module[{

--- a/test/test_SM_cxxdiagrams.meta
+++ b/test/test_SM_cxxdiagrams.meta
@@ -118,8 +118,8 @@ nonzeroVertexPairs = {
 		{"CpbargWpgWpVZ"}
 	},
 	{
-		{TreeMasses`GetWBoson[], CXXDiagrams`LorentzConjugate[TreeMasses`GetWBoson[]],
-			TreeMasses`GetZBoson[]},
+      {CXXDiagrams`LorentzConjugate[TreeMasses`GetWBoson[]], TreeMasses`GetWBoson[],
+         TreeMasses`GetZBoson[]},
 		{"CpconjVWpVWpVZ"}
 	},
 	{


### PR DESCRIPTION
I think there might be a sign error in `VVV` vertices.
`Vertex[{conj[VWp], VWp, VZ}]` gives
```mathematica
{
{conj[VWp[{lt1}]], VWp[{lt2}], VZ[{lt3}]}, 
{I g2 Cos[ThetaW], 
   g[lt1, lt2] (-Mom[conj[VWp[{lt1}]], lt3] + Mom[VWp[{lt2}], lt3]) + 
   g[lt2, lt3] (-Mom[VWp[{lt2}], lt1] + Mom[VZ[{lt3}], lt1]) + 
   g[lt1, lt3] (Mom[conj[VWp[{lt1}]], lt2] - Mom[VZ[{lt3}], lt2])
}
}
```
while `Vertex[{VWp, conj[VWp], VZ}]` gives
```mathematica
{
{VWp[{lt1}], conj[VWp[{lt2}]], VZ[{lt3}]}, 
{-I g2 Cos[ThetaW], 
   -g[lt1, lt2] (-Mom[conj[VWp[{lt2}]], lt3] + Mom[VWp[{lt1}], lt3]) - 
   g[lt2, lt3] (Mom[conj[VWp[{lt2}]], lt1] - Mom[VZ[{lt3}], lt1]) - 
   g[lt1, lt3] (-Mom[VWp[{lt1}], lt2] + Mom[VZ[{lt3}], lt2])
}
}
```
If you look only a the value of the coupling, not the lorentz structure, then they differ by sign. But currently, there is no `SortCp` rule for `VVV` couplings. This means, that when you ask for the value of `Vertex[{conj[VWp], VWp, VZ}]` you'll get the same as for `Vertex[{VWp, conj[VWp], VZ}]`. This PR fixes this. The only thing I'm not sure is why hasn't this been a problem before? I've added Jae-hyeon to the discussion since he's the original author of `SortCp`.

Ps. This potentially also affects @dhjjacob and @uukhas