### PR TITLE
Avoid SARAH`Start if there is no need 

### DIFF
--- a/meta/EffectiveCouplings.m
+++ b/meta/EffectiveCouplings.m
@@ -502,8 +502,9 @@ CreateEffectiveCouplingPrototype[coupling_] :=
 GetEffectiveVEV[] :=
     Module[{vev, parameters = {}, result = ""},
            If[SARAH`SupersymmetricModel,
+              (* The last replacement fixes vev issue during usage of Utils`DumpStart *)
               vev = Simplify[2 Sqrt[-SARAH`Vertex[{SARAH`VectorW, Susyno`LieGroups`conj[SARAH`VectorW]}][[2,1]]
-                           / SARAH`leftCoupling^2] /. SARAH`sum[a_,b_,c_,d_] :> Sum[d,{a,b,c}]];
+                           / SARAH`leftCoupling^2] /. SARAH`sum[a_,b_,c_,d_] :> Sum[d,{a,b,c}]] /. (x_)[{_}] :> x;
               vev = Parameters`DecreaseIndexLiterals[vev];
               parameters = Parameters`FindAllParameters[vev];
               result = "const auto vev = " <> CConversion`RValueToCFormString[vev] <> ";\n";,

--- a/meta/EffectiveCouplings.m
+++ b/meta/EffectiveCouplings.m
@@ -502,9 +502,8 @@ CreateEffectiveCouplingPrototype[coupling_] :=
 GetEffectiveVEV[] :=
     Module[{vev, parameters = {}, result = ""},
            If[SARAH`SupersymmetricModel,
-              (* The last replacement fixes vev issue during usage of Utils`DumpStart *)
               vev = Simplify[2 Sqrt[-SARAH`Vertex[{SARAH`VectorW, Susyno`LieGroups`conj[SARAH`VectorW]}][[2,1]]
-                           / SARAH`leftCoupling^2] /. SARAH`sum[a_,b_,c_,d_] :> Sum[d,{a,b,c}]] /. (x_)[{_}] :> x;
+                           / SARAH`leftCoupling^2] /. SARAH`sum[a_,b_,c_,d_] :> Sum[d,{a,b,c}]];
               vev = Parameters`DecreaseIndexLiterals[vev];
               parameters = Parameters`FindAllParameters[vev];
               result = "const auto vev = " <> CConversion`RValueToCFormString[vev] <> ";\n";,

--- a/meta/NPointFunctions.m
+++ b/meta/NPointFunctions.m
@@ -856,6 +856,7 @@ Module[
    DistributeDefinitions[currentPath, currentDir, fsMetaDir, sarahInputDirs,
       sarahOutputDir, SARAHModelName, eigenstates];
 
+   SetSharedFunction[Print];
    ParallelEvaluate[
       $Path = currentPath;
       SetDirectory@currentDir;
@@ -863,6 +864,7 @@ Module[
       NPointFunctions`CreateFAModelFile[sarahInputDirs,sarahOutputDir,
          SARAHModelName, eigenstates];,
       kernel];
+   UnsetShared[Print];
 ];
 GenerateFAModelFileOnKernel // Utils`MakeUnknownInputDefinition;
 GenerateFAModelFileOnKernel ~ SetAttributes ~ {Locked,Protected};

--- a/meta/NPointFunctions/createFAModelFile.m
+++ b/meta/NPointFunctions/createFAModelFile.m
@@ -20,7 +20,7 @@
 
 *)
 
-BeginPackage["NPointFunctions`", {"SARAH`"}];
+BeginPackage["NPointFunctions`", {"SARAH`", "Utils`"}];
 
 CreateFAModelFile::usage=
 "@brief Create the FeynArts model file using SARAH`.`MakeFeynArts[].
@@ -32,13 +32,13 @@ CreateFAModelFile::usage=
 
 Begin["`Private`"];
 
