### PR TITLE
tweak SSMMhInput to give correct Higgs mass at the SUSY scale

### DIFF
--- a/model_files/SSMMhInput/FlexibleSUSY.m.in
+++ b/model_files/SSMMhInput/FlexibleSUSY.m.in
@@ -20,6 +20,8 @@ EXTPAR = {
 
 EWSBOutputParameters = { mu2, MS };
 
+OnlyLowEnergyFlexibleSUSY = False;
+
 HighScale = Qin;
 
 HighScaleFirstGuess = Qin;
@@ -36,7 +38,8 @@ SUSYScale = QEWSB;
 SUSYScaleFirstGuess = QEWSB;
 
 SUSYScaleInput = {
-    {vS, vSInput}
+   FSFindRoot[{\[Lambda]}, {MhInput - Pole[M[hh[1]]]}],
+   {vS, vSInput}
 };
 
 LowScale = LowEnergyConstant[MZ];
@@ -44,7 +47,6 @@ LowScale = LowEnergyConstant[MZ];
 LowScaleFirstGuess = LowEnergyConstant[MZ];
 
 LowScaleInput = {
-   FSFindRoot[{\[Lambda]}, {MhInput - Pole[M[hh[1]]]}],
    {v, 2 MZMSbar / Sqrt[GUTNormalization[g1]^2 g1^2 + g2^2]},
    {Yu, Automatic},
    {Yd, Automatic},
@@ -52,13 +54,12 @@ LowScaleInput = {
 };
 
 InitialGuessAtLowScale = {
+   {\[Lambda], 0.1},
    {v, LowEnergyConstant[vev]},
    {Yu, Automatic},
    {Yd, Automatic},
    {Ye, Automatic}
 };
-
-OnlyLowEnergyFlexibleSUSY = False;
 
 DefaultPoleMassPrecision = MediumPrecision;
 HighPoleMassPrecision    = {hh};


### PR DESCRIPTION
In the `SSMMhInput` lambda is set at the low scale by solving for the Higgs pole mass input using
```mathematica
FSFindRoot[{\[Lambda]}, {MhInput - Pole[M[hh[1]]]}]
```
The problem is that before you get to the SUSY scale, you collect enough logs that the pole mass is no longer `MhInput`. In the default input, this gives 0.5 GeV shift for `MhInput` = 125 GeV. Maybe the procedure in this PR would be better? I had to also give a starting value for `lambda` at the low scale, otherwise it doesn't work. 