### PR TITLE
rename config/version to config/flexiblesusy-version

### DIFF
--- a/config/module.mk
+++ b/config/module.mk
@@ -28,7 +28,7 @@ REQUIRED_SARAH_VERSION_FILE := \
 		$(DIR)/required_sarah_version.m
 
 FLEXIBLESUSY_VERSION_FILE := \
-		$(DIR)/version
+		$(DIR)/flexiblesusy-version
 
 FLEXIBLESUSY_GIT_COMMIT_FILE := \
 		$(DIR)/git_commit

--- a/configure
+++ b/configure
@@ -3808,7 +3808,7 @@ if test "x${enable_meta}" = "xyes"; then
     add_metaflags
 fi
 
-echo "$FLEXIBLESUSY_VERSION" > ${CONFIGDIR}/version
+echo "$FLEXIBLESUSY_VERSION" > ${CONFIGDIR}/flexiblesusy-version
 echo "$GIT_COMMIT" > ${CONFIGDIR}/git_commit
 echo "{${required_sarah_major}, ${required_sarah_minor}, ${required_sarah_patch}}" > ${CONFIGDIR}/required_sarah_version.m
 


### PR DESCRIPTION
to fix a compilation error with boost 1.74

fixes #267