-CreateFAModelFile[sarahInputDirs_, sarahOutputDir_, sarahModelName_, 
+CreateFAModelFile[sarahInputDirs_, sarahOutputDir_, sarahModelName_,
    eigenstates_] :=
 (
    SARAH`SARAH@SARAH`InputDirectories = sarahInputDirs;
    SARAH`SARAH@SARAH`OutputDirectory = sarahOutputDir;
-   SARAH`Start@sarahModelName;
-   SA`CurrentStates = eigenstates; 
+   Quiet[Utils`DumpStart@sarahModelName];
+   SA`CurrentStates = eigenstates;
    SARAH`InitVertexCalculation[eigenstates, False];
    SARAH`partDefinition = SARAH`ParticleDefinitions@eigenstates;
    SARAH`Particles@SARAH`Current = SARAH`Particles@eigenstates;

--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -307,11 +307,11 @@ IsParticle[p_, states_:FlexibleSUSY`FSEigenstates] :=
     MemberQ[GetParticles[states], p] || MemberQ[GetParticles[states], FSAntiField[p]];
 
 FieldInfo[field_, OptionsPattern[{includeLorentzIndices -> False,
-	includeColourIndices -> False}]] := 
+	includeColourIndices -> False}]] :=
 	Module[{fieldInfo = Cases[SARAH`Particles[FlexibleSUSY`FSEigenstates],
 		{SARAH`getParticleName @ field, ___}][[1]]},
 		fieldInfo = DeleteCases[fieldInfo, {SARAH`generation, 1}, {2}];
-		
+
 		fieldInfo = If[!OptionValue[includeLorentzIndices],
 			DeleteCases[fieldInfo, {SARAH`lorentz, _}, {2}],
 			fieldInfo];
@@ -1008,7 +1008,8 @@ GetMixingMatrixSymbol[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[3]];
 
 GetMassEigenstate[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[2]];
 
-GetMassMatrix[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[1]];
+(* The last replacement fixes vev issue during usage of Utils`DumpStart *)
+GetMassMatrix[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[1]] /. (x_)[{_}] :> x;
 
 MakeESSymbol[p_List] := Symbol[StringJoin[ToString /@ p]];
 MakeESSymbol[FlexibleSUSY`M[p_List]] := FlexibleSUSY`M[MakeESSymbol[p]];

--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -1008,8 +1008,7 @@ GetMixingMatrixSymbol[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[3]];
 
 GetMassEigenstate[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[2]];
 
-(* The last replacement fixes vev issue during usage of Utils`DumpStart *)
-GetMassMatrix[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[1]] /. (x_)[{_}] :> x;
+GetMassMatrix[massMatrix_TreeMasses`FSMassMatrix] := massMatrix[[1]];
 
 MakeESSymbol[p_List] := Symbol[StringJoin[ToString /@ p]];
 MakeESSymbol[FlexibleSUSY`M[p_List]] := FlexibleSUSY`M[MakeESSymbol[p]];

--- a/meta/Utils.m
+++ b/meta/Utils.m
@@ -590,7 +590,7 @@ Module[
       If[FileExistsQ@#, DeleteFile@#] &@ fileDef;
       DumpSave[fileDef,
          {
-            "Model`","Global`", "SA`", "SARAH`", "SPheno`",
+            "Himalaya`", "Model`","Global`", "SA`", "SARAH`", "SPheno`",
             "Susyno`LieGroups`", "FlexibleSUSY`"
          }
       ];

--- a/meta/Utils.m
+++ b/meta/Utils.m
@@ -216,6 +216,13 @@ MathIndexToCPP::usage = "Converts integer-literal index from mathematica to c/c+
 
 FSPermutationSign::usage = "Returns the sign of a permutation given in a Cycles form";
 
+DumpStart::usage ="
+@brief Used to start the model from existing \"kernel snapshot\", i.e. from
+       the existing copy of kernel definitions after the first initialization
+       of the model via \"normal\" SARAH`Start way.
+@param model The name of the model to work with.
+@returns Null.";
+
 Begin["`Private`"];
 
 AppendOrReplaceInList[values_List, elem_, test_:SameQ] :=
