### PR TITLE
Replacement for SARAH`Vertex

### DIFF
--- a/meta/Cache.m
+++ b/meta/Cache.m
@@ -1,0 +1,320 @@
+(* ::Package:: *)
+
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+BeginPackage["Cache`", {"SARAH`", "Utils`"}];
+
+GetVertex::usage = "
+@brief Is used instead of SARAH`Vertex without additional options.
+@param input A list of three or four elements without check, whether they are
+       particles or not.
+@returns An expression, which would be returned by SARAH`Vertex.";
+GetVertex::errGetOnce = "
+Date should be loaded once.";
+GetVertex::errPutOnce = "
+Data should be saved once.";
+GetVertex::errNotDef = "
+Variable `1` should be defined before initialization.";
+GetVertex::errNoFile = "
+File `1` does not exist, but required.";
+
+Begin["`internal`"];
+
+With[{AOQ = Utils`AssertOrQuit, NAME = "CachedVertices.m",
+      M = SARAH`Mom, G = SARAH`g, B = SARAH`bar, PL = SARAH`PL, PR = SARAH`PR,
+      L1 = SARAH`lt1, L2 = SARAH`lt2, L3 = SARAH`lt3, L4 = SARAH`lt4,
+      GT = SARAH`getType, GG = SARAH`g[_, _], LP = SARAH`LorentzProduct,
+      MD = HoldPattern[SARAH`Mom[_, _] - SARAH`Mom[_, _]]},
+
+Module[{putOnce, defineRules,
+
+      CheckInitialization, getOnce, dir, file3, file4, rules, impl,
+
+      out, save = {}, vertexType, perm, indexRules,
+      particlesC, orderC, vertexC, orderN, vertexN, idxCurrent,
+      idxGeneric,
+
+      DefineCanonical, CanonicalType, DefineSaved, IndexRules,
+      OrderedIndices, ClearIndices, GetIndices, FillIndices, ZeroType,
+      RuleType, CatchSU3, CatchZero, Lorentz, Swap, Fermion,
+      NewIndices, PrepareToSave, RestoreIndices, Body, Momenta,
+
+
+      fieldsN, rest, restoreRules, back
+   },
+
+
+   CheckInitialization[] := (
+      AOQ[Head@getOnce === Symbol, GetVertex::errGetOnce];
+      AOQ[Head@# =!= Symbol, GetVertex::errNotDef, #] &@ SA`subUnitaryCondition;
+      AOQ[Head@# =!= Symbol, GetVertex::errNotDef, #] &@ SARAH`subDependences;
+      AOQ[Head@# =!= Symbol, GetVertex::errNotDef, #] &@ SARAH`$sarahCurrentOutputMainDir;
+
+      dir = FileNameJoin@{SARAH`$sarahCurrentOutputMainDir, "EWSB", "Vertices"};
+      file3 = FileNameJoin@{dir, "VertexList3.m"};
+      file4 = FileNameJoin@{dir, "VertexList4.m"};
+
+      AOQ[FileExistsQ@file3, GetVertex::errNoFile, file3];
+      AOQ[FileExistsQ@file4, GetVertex::errNoFile, file4]
+   );
+
+   GetVertex /: Get[GetVertex] :=
+   If[CheckInitialization[],
+
+      DefineCanonical /@ Get@file3;
+      DefineCanonical /@ Get@file4;
+
+      rules = ReleaseHold[(First /@ DownValues@impl) /. _[e : {__}] :> Rule[Sort@e, e]];
+
+      If[FileExistsQ@#, DefineSaved /@ Get@#] &@ FileNameJoin@{dir, NAME};
+
+      Unprotect@GetVertex;
+
+      GetVertex[input : {Repeated[_, {2}]}] := SARAH`Vertex@input;
+
+      GetVertex[input : {Repeated[_, {3, 4}]}] :=
+      With[{particlesN = ClearIndices@input},
+         {vertexType, out} = If[Head@# === List,
+            #,
+
+            vertexN = Simplify[SARAH`Vertex@particlesN] /. SA`subUnitaryCondition;
+            PrepareToSave@particlesN;
+            DefineSaved@Last@save
+         ] &@ impl[particlesN];
+         idxGeneric = OrderedIndices@First@out;
+         idxCurrent = FillIndices[{idxGeneric, OrderedIndices@input}];
+         restoreRules = RestoreIndices@{idxGeneric, idxCurrent};
+
+         out = Switch[vertexType,
+            Dynamic|Plus|Minus|PlusMinus, Lorentz@#,
+            Identity|Ordering|Null|None, #
+         ] & [out /. restoreRules];
+
+         CatchZero@CatchSU3@out
+      ];
+
+      GetVertex /: Put[GetVertex] :=
+      If[AOQ[Head@putOnce === Symbol, GetVertex::errPutOnce],
+
+         If[save =!= {},
+            If[FileExistsQ@#,
+               Put[Sort@Join[Get@#, save], #];,
+               Put[Sort@save, #]
+            ] &@ FileNameJoin@{dir, NAME};
+         ];
+         putOnce = {};
+      ];
+
+      GetVertex // Utils`MakeUnknownInputDefinition;
+      GetVertex ~ SetAttributes ~ {Protected, Locked};
+
+      getOnce = {};
+   ];
+   Protect@GetVertex;
+
+   PrepareToSave[particlesN_] := If[FreeQ[rules, Sort@particlesN],
+
+      out = vertexN /. SARAH`subDependences // TrigReduce;
+      AppendTo[save, {First@vertexN, ZeroType@out}];,
+
+      particlesC = Sort[particlesN] /. rules;
+      orderC = Ordering@particlesC;
+      orderN = Ordering@particlesN;
+      perm = orderC[[Ordering@orderN]];
+      {vertexType, vertexC} = impl@particlesC;
+
+      indexRules = MapThread[Rule, {IndexRules[vertexC, orderC], IndexRules[vertexN, orderN]}];
+
+      AppendTo[save, {particlesC, perm, indexRules, RuleType[vertexC /. indexRules, vertexN]}];
+   ];
+
+   IndexRules[vertex_, order_] := GetIndices@Part[vertex, 1, order];
+
+   OrderedIndices[expr : {__}] := GetIndices /@ expr;
+
+   GetIndices[expr_] := Flatten@Cases[expr, e : {__} :> e, Infinity];
+
+   FillIndices[idxs_] := MapThread[PadRight[#2, Length@#1, Drop[#1, Length@#2]] &, idxs];
+
+   RestoreIndices[idxs_] := Flatten@MapThread[
+      Thread@Rule[#1, PadRight[#2, Length@#1, Remove]] &, idxs
+   ] /. Rule[_, Remove] :> (## &[]);
+
+   ClearIndices[expr : {__}] := expr /. e_[{__}] :> e;
+
+   NewIndices[ind_, {idxs___}] := ToExpression /@
+      StringReplace[ToString/@{idxs}, DigitCharacter.. :> ToString@ind];
+
+   DefineCanonical[v_] := With[{lhs = ClearIndices@Part[v, 1]},
+      impl[lhs] = {CanonicalType@v, v /. SA`subUnitaryCondition};
+   ];
+
+   Fermion[{{e1_, PL}, {e2_, PR}}] :=
+      {{-e2, PL}, {-e1, PR}};
+   Fermion[{{e1_, LP[g1_, PL]}, {e2_, LP[g2_, PR]}}] :=
+      {{-e2, LP[g2, PL]}, {-e1, LP[g1, PR]}};
+   Fermion[{{e1_, LP[g1_, PL]}, {e2_, PR}}] :=
+      {{-e2, PL}, {-e1, LP[g1, PR]}};
+
+   Momenta[Plus, {{e_, d:MD}}] = {{e, d}};
+   Momenta[Minus, {{e_, d:MD}}] = {{-e, -d}};
+
+   Lorentz[{p_, {e_, d_M}}] :=
+   Module[{ind, pos},
+      back = Swap /@ restoreRules;
+      ind = Flatten@Join[#[GT /@ p, SARAH`S | SARAH`V], #[Head /@ p, B]] &@ Position;
+      ind = Complement[{1, 2, 3}, ind][[1]];
+      {p, {e, d /. {i__} :> NewIndices[ind, {i} /. back]}}
+   ];
+
+   Lorentz[{p_, {e_, d:MD}}] :=
+   Module[{newE, newD, asthere = Simplify[e*d]},
+      If[FreeQ[restoreRules, _Integer],
+         back = Swap /@ restoreRules;
+         {newE, newD} = {Coefficient[asthere, #], #} &@ Cases[asthere, MD][[1]];
+
+         If[-M[p[[1]] /. back, L3] + M[p[[2]] /. back, L3] === newD,
+            {p, -{newE, newD}},
+            {p, {newE, newD}}
+         ],
+
+         SARAH`Vertex[First@out /. restoreRules]
+      ]
+
+   ];
+
+   Lorentz[{p_, {e_, d_ /; Count[d, GG, Infinity] === 3}}] :=
+      Module[{newE = 1, newD = 1, asthere = Simplify[e*d], c12},
+      Do[
+         If[FreeQ[#, L1 | L2 | L3], newE = newE*#, newD = newD*#] &@ asthere[[i]],
+         {i, Length@asthere}
+      ];
+      c12 = Coefficient[newD, G[L1, L2]];
+
+      If[Head[DeleteCases[DeleteCases[c12, M[A_[{c___, L2, b___}], L3], 3], M[Susyno`LieGroups`conj[A_[{c___, L2, b___}]], L3], 3]] === Plus,
+         {p, -{newE, newD}},
+         {p, {newE, newD}}
+      ]
+   ];
+
+   Lorentz[{p_, e : Repeated[{_, _}, {3}]}] := {p,
+      Flatten@Cases[{e}, {_, G[L1, L2]*G[L3, L4]}],
+      Flatten@Cases[{e}, {_, G[L1, L3]*G[L2, L4]}],
+      Flatten@Cases[{e}, {_, G[L1, L4]*G[L2, L3]}]
+   };
+
+   CanonicalType[v_] := Switch[v,
+      {_, {_, _M}}, Dynamic,
+      {_, {_, MD}}, PlusMinus,
+      {_, p_ /; Count[p, GG, Infinity] === 3}, Dynamic,
+      {_, Repeated[{_, _}, {3}]}, Dynamic,
+      _, None
+   ];
+
+   RuleType[{_, {_, _M}}, _] := Dynamic;
+   RuleType[{_, {_, MD}}, _] :=
+   If[Simplify@Last[vertexN/Body[particlesC, perm, indexRules]] === {-1, -1},
+      Minus,
+      Plus
+   ];
+   RuleType[{_, p_ /; Count[p, GG, Infinity] === 3}, _] := Dynamic;
+   RuleType[{Repeated[_, {4}]}, _] := Dynamic;
+   RuleType[vertexC_, vertexN_] :=
+      If[TrigExpand@Expand@Rest[vertexC] === TrigExpand@Expand@Rest[vertexN], Identity, Ordering];
+
+   CatchSU3[expr_] := expr /. { SARAH`fSU3[a_, a_, b_] -> 0, SARAH`fSU3[a_, b_, b_] -> 0};
+
+   CatchZero[{p_}] := {p};
+   CatchZero[{p_, {0, d_Integer}}] := {p, {0, d}};
+   CatchZero[{p_, {0, d:MD}}] := {p, {0, d}};
+   CatchZero[{p_, {0, _}}] := {p, {0, 1}};
+   CatchZero[{p_, {0, _}, {0, _}}] := {p, {0, PL}, {0, PR}};
+   CatchZero[{p_, Repeated[{}, {3}]}] := {p,
+      {0, G[L1, L2]*G[L3, L4]},
+      {0, G[L1, L3]*G[L2, L4]},
+      {0, G[L1, L4]*G[L3, L2]}
+   };
+   CatchZero[{p_, v__}] := {p, v};
+
+   ZeroType[{_}] := 0;
+   ZeroType[{_, {0, _}}] := 1;
+   ZeroType[{_, Repeated[{0, _}, {2}]}] := 2;
+   ZeroType[{_, Repeated[{0, _}, {3}]}] := 3;
+
+   DefineSaved[{particles_, 0}] :=
+   With[{lhs = ClearIndices@particles},
+      impl[lhs] = {Null, {particles}}
+   ];
+
+   DefineSaved[{particles_, 1}] :=
+   With[{lhs = ClearIndices@particles},
+      impl[lhs] = {Null, {particles, {0, 1}}}
+   ];
+
+   DefineSaved[{particles_, 2}] :=
+   With[{lhs = ClearIndices@particles},
+      impl[lhs] = {Null, {particles, {0, PL}, {0, PR}}}
+   ];
+
+   DefineSaved[{particles_, 3}] :=
+   With[{lhs = ClearIndices@particles},
+      impl[lhs] = {Null, {particles,
+         {0, G[L1, L2]*G[L3, L4]},
+         {0, G[L1, L3]*G[L2, L4]},
+         {0, G[L1, L4]*G[L3, L2]}
+      }}
+   ];
+
+   defineRules =
+   {
+      Ordering -> Fermion,
+      Dynamic -> Identity,
+      Plus -> (Momenta[Plus, #]&),
+      Minus -> (Momenta[Minus, #]&)
+   };
+
+   DefineSaved[{particles_, ordering_, indexRules_,
+      function:Identity|Ordering|Dynamic|Plus|Minus}] :=
+   With[{
+         lhs = Part[particles, ordering],
+         rhs = (
+            fieldsN = Part[First@# /. indexRules, ordering];
+            rest = (function /. defineRules)[Rest@# /. indexRules];
+            Prepend[rest, fieldsN]
+         ) &@ Last@impl@particles
+      },
+      impl[lhs] = {function, rhs}
+   ];
+
+   Body[particles_, ordering_, indexRules_] := (
+      fieldsN = Part[First@# /. indexRules, ordering];
+      Prepend[Rest@# /. indexRules, fieldsN]
+   ) &@ Last@impl@particles;
+
+   Swap[x_ -> y_] := y -> x;
+
+]; (* Module *)
+]; (* With *)
+
+End[];
+EndPackage[];

--- a/meta/Cache.m
+++ b/meta/Cache.m
@@ -40,7 +40,7 @@ File `1` does not exist, but required.";
 
 Begin["`internal`"];
 
-With[{AOQ = Utils`AssertOrQuit, NAME = "CachedVertices.m",
+With[{AOQ = Utils`AssertOrQuit, NAME = "CachedVertices.m", COMPLEXITY = 300,
       M = SARAH`Mom, G = SARAH`g, B = SARAH`bar, PL = SARAH`PL, PR = SARAH`PR,
       L1 = SARAH`lt1, L2 = SARAH`lt2, L3 = SARAH`lt3, L4 = SARAH`lt4,
       GT = SARAH`getType, GG = SARAH`g[_, _], LP = SARAH`LorentzProduct,
@@ -166,7 +166,10 @@ Module[{putOnce, defineRules,
       StringReplace[ToString/@{idxs}, DigitCharacter.. :> ToString@ind];
 
    DefineCanonical[v_] := With[{lhs = ClearIndices@Part[v, 1]},
-      impl[lhs] = {CanonicalType@v, v /. SA`subUnitaryCondition};
+      impl[lhs] = {
+         CanonicalType@v,
+         If[LeafCount@Last@v > COMPLEXITY, v, v /. SA`subUnitaryCondition]
+      };
    ];
 
    Fermion[{{e1_, PL}, {e2_, PR}}] :=

--- a/meta/Cache.m
+++ b/meta/Cache.m
@@ -176,8 +176,8 @@ Module[{putOnce, defineRules,
    Fermion[{{e1_, LP[g1_, PL]}, {e2_, PR}}] :=
       {{-e2, PL}, {-e1, LP[g1, PR]}};
 
-   Momenta[Plus, {{e_, d:MD}}] = {{e, d}};
-   Momenta[Minus, {{e_, d:MD}}] = {{-e, -d}};
+   Momenta[Plus, {{e_, d:MD}}] := {{e, d}};
+   Momenta[Minus, {{e_, d:MD}}] := {{-e, -d}};
 
    Lorentz[{p_, {e_, d_M}}] :=
    Module[{ind, pos},

--- a/meta/EffectiveCouplings.m
+++ b/meta/EffectiveCouplings.m
@@ -20,7 +20,7 @@
 
 *)
 
-BeginPackage["EffectiveCouplings`", {"SARAH`", "CConversion`", "Parameters`", "SelfEnergies`", "TreeMasses`", "TextFormatting`", "Utils`", "Vertices`", "Constraint`"}];
+BeginPackage["EffectiveCouplings`", {"SARAH`", "Cache`", "CConversion`", "Parameters`", "SelfEnergies`", "TreeMasses`", "TextFormatting`", "Utils`", "Vertices`", "Constraint`"}];
 
 InitializeEffectiveCouplings::usage="";
 InitializeMixingFromModelInput::usage="";
@@ -238,7 +238,7 @@ GetTwoBodyDecays[particle_] :=
                                 {i, 1, Length[allParticles]}, {j, 1, Length[allParticles]}];
            combinations = DeleteDuplicates[Flatten[combinations, 1]];
            For[i = 1, i <= Length[combinations], i++,
-               vertex = SARAH`Vertex[combinations[[i]], UseDependences -> True];
+               vertex = Cache`GetVertex@combinations[[i]];
                If[NonZeroVertexQ[vertex],
                   fields = First[vertex];
                   coupling = Rest[vertex];
@@ -270,18 +270,16 @@ GetParticlesCouplingToVectorBoson[vector_] :=
                   (* @note could use defined functions in e.g. TreeMasses, plus check
                      for undefined group factors, but will do it this way for now
                      to ensure consistency with SARAH                                  *)
-                  charge = SARAH`Vertex[{SARAH`AntiField[allParticles[[i]]],
-                                         allParticles[[i]], SARAH`VectorG},
-                                        UseDependences -> True][[2,1]];
+                  charge = Cache`GetVertex[{SARAH`AntiField[allParticles[[i]]],
+                                         allParticles[[i]], SARAH`VectorG}][[2,1]];
                   If[charge =!= 0,
                      particles = Append[particles, allParticles[[i]]];
                     ];,
                   charge = TreeMasses`GetElectricCharge[allParticles[[i]]];
                   If[NumericQ[charge],
                      charge = {charge},
-                     charge = Cases[SARAH`Vertex[{SARAH`AntiField[allParticles[[i]]],
-                                                  allParticles[[i]], SARAH`VectorP},
-                                                 UseDependences -> True][[2,1]], _?NumberQ];
+                     charge = Cases[Cache`GetVertex[{SARAH`AntiField[allParticles[[i]]],
+                                                  allParticles[[i]], SARAH`VectorP}][[2,1]], _?NumberQ];
                     ];
                   If[charge =!= {} && SARAH`AntiField[allParticles[[i]]] =!= allParticles[[i]] &&
                      charge =!= {0},
@@ -502,7 +500,7 @@ CreateEffectiveCouplingPrototype[coupling_] :=
 GetEffectiveVEV[] :=
     Module[{vev, parameters = {}, result = ""},
            If[SARAH`SupersymmetricModel,
-              vev = Simplify[2 Sqrt[-SARAH`Vertex[{SARAH`VectorW, Susyno`LieGroups`conj[SARAH`VectorW]}][[2,1]]
+              vev = Simplify[2 Sqrt[-Cache`GetVertex[{SARAH`VectorW, Susyno`LieGroups`conj[SARAH`VectorW]}][[2,1]]
                            / SARAH`leftCoupling^2] /. SARAH`sum[a_,b_,c_,d_] :> Sum[d,{a,b,c}]];
               vev = Parameters`DecreaseIndexLiterals[vev];
               parameters = Parameters`FindAllParameters[vev];

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -28,6 +28,7 @@ BeginPackage["FlexibleSUSY`",
               "BetaFunction`",
               "Parameters`",
               "TextFormatting`",
+              "Cache`",
               "CConversion`",
               "TreeMasses`",
               "EWSB`",
@@ -3787,6 +3788,7 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
            nPointFunctions = Vertices`EnforceCpColorStructures @
            					 Vertices`SortCps @
              				 Join[PrepareSelfEnergies[FSEigenstates], PrepareTadpoles[FSEigenstates]];
+           Get[Cache`GetVertex];
            PrepareUnrotatedParticles[FSEigenstates];
 
            DebugPrint["particles (mass eigenstates): ", TreeMasses`GetParticles[]];
@@ -4675,7 +4677,7 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
                               {{FileNameJoin[{$flexiblesusyTemplateDir, "LesHouches.in"}],
                                 FileNameJoin[{FSOutputDir, "LesHouches.in." <> FlexibleSUSY`FSModelName <> "_generated"}]}}
                              ];
-
+           Put[Cache`GetVertex];
            Utils`PrintHeadline["FlexibleSUSY has finished"];
           ];
 

--- a/meta/TreeMasses.m
+++ b/meta/TreeMasses.m
@@ -20,7 +20,7 @@
 
 *)
 
-BeginPackage["TreeMasses`", {"SARAH`", "TextFormatting`", "CConversion`", "Parameters`", "Utils`"}];
+BeginPackage["TreeMasses`", {"SARAH`", "TextFormatting`", "Cache`", "CConversion`", "Parameters`", "Utils`"}];
 
 FSMassMatrix::usage="Head of a mass matrix";
 
@@ -307,11 +307,11 @@ IsParticle[p_, states_:FlexibleSUSY`FSEigenstates] :=
     MemberQ[GetParticles[states], p] || MemberQ[GetParticles[states], FSAntiField[p]];
 
 FieldInfo[field_, OptionsPattern[{includeLorentzIndices -> False,
-	includeColourIndices -> False}]] := 
+	includeColourIndices -> False}]] :=
 	Module[{fieldInfo = Cases[SARAH`Particles[FlexibleSUSY`FSEigenstates],
 		{SARAH`getParticleName @ field, ___}][[1]]},
 		fieldInfo = DeleteCases[fieldInfo, {SARAH`generation, 1}, {2}];
-		
+
 		fieldInfo = If[!OptionValue[includeLorentzIndices],
 			DeleteCases[fieldInfo, {SARAH`lorentz, _}, {2}],
 			fieldInfo];
@@ -632,8 +632,7 @@ GetElectricCharge[p_] :=
               charge = 0;,
               charge = SARAH`getElectricCharge[p];
               If[!NumericQ[charge],
-                 charge = Cases[-I SARAH`Vertex[{SARAH`AntiField[p], p, SARAH`VectorP},
-                                                UseDependences -> True][[2,1]], _?NumberQ];
+                 charge = Cases[-I Cache`GetVertex[{SARAH`AntiField[p], p, SARAH`VectorP}][[2,1]], _?NumberQ];
                  If[charge === {},
                     charge = 0;,
                     charge = First[charge];

--- a/meta/WeinbergAngle.m
+++ b/meta/WeinbergAngle.m
@@ -20,7 +20,7 @@
 
 *)
 
-BeginPackage["WeinbergAngle`", {"SARAH`", "CConversion`", "Parameters`", "SelfEnergies`",
+BeginPackage["WeinbergAngle`", {"SARAH`", "Cache`", "CConversion`", "Parameters`", "SelfEnergies`",
                                 "TextFormatting`", "ThresholdCorrections`", "TreeMasses`",
                                 "Utils`", "Vertices`"}];
 
@@ -315,7 +315,7 @@ HiggsTopVertices[higgsName_] :=
                                Length[indexRange] - 1];
            topQuark = Level[TreeMasses`GetUpQuark[{3}], {Boole[ListQ[TreeMasses`GetUpQuark[{3}]]]}][[1]];
            higgsVertices =
-              Vertices`StripGroupStructure[SARAH`Vertex[{bar[topQuark], topQuark, higgsName[#]}] & /@
+              Vertices`StripGroupStructure[Cache`GetVertex[{bar[topQuark], topQuark, higgsName[#]}] & /@
                                               indexList, SARAH`ctNr /@ Range[4]];
            higgsVertices = Cases[higgsVertices,
                                  {{__, higgsField_}, {coeffPL_, SARAH`PL}, {coeffPR_, SARAH`PR}} /;
@@ -949,7 +949,7 @@ GetNeutrinoIndex[] :=
                             GetWPlusBoson[]][SARAH`PL];
            (*follow vertex conventions:*)
            coupl = Vertices`SortCp[coupl];
-           (*omit a possible minus sign:*)   
+           (*omit a possible minus sign:*)
            If[MatchQ[coupl, Times[-1, _]], coupl = -coupl];
            coupl = SelfEnergies`CreateCouplingSymbol[coupl];
            For[k = 0, k <= 2, k++,

--- a/meta/module.mk
+++ b/meta/module.mk
@@ -64,6 +64,7 @@ META_SRC     := \
 		$(DIR)/AMuon.m \
 		$(DIR)/AnomalousDimension.m \
 		$(DIR)/BetaFunction.m \
+		$(DIR)/Cache.m \
 		$(DIR)/CConversion.m \
 		$(DIR)/Constraint.m \
 		$(DIR)/ConvergenceTester.m \

--- a/test/module.mk
+++ b/test/module.mk
@@ -99,6 +99,7 @@ TEST_SH := \
 
 TEST_META := \
 		$(DIR)/test_BetaFunction.m \
+		$(DIR)/test_Cache.m \
 		$(DIR)/test_CConversion.m \
 		$(DIR)/test_Constraint.m \
 		$(DIR)/test_EWSB.m \

--- a/test/test_Cache.m
+++ b/test/test_Cache.m
@@ -1,0 +1,195 @@
+(* :Copyright:
+
+   ====================================================================
+   This file is part of FlexibleSUSY.
+
+   FlexibleSUSY is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   FlexibleSUSY is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with FlexibleSUSY.  If not, see
+   <http://www.gnu.org/licenses/>.
+   ====================================================================
+
+*)
+
+
+
+time = AbsoluteTime[];
+
+Module[{
+      file = OpenRead@FileNameJoin@{Directory[], "Makefile"},
+      cond = False, str,
+      regex1 = RegularExpression["MODELS\\s+:=\\s+(models/\\w+\\s*)+"],
+      regex2 = RegularExpression@"models/(\\w+)"
+   },
+
+   While[!cond,
+      str = ReadLine[file];
+      cond = StringMatchQ[str, regex1];
+      If[cond, models = StringCases[str, regex2 :> "$1"]];
+   ];
+
+   Close@file;
+
+];
+
+models = Module[{
+      file = OpenRead@FileNameJoin@{Directory[], "models", #, "start.m"},
+      cond = False, str, out,
+      regex1 = RegularExpression["Start..(\\w+)..;"]
+   },
+
+   While[!cond,
+      str = ReadLine[file];
+      cond = StringMatchQ[str, regex1];
+      If[cond, out = StringCases[str, regex1 :> "$1"]];
+   ];
+
+   Close@file;
+   out[[1]]
+]&/@models;
+
+Print@models;
+
+AppendTo[$ContextPath, "SARAH`"];
+AppendTo[$ContextPath, "Susyno`LieGroups`"];
+
+Needs["TestSuite`", "TestSuite.m"];
+
+CheckRude[str_String, type:Identity|Clear|Replace|Inverse] :=
+Module[{
+      model = str, fsmodel = fsstr, dir = Directory[], path = $Path, pos3, pos4, prt,
+      time = AbsoluteTime[], jobs, kers, res, ok = True,
+      func = Switch[type,
+         Identity, Identity,
+         Clear, #/.fse_[{__}]:>fse&,
+         Replace, #/.{SARAH`gt1:>RandomInteger@{1,3},
+                      SARAH`gt2:>RandomInteger@{1,3},
+                      SARAH`gt3:>RandomInteger@{1,3}}&,
+         Inverse, Prepend[Rest@#, SARAH`AntiField@First@#]&@*(#/.fse_[{__}]:>fse&)
+      ]
+   },
+   Print["test for ", str];
+
+   prt = GetPartitions@str;
+
+   While[ok,
+
+      Check[
+         kers = LaunchKernels@4;
+         ok = False;,
+
+         CloseKernels@kers;
+         ok = True;
+         Print@"Relaunching kernels",
+         LinkObject::linkd
+         ];
+
+   ];
+
+   jobs = Table[
+      pos3 = prt[[1, i]];
+      pos4 = prt[[2, i]];
+      ParallelSubmit[{model, dir, path, func, pos3, pos4},
+         SetDirectory[dir];
+         $Path = path;
+         Block[{Print},
+            Needs["TestSuite`", "TestSuite.m"];
+            Needs["Cache`", "Cache.m"];
+            SARAH`Start@model;
+         ];
+         SARAH`RXi[_] = 1;
+         SA`CurrentStates = EWSB;
+         SARAH`$sarahCurrentOutputMainDir =
+            FileNameJoin@{Directory[], "Output", model};
+         all3 = First/@Get@FileNameJoin@{SARAH`$sarahCurrentOutputMainDir,
+            "EWSB", "Vertices", "VertexList3.m"};
+         all4 = First/@Get@FileNameJoin@{SARAH`$sarahCurrentOutputMainDir,
+            "EWSB", "Vertices", "VertexList4.m"};
+         vertices = func/@Join[all3[[pos3]], all4[[pos4]]];
+         fsS1 = SA`subUnitaryCondition;
+         fsS2 = SA`subUnitaryCondition /. Susyno`LieGroups`b :> Susyno`LieGroups`a;
+         Get[Cache`GetVertex];
+         Do[
+            perm = Permutations@vertices[[vert]];
+            Do[
+               cache = TrigExpand@Expand[Simplify[Expand@Cache`GetVertex@perm[[subv]]] /. fsS1 /. fsS2];
+               sarah = TrigExpand@Expand[Simplify[SARAH`Vertex@perm[[subv]]] /. fsS1 /. fsS2];
+               If[MatchQ[sarah,{{_, _,_, _}, {0, 1|SARAH`g[_, _]}}],
+                  bad = " 4part case: ";
+                  sarah = sarah /. SARAH`g[_, _] :> 1;
+                  cache = cache /. SARAH`g[_, _] :> 1;,
+                  bad = ": ";
+               ];
+               Print[vert, "/", Length@vertices, " ", subv, "/", Length@perm, bad, perm[[subv]]];
+               If[MatchQ[sarah,{{_, _, _}, {_, HoldPattern[-2*SARAH`Mom[_,_]+2*SARAH`Mom[_,_]]}}],
+                  Print["Wrong sarah expression for SSV vertex!"];
+                  ,
+                  TestEquality[cache, sarah];
+               ];,
+
+               {subv, Length@perm}
+            ];,
+
+            {vert, Length@vertices}
+         ];
+         If[GetNumberOfFailedTests[] === 0, Put[Cache`GetVertex]];
+         PrintTestSummary[];
+         GetNumberOfFailedTests[]
+      ],
+      {i, 4}
+   ];
+   res = WaitAll@jobs;
+   CloseKernels@kers;
+
+   Print["Time needed: ", ToString[N[(AbsoluteTime[]-time)/60.,{Infinity,3}]], "m.\n"];
+
+   TestEquality[res, {0, 0, 0, 0}];
+];
+
+GetPartitions[model_String] :=
+With[{dir = FileNameJoin@{Directory[], "Output", model, "EWSB", "Vertices"}},
+Module[{
+      ker = LaunchKernels@1, par3, par4
+   },
+   {{par3, par4}} = ParallelEvaluate[
+      f[{min_, max_, rest___}] :=
+         {Range @@ min, Sequence @@ f[{{Last@min + 1, Last@min + First@max}, rest}]};
+      f[{{min_, max_}}] :=
+         {Range[min, max]};
+
+      FairSplit[l_, n_] :=
+      Module[{subs},
+         subs = Table[{Floor[l/n]}, n];
+         Do[++subs[[i]], {i, Mod[l, n]}];
+         f@subs
+      ];
+      {
+         FairSplit[Length@Get@FileNameJoin@{dir, "VertexList3.m"}, 4],
+         FairSplit[Length@Get@FileNameJoin@{dir, "VertexList4.m"}, 4]
+      }, ker, DistributedContexts -> None];
+
+   CloseKernels@ker;
+   {par3, par4}
+]
+];
+
+
+(
+   CheckRude[#, Inverse];
+   CheckRude[#, Clear];
+   CheckRude[#, Replace];
+   CheckRude[#, Identity];
+)& /@ models ;
+
+Print[StringJoin[">>test>> done in ",ToString[N[(AbsoluteTime[]-Global`time)/60.,{Infinity,3}]]," m.\n"]];
+
+PrintTestSummary[];


### PR DESCRIPTION
Connected to #63, #270, #271 

This PR adds one new function, named ``Cache`GetVertex``, which replaces ``SARAH`Vertex`` function. It pretends to give *the same* result as replaced function, but faster.

Before the first usage it should be "activated" with ``Get[Cache`GetVertex]``. In the end, in order to save new results ``Put[Cache`GetVertex]`` can be used. 

Also has a unit test, which checks *all non-zero* field combinations:
   1) different permutations without indices,
   2) different permutations with *default* symbolic indices,
   3) different permutations with *default* symbolic indices, where generation indices are replaced by integers,
   4) small subset of zero-vertex field combinations, in order to check the mechanism.

Some known issues and possible suggestions:
   1) We can unify zero-vertex output to  `{{<fields>}, {0, 1}}`. `SARAH` gives a lot of different zeroes, and sometimes they are "random" (= strongly depend on internal Lagrangian form), i.e. for `SSVV` vertices it is `{0,1}` and sometimes `{0,g[lt1,lt2]}`. This is bad.
   2) `SARAH SSV` vertices with momenta difference also give "random" signs in front of coefficient and Lorentz structure (and sometimes even wrong results! - look at `Vertex@{bar@Fu@{1, 1}, Fu, VZ}` for `MRSSM`, or `Vertex@{phiO, VG, phiO}` for the same model. The last example is a very bad bug, and I am going to report about it). New functions give the result, which it identical to `SARAH` expression, but when one adds integer indices, then I gave up to implement the fast evaluation, because the results are "randomly" multiplied by minus sign, so then ``SARAH`Vertex`` is called instead.
   3) Calls for two particles are not cached.

