### PR TITLE
fix compilation error in CPV models with LowPrecision scalar mass

### DIFF
--- a/src/eigen_utils.hpp
+++ b/src/eigen_utils.hpp
@@ -236,7 +236,9 @@ void reorder_vector(
 }
 
 /**
- * @brief reorders vector v according to ordering of diagonal elements in mass_matrix
+ * @brief reorders vector v according to ordering of the magitude of
+ * the diagonal elements in matrix
+ *
  * @param v vector with elementes to be reordered
  * @param matrix matrix with diagonal elements with reference ordering
  */
@@ -245,7 +247,7 @@ void reorder_vector(
    Eigen::Array<double,Eigen::MatrixBase<Derived>::RowsAtCompileTime,1>& v,
    const Eigen::MatrixBase<Derived>& matrix)
 {
-   reorder_vector(v, matrix.diagonal().array().eval());
+   reorder_vector(v, matrix.diagonal().array().cwiseAbs().eval());
 }
 
 /// sorts an Eigen array

--- a/test/test_eigen_utils.cpp
+++ b/test/test_eigen_utils.cpp
@@ -163,6 +163,40 @@ BOOST_AUTO_TEST_CASE(test_reorder_vector_with_matrix)
    BOOST_CHECK_EQUAL(vec1(2), 2);
 }
 
+BOOST_AUTO_TEST_CASE(test_reorder_vector_with_matrix_abs)
+{
+   Eigen::Array<double,3,1> vec1;
+   vec1 << 1, 2, 3;
+
+   Eigen::Matrix<double,3,3> matrix;
+   matrix << 3, 0, 0,
+             0, 1, 0,
+             0, 0, -2; // uses abs() of diagonal values
+
+   reorder_vector(vec1, matrix);
+
+   BOOST_CHECK_EQUAL(vec1(0), 3);
+   BOOST_CHECK_EQUAL(vec1(1), 1);
+   BOOST_CHECK_EQUAL(vec1(2), 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_reorder_vector_with_matrix_complex)
+{
+   Eigen::Array<double,3,1> vec1;
+   vec1 << 1, 2, 3;
+
+   Eigen::Matrix<std::complex<double>,3,3> matrix;
+   matrix << 3, 0, 0,
+             0, 1, 0,
+             0, 0, 2;
+
+   reorder_vector(vec1, matrix);
+
+   BOOST_CHECK_EQUAL(vec1(0), 3);
+   BOOST_CHECK_EQUAL(vec1(1), 1);
+   BOOST_CHECK_EQUAL(vec1(2), 2);
+}
+
 BOOST_AUTO_TEST_CASE(test_remove_if_equal)
 {
    Eigen::Array<double,5,1> src;


### PR DESCRIPTION
diagonalization.  The function `reorder_vector` now uses the component-wise magnitude for the ordering.

Note: This changes the behavior of low-precision pole mass calculation in case of running tachyons.

fixes #281