### PR TITLE
Fix macOS BigSur configure problem finding pthreads

### DIFF
--- a/configure
+++ b/configure
@@ -433,7 +433,7 @@ check_library() {
 
     libs=""
     for i in $lib ; do
-        for ext in .a .lib "" .so .sl .dylib .dll.a ; do
+        for ext in .a .lib "" .so .sl .dylib .dll.a .tbd ; do
             libs="$libs $i$ext"
         done
     done
@@ -1518,10 +1518,10 @@ check_thread_libs() {
 
     # additional search paths by the compiler
     local cc_lib_search_paths=""
-
     case "$cxx_compiler_type" in
 	gnu|clang)
 	    cc_lib_search_paths=$(${CXX} -print-search-dirs | sed -n -e '/libraries:/s/libraries: *=//p')
+	    cc_lib_search_paths=$cc_lib_search_paths$(${CXX} -Xlinker -v 2>&1 | sed -n '/Library search paths:/,/Framework search paths:/p' | sed '/Library search paths:/d; /Framework search paths:/d' | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g' | tr -s '[:blank:]' ':')
 	    ;;
     esac
 


### PR DESCRIPTION
This aims to fix the problem here https://github.com/FlexibleSUSY/FlexibleSUSY/issues/292 .

@azedarach helped find the right use of sed etc on the macOS, but I will need to get a BigSur user to test it before we can merge it in (i will see if my GAMBIT collaborator Jonathan Cornell can after he has tested a similar fix in GAMBIT).  In the meantime Alex will probably want to look at the very ugly way I do this, though and may have comments.

Finally it only fixes the issue of not finding the library.  For the FS - 2.0.1 in gambit I have also made a change so that if the pthread libs are not found it simply disables multi-threading (as long as it was not explicitly enabled) instead of always giving a configure error.  I think we should do something similar in FS but the configure script has evolved so much its quite a different change that is is needed to do this.  For 2.0.1  the changes were like in this diff code:

```
diff --git a/contrib/MassSpectra/flexiblesusy/configure b/contrib/MassSpectra/flexiblesusy/configure
index b9cbae8..97c1f8a 100755
--- a/contrib/MassSpectra/flexiblesusy/configure
+++ b/contrib/MassSpectra/flexiblesusy/configure
@@ -1276,7 +1276,6 @@ check_std_threads() {
         if try_compile_cpp_program "#include <thread>
 #include <mutex>" "std::mutex mtx; std::thread thr;";
         then
-            enable_threads="yes"
             result "ok"
         else
             result "not available"
@@ -1297,11 +1296,23 @@ check_std_threads() {
 check_thread_libs() {
     # link libpthread only if $enable_threads = yes
     # I'm assuming here, that no other library we link needs libpthread.
-    if [ "x$enable_threads" = "xyes" -o -n "$pthread_lib_dir" ] ; then
+    if [ "x$enable_threads" = "xno" ] ; then
+	return 0
+    fi
+    if [ -n $pthread_lib_dir ] ; then
+	 message "Checking for libpthread..."
         check_library "libpthread" "$pthread_lib_dir" "$default_lib_paths"
-        if [ -z "$found_lib" ]; then
-            message "Error: libpthread must be installed to enable multithreading!"
-            exit 1
+        if [ -z "$found_lib" ] ; then
+            message "cannot find libpthread, which needs to be installed to enable multithreading."
+            if test "x${enable_threads}" = "xyes" ; then
+		message "Either reconfigure with \`--disable-threads' or"
+		message "pass the library location with \`--with-pthread-libdir='"
+		exit 1
+	    fi
+	    message "will disable multi-threading"
+	    enable_threads="no"
+	    return 0
         fi
+	enable_threads="yes"
         THREADLIBS=-l$(echo "$found_lib" | sed 's/^lib\(.*\)\..*$/\1/')
         # need to link whole libpthread.a for static linking
         if [ "x$enable_static" = xyes ] ; then
```