@@ -549,6 +556,76 @@ FSBooleanQ[b_] :=
       BooleanQ[b],
       If[b === True || b === False, True, False]
    ];
+
+DumpStart[model:_String] :=
+Module[
+   {
+      dirOut = FileNameJoin@{
+         SARAH`SARAH[SARAH`OutputDirectory],
+         model,
+         "Dump"
+      },
+      dirSARAH = Append[SARAH`SARAH@SARAH`InputDirectories,
+         FileNameDrop@FindFile@"SARAH`"
+      ],
+      fileDef, fileHash, sarahFiles, create, write = WriteString["stdout",#]&
+   },
+   fileDef = FileNameJoin@{dirOut, "definitions.mx"};
+   fileHash = FileNameJoin@{dirOut, "hash.m"};
+   sarahFiles = Select[
+      DeleteDuplicates@FileNames[All, dirSARAH, Infinity],
+      !(DirectoryQ@#)&
+   ];
+
+   create[] := (
+      If[!DirectoryQ@dirOut,
+         write[dirOut <> " does not exist, creating it ..."];
+         CreateDirectory@dirOut
+         write[" done\n"];
+      ];
+
+      SARAH`Start@model;
+
+      write["Saving definitions to " <> fileDef <> " ..."];
+      If[FileExistsQ@#, DeleteFile@#] &@ fileDef;
+      DumpSave[fileDef,
+         {
+            "Model`","Global`", "SA`", "SARAH`", "SPheno`",
+            "Susyno`LieGroups`", "FlexibleSUSY`"
+         }
+      ];
+      write[" done\n"];
+
+      definitionsHash = FileHash@fileDef;
+      sarahHash = Hash[FileHash /@ sarahFiles];
+
+      write["Saving hash to " <> fileHash <> " ..."];
+      If[FileExistsQ@#, DeleteFile@#] &@ fileHash;
+      Save[fileHash, {definitionsHash, sarahHash}];
+      write[" done\n"];
+   );
+
+   If[DirectoryQ@dirOut && FileExistsQ@fileDef && FileExistsQ@fileHash,
+
+      Print["Comparing hash with " <> fileHash <> "."];
+      Get@fileHash;
+
+      If[And[definitionsHash === FileHash@fileDef,
+         sarahHash === Hash[FileHash /@ sarahFiles]],
+
+         Print["Taking definitions from " <> fileDef <> "."];
+         DumpGet@fileDef;
+         ,
+
+         Print["Some files were changed, rerunning SARAH`Start.\n"];
+         create[]
+      ];,
+
+      create[]
+   ];
+];
+DumpStart // MakeUnknownInputDefinition;
+DumpStart ~ SetAttributes ~ {Protected, Locked};
 
 (* MathIndexToCPP *)
 

--- a/meta/Utils.m
+++ b/meta/Utils.m
@@ -598,10 +598,12 @@ Module[
 
       definitionsHash = FileHash@fileDef;
       sarahHash = Hash[FileHash /@ sarahFiles];
+      himalayaHash = FileHash@FindFile@"Himalaya`";
+      fsHash = FileHash@FindFile@"FlexibleSUSY`";
 
       write["Saving hash to " <> fileHash <> " ..."];
       If[FileExistsQ@#, DeleteFile@#] &@ fileHash;
-      Save[fileHash, {definitionsHash, sarahHash}];
+      Save[fileHash, {definitionsHash, sarahHash, himalayaHash, fsHash}];
       write[" done\n"];
    );
 
@@ -611,7 +613,9 @@ Module[
       Get@fileHash;
 
       If[And[definitionsHash === FileHash@fileDef,
-         sarahHash === Hash[FileHash /@ sarahFiles]],
+         sarahHash === Hash[FileHash /@ sarahFiles],
+         himalayaHash === FileHash@FindFile@"Himalaya`",
+         fsHash === FileHash@FindFile@"FlexibleSUSY`"],
 
          Print["Taking definitions from " <> fileDef <> "."];
          DumpGet@fileDef;

--- a/meta/WeinbergAngle.m
+++ b/meta/WeinbergAngle.m
@@ -377,10 +377,9 @@ RhoHatTree[]:=
            Zmass2unmixed = UnmixedZMass2[];
            Zmass2mixed = FindMassZ2[TreeMasses`GetUnmixedParticleMasses[] /.
                                        Parameters`ApplyGUTNormalization[]];
-           (* The last replacement fixes vev issue during usage of Utils`DumpStart *)
            expr = Simplify[RhoZero[] Zmass2unmixed / Zmass2mixed /.
                               SARAH`Weinberg -> ExpressWeinbergAngleInTermsOfGaugeCouplings[],
-                           SARAH`hyperchargeCoupling > 0 && SARAH`leftCoupling > 0] /. (x_)[{_}] :> x;
+                           SARAH`hyperchargeCoupling > 0 && SARAH`leftCoupling > 0];
            result = Parameters`CreateLocalConstRefs[expr] <> "\n";
            result = result <> "rhohat_tree = ";
            result = result <> CConversion`RValueToCFormString[expr] <> ";";

--- a/meta/WeinbergAngle.m
+++ b/meta/WeinbergAngle.m
@@ -377,9 +377,10 @@ RhoHatTree[]:=
            Zmass2unmixed = UnmixedZMass2[];
            Zmass2mixed = FindMassZ2[TreeMasses`GetUnmixedParticleMasses[] /.
                                        Parameters`ApplyGUTNormalization[]];
+           (* The last replacement fixes vev issue during usage of Utils`DumpStart *)
            expr = Simplify[RhoZero[] Zmass2unmixed / Zmass2mixed /.
                               SARAH`Weinberg -> ExpressWeinbergAngleInTermsOfGaugeCouplings[],
-                           SARAH`hyperchargeCoupling > 0 && SARAH`leftCoupling > 0];
+                           SARAH`hyperchargeCoupling > 0 && SARAH`leftCoupling > 0] /. (x_)[{_}] :> x;
            result = Parameters`CreateLocalConstRefs[expr] <> "\n";
            result = result <> "rhohat_tree = ";
            result = result <> CConversion`RValueToCFormString[expr] <> ";";
@@ -949,7 +950,7 @@ GetNeutrinoIndex[] :=
                             GetWPlusBoson[]][SARAH`PL];
            (*follow vertex conventions:*)
            coupl = Vertices`SortCp[coupl];
-           (*omit a possible minus sign:*)   
+           (*omit a possible minus sign:*)
            If[MatchQ[coupl, Times[-1, _]], coupl = -coupl];
            coupl = SelfEnergies`CreateCouplingSymbol[coupl];
            For[k = 0, k <= 2, k++,

--- a/templates/start.m.in
+++ b/templates/start.m.in
@@ -14,7 +14,7 @@ Print["Current working directory: ", workingDirectory];
 Print["SARAH output directory: ", SARAH`SARAH[OutputDirectory]];
 Print["Starting model: ", ToString[HoldForm[Start["@ModelName@"@SubModel@]]]];
 
-Start["@ModelName@"@SubModel@];
+DumpStart["@ModelName@"@SubModel@];
 
 MakeFlexibleSUSY[InputFile -> FileNameJoin[{"@DIR@","FlexibleSUSY.m"}],
                  OutputDirectory -> "@DIR@",

--- a/test/test_MRSSM2_f_to_f_conversion.meta
+++ b/test/test_MRSSM2_f_to_f_conversion.meta
@@ -34,7 +34,7 @@ SARAH`SARAH[InputDirectories] =
    ToFileName@{$sarahDir, "Models"}
 };
 
-Start@"MRSSM";
+DumpStart@"MRSSM";
 
 modelFile = FileNameJoin@{workingDirectory, "models", "MRSSM2", "FlexibleSUSY.m"};
 

--- a/test/test_MSSM_matching_selfenergy_Fd.meta
+++ b/test/test_MSSM_matching_selfenergy_Fd.meta
@@ -32,7 +32,7 @@ SARAH`SARAH[InputDirectories] = {
    FileNameJoin[{workingDirectory, "sarah"}],
    ToFileName[{$sarahDir, "Models"}]};
 
-Start@"MSSM";
+DumpStart@"MSSM";
 
 modelFile = FileNameJoin@{workingDirectory, "models", "MSSM", "FlexibleSUSY.m"};
 

--- a/test/test_MSSM_npointfunctions.meta
+++ b/test/test_MSSM_npointfunctions.meta
@@ -34,7 +34,7 @@ SARAH`SARAH[InputDirectories] =
    ToFileName@{$sarahDir, "Models"}
 };
 
-Start@"MSSM";
+DumpStart@"MSSM";
 
 modelFile = FileNameJoin@{workingDirectory, "models", "MSSM", "FlexibleSUSY.m"};
 

--- a/test/test_SM_cxxdiagrams.meta
+++ b/test/test_SM_cxxdiagrams.meta
@@ -32,7 +32,7 @@ SARAH`SARAH[InputDirectories] = {
     ToFileName[{$sarahDir, "Models"}]
 };
 
-Start["SM"];
+DumpStart["SM"];
 
 modelFile = FileNameJoin[{workingDirectory, "models", "SM", "FlexibleSUSY.m"}];
 

--- a/test/test_SM_matching_selfenergy_Fd.meta
+++ b/test/test_SM_matching_selfenergy_Fd.meta
@@ -34,7 +34,7 @@ SARAH`SARAH[InputDirectories] =
    ToFileName@{$sarahDir, "Models"}
 };
 
-Start@"SM";
+DumpStart@"SM";
 
 modelFile = FileNameJoin@{workingDirectory, "models", "SM", "FlexibleSUSY.m"};
 

--- a/test/test_SM_npointfunctions.meta
+++ b/test/test_SM_npointfunctions.meta
@@ -34,7 +34,7 @@ SARAH`SARAH[InputDirectories] =
    ToFileName@{$sarahDir, "Models"}
 };
 
-Start@"SM";
+DumpStart@"SM";
 
 modelFile = FileNameJoin@{workingDirectory, "models", "SM", "FlexibleSUSY.m"};
 


### PR DESCRIPTION
The only purpose is to save some time during development. (connected to my question #213)

Every change in the meta code causes ``SARAH`Start`` to be called. For some models, it takes quite a lot of time (on my machine, for `MRSSM` it takes 70 seconds). This time interrupts a bit a working flow. So this PR introduces a new function, ``Utils`DumpStart``, which saves the snapshot of definitions inside the kernel after the first ``SARAH`Start`` usage and loads them during the next meta phase call. It saves some time. 

There were some issues during implementation:
1) There is no "normal" way to save current state of kernel. There is no "easy" way to save required definitions *and* their contexts in cross-platform way. Because of this I was stuck to `DumpSave`, which works better than `Save` and does what was needed quite simply.

2) Some names of `FlexibleSUSY` (I think `VEV` and `SUM`) are proceeded incorrectly somehow somewhere. My patch to this was adding this context to `DumpSave`. It is quite ugly, but it works. 

3) If one uses `DumpGet` instead of ``SARAH`Start``, then `SARAH` does some weird things to vevs. Instead of just `vd` it returns `vd[{1}]`, which is not proceeded correctly by `FlexibleSUSY`. I have changed only 3 files in order to fix this by adding one replacement rule there with some notes. **UPD:** this is caused by ``Himalaya` `` context. If one dumps it as well, then everything is fine (see 4312491).

This PR also can be useful for @wkotlarski's CI checks, because it can improve the speed of checks for models by dosen of minutes, if one saves this dump output between them.