### PR TITLE
Br(l to l gamma): fix total decay width for decaying lepton

### DIFF
--- a/doc/slha_input.rst
+++ b/doc/slha_input.rst
@@ -638,7 +638,11 @@ physical input parameters, which are not contained in a SLHA-compliant
 ======= ====================================== ============================== ==================
   0      alpha_em(0) in the Thompson limit      any positive double            1./137.035999074
   1      SM Higgs pole mass                     any positive double            125.09
+  2      Planck constant, reduced               any positive double            6.582119569e-25
+  3      Muon mean life                         any positive double            2.1969811e-6
+  4      Tau mean life                          any positive double            290.3e-15
 ======= ====================================== ============================== ==================
+
 
 
 MODSEL block (MODSEL)

--- a/meta/BrLToLGamma.m
+++ b/meta/BrLToLGamma.m
@@ -108,7 +108,7 @@ CreateInterfaceFunctionForBrLToLGamma[inFermion_ -> {outFermion_, spectator_}] :
                   "// eq. 51 of arXiv:hep-ph/9510309 (note that we include 'e' in the definition of form_factor)\n" <>
                   "const double partial_width = pow(leptonInMassOS,5)/(16.0*Pi) * (std::norm(form_factors[2]) + std::norm(form_factors[3]));\n" <>
 
-                  "const double total_width = lepton_total_decay_width(generationIndex1, qedqcd);\n" <>
+                  "const double total_width = lepton_total_decay_width(generationIndex1, physical_input);\n" <>
                   "\nreturn partial_width/total_width;\n"
                ] <> "}";
 

--- a/meta/BrLToLGamma.m
+++ b/meta/BrLToLGamma.m
@@ -108,7 +108,7 @@ CreateInterfaceFunctionForBrLToLGamma[inFermion_ -> {outFermion_, spectator_}] :
                   "// eq. 51 of arXiv:hep-ph/9510309 (note that we include 'e' in the definition of form_factor)\n" <>
                   "const double partial_width = pow(leptonInMassOS,5)/(16.0*Pi) * (std::norm(form_factors[2]) + std::norm(form_factors[3]));\n" <>
 
-                  "const double total_width = lepton_total_decay_width(generationIndex1);\n" <>
+                  "const double total_width = lepton_total_decay_width(generationIndex1, qedqcd);\n" <>
                   "\nreturn partial_width/total_width;\n"
                ] <> "}";
 

--- a/meta/BrLToLGamma.m
+++ b/meta/BrLToLGamma.m
@@ -22,7 +22,7 @@
 
 *)
 
-BeginPackage["BrLToLGamma`", 
+BeginPackage["BrLToLGamma`",
    {"SARAH`", "TextFormatting`", "TreeMasses`", "CXXDiagrams`", "CConversion`"}
 ];
 
@@ -96,11 +96,11 @@ CreateInterfaceFunctionForBrLToLGamma[inFermion_ -> {outFermion_, spectator_}] :
                   "model, " <> discardSMcontributions <> ");\n" <>
                   (* Dominik suggest that the phase space prefactor should use pole masses  so we get them from the input file *)
                   "double leptonInMassOS;\n" <>
-                  "switch (generationIndex1) {\n" <> 
+                  "switch (generationIndex1) {\n" <>
                   IndentText[
-                     "case 0: leptonInMassOS = qedqcd.displayMass(softsusy::mElectron); break;\n" <> 
-                     "case 1: leptonInMassOS = qedqcd.displayMass(softsusy::mMuon);     break;\n" <> 
-                     "case 2: leptonInMassOS = qedqcd.displayMass(softsusy::mTau);      break;\n" <> 
+                     "case 0: leptonInMassOS = qedqcd.displayMass(softsusy::mElectron); break;\n" <>
+                     "case 1: leptonInMassOS = qedqcd.displayMass(softsusy::mMuon);     break;\n" <>
+                     "case 2: leptonInMassOS = qedqcd.displayMass(softsusy::mTau);      break;\n" <>
                      "default: throw std::invalid_argument(\"Unrecognized lepton\");\n"
                   ] <>
                   "}\n" <>
@@ -108,9 +108,7 @@ CreateInterfaceFunctionForBrLToLGamma[inFermion_ -> {outFermion_, spectator_}] :
                   "// eq. 51 of arXiv:hep-ph/9510309 (note that we include 'e' in the definition of form_factor)\n" <>
                   "const double partial_width = pow(leptonInMassOS,5)/(16.0*Pi) * (std::norm(form_factors[2]) + std::norm(form_factors[3]));\n" <>
 
-                  "const double total_width = lepton_total_decay_width<" <>
-                     CXXNameOfField[inFermion] <> ", " <> CXXNameOfField[outFermion] <> 
-                     ">(indices1, indices2, model, qedqcd);\n" <>
+                  "const double total_width = lepton_total_decay_width(generationIndex1);\n" <>
                   "\nreturn partial_width/total_width;\n"
                ] <> "}";
 

--- a/src/physical_input.cpp
+++ b/src/physical_input.cpp
@@ -51,7 +51,10 @@ const std::array<std::string, Physical_input::NUMBER_OF_INPUT_PARAMETERS>& Physi
 {
    static const std::array<std::string, NUMBER_OF_INPUT_PARAMETERS> names = {
       "alpha_em(0)",
-      "mh_pole"
+      "mh_pole",
+      "hbar",
+      "muon_mean_life",
+      "tau_mean_life"
    };
    return names;
 }
@@ -76,11 +79,17 @@ void Physical_input::set(const Eigen::ArrayXd& vec)
  * |----------------------------------|------------------------------|-----------------|
  * | alpha_em_0                       | any positive double          | 1/137.035999074 |
  * | mh_pole                          | any positive double          | 125.09          |
+ * | hbar                             | any positive double          | 6.582119569e-25 |
+ * | muon_mean_life                   | any positive double          | 2.1969811e-6    |
+ * | tau_mean_life                    | any positive double          | 290.3e-15       |
  */
 void Physical_input::reset()
 {
    values[alpha_em_0] = 1./137.035999074;
    values[mh_pole] = 125.09;
+   values[hbar] = 6.582119569e-25;
+   values[muon_mean_life] = 2.1969811e-6;
+   values[tau_mean_life] = 290.3e-15;
 }
 
 } // namespace flexiblesusy

--- a/src/physical_input.hpp
+++ b/src/physical_input.hpp
@@ -38,6 +38,10 @@ public:
    enum Input : int {
       alpha_em_0,                ///< [0] alpha_em(0), thompson limit
       mh_pole,                   ///< [1] SM Higgs pole mass
+      hbar,                      ///< [2] Planck constant, reduced, [GeV*s]
+      muon_mean_life,            ///< [3] Muon mean life, [s]
+      tau_mean_life,             ///< [4] Tau mean life, [s]
+
       NUMBER_OF_INPUT_PARAMETERS ///< number of possible input parameters
    };
 

--- a/templates/l_to_lgamma.cpp.in
+++ b/templates/l_to_lgamma.cpp.in
@@ -45,20 +45,33 @@ using namespace @ModelName@_FFV_form_factors;
 namespace @ModelName@_l_to_lgamma {
 
 /**
- * @param[in] g Generation index of decaying lepton.
+ * @param[in] g      Generation index of decaying lepton.
+ * @param[in] qedqcd Reference to low-energy data.
  * @return Total decay width in GeV, according to PDG data.
  */
-double lepton_total_decay_width(int g) {
+double lepton_total_decay_width(int g, const softsusy::QedQcd& qedqcd) {
    // https://pdg.lbl.gov/2020/reviews/rpp2020-rev-phys-constants.pdf
-   constexpr double hbar = 6.582119569e-25, // [GeV*s]
+   constexpr double hbar = 6.582119569e-25,   // [GeV*s]
    // https://pdg.lbl.gov/2020/listings/rpp2020-list-muon.pdf
-                    muon = 2.1969811e-6,    // [s]
+                    mass_muon = 0.1056583745, // [GeV]
+                    time_muon = 2.1969811e-6, // [s]
    // https://pdg.lbl.gov/2020/listings/rpp2020-list-tau.pdf
-                    tau  = 290.3e-15;       // [s]
+                    mass_tau  = 1.77686,      // [GeV]
+                    time_tau  = 290.3e-15;    // [s]
    switch (g) {
       case 0: throw std::invalid_argument("Electron decay is not supported");
-      case 1: return hbar/muon;
-      case 2: return hbar/tau;
+      case 1:
+              auto softMass = qedqcd.displayMass(softsusy::mMuon);
+              if (!is_zero(softMass - mass_muon)) {
+                 WARNING("Difference in low energy muon mass and the one of PDG");
+              }
+              return hbar/time_muon;
+      case 2:
+              auto softMass = qedqcd.displayMass(softsusy::mTau);
+              if (!is_zero(softMass - mass_tau)) {
+                 WARNING("Difference in low energy tau mass and the one of PDG");
+              }
+              return hbar/time_tau;
       default: throw std::invalid_argument("Unrecognized lepton");
    }
 }

--- a/templates/l_to_lgamma.cpp.in
+++ b/templates/l_to_lgamma.cpp.in
@@ -45,17 +45,18 @@ using namespace @ModelName@_FFV_form_factors;
 namespace @ModelName@_l_to_lgamma {
 
 /**
- * @param[in] nI     Generation index of incoming lepton.
+ * @param[in] g Generation index of decaying lepton.
  * @return Total decay width in GeV, according to PDG data.
  */
-double lepton_total_decay_width(int nI) {
+double lepton_total_decay_width(int g) {
    // https://pdg.lbl.gov/2020/reviews/rpp2020-rev-phys-constants.pdf
    constexpr double hbar = 6.582119569e-25, // [GeV*s]
    // https://pdg.lbl.gov/2020/listings/rpp2020-list-muon.pdf
                     muon = 2.1969811e-6,    // [s]
    // https://pdg.lbl.gov/2020/listings/rpp2020-list-tau.pdf
                     tau  = 290.3e-15;       // [s]
-   switch (nI) {
+   switch (g) {
+      case 0: throw std::invalid_argument("Electron decay is not supported");
       case 1: return hbar/muon;
       case 2: return hbar/tau;
       default: throw std::invalid_argument("Unrecognized lepton");

--- a/templates/l_to_lgamma.cpp.in
+++ b/templates/l_to_lgamma.cpp.in
@@ -44,27 +44,22 @@ using namespace @ModelName@_FFV_form_factors;
 
 namespace @ModelName@_l_to_lgamma {
 
-template <typename FIn, typename FOut, typename T1, typename T2>
-double lepton_total_decay_width(
-      T1 const& indices1, T2 const& indices2, 
-      const @ModelName@_mass_eigenstates& model, const softsusy::QedQcd& qedqcd) {
-
-   context_base context {model};
-
-   const auto leptonInMass = context.mass<FIn>(indices1);
-   const auto leptonOutMass = context.mass<FOut>(indices2);
-   const auto r = pow(leptonOutMass/leptonInMass, 2);
-   const auto GF2 = pow(qedqcd.displayFermiConstant(), 2);
-   const double Alpha = Sqr(FIn::electric_charge * unit_charge(context))/(4*Pi);
-
-   // eq. 10.6 of http://pdg.lbl.gov/2018/reviews/rpp2018-rev-standard-model.pdf
-   return 
-      // tree-level (with massless outgoing lepton)
-      GF2*pow(leptonInMass,5)/(192.0*pow(Pi,3)) 
-      // outgoing lepton mass correction
-      * (1 - 8*r + 8*pow(r,3) - pow(r,4) - 12*r*r*std::log(r));
-      // higher order correction
-      //* (1.0 + 0.5 * Alpha * (6.25-Sqr(Pi))/Pi)
+/**
+ * @param[in] nI     Generation index of incoming lepton.
+ * @return Total decay width in GeV, according to PDG data.
+ */
+double lepton_total_decay_width(int nI) {
+   // https://pdg.lbl.gov/2020/reviews/rpp2020-rev-phys-constants.pdf
+   constexpr double hbar = 6.582119569e-25, // [GeV*s]
+   // https://pdg.lbl.gov/2020/listings/rpp2020-list-muon.pdf
+                    muon = 2.1969811e-6,    // [s]
+   // https://pdg.lbl.gov/2020/listings/rpp2020-list-tau.pdf
+                    tau  = 290.3e-15;       // [s]
+   switch (nI) {
+      case 1: return hbar/muon;
+      case 2: return hbar/tau;
+      default: throw std::invalid_argument("Unrecognized lepton");
+   }
 }
 
 @LToLGamma_InterfaceDefinitions@

--- a/templates/l_to_lgamma.cpp.in
+++ b/templates/l_to_lgamma.cpp.in
@@ -12,10 +12,7 @@
 // General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with FlexibleSUSY.  If not, see
-// <http://www.gnu.org/licenses/>.
-// ====================================================================
-
+// along with FlexibleSUSY.  If not, see // <http://www.gnu.org/licenses/>.  // ====================================================================
 
 /**
  * @file @ModelName@_l_to_lgamma.cpp
@@ -49,29 +46,14 @@ namespace @ModelName@_l_to_lgamma {
  * @param[in] qedqcd Reference to low-energy data.
  * @return Total decay width in GeV, according to PDG data.
  */
-double lepton_total_decay_width(int g, const softsusy::QedQcd& qedqcd) {
-   // https://pdg.lbl.gov/2020/reviews/rpp2020-rev-phys-constants.pdf
-   constexpr double hbar = 6.582119569e-25,   // [GeV*s]
-   // https://pdg.lbl.gov/2020/listings/rpp2020-list-muon.pdf
-                    mass_muon = 0.1056583745, // [GeV]
-                    time_muon = 2.1969811e-6, // [s]
-   // https://pdg.lbl.gov/2020/listings/rpp2020-list-tau.pdf
-                    mass_tau  = 1.77686,      // [GeV]
-                    time_tau  = 290.3e-15;    // [s]
+double lepton_total_decay_width(int g, const Physical_input& physical_input) {
+   const auto hbar = physical_input.get(Physical_input::hbar);
    switch (g) {
       case 0: throw std::invalid_argument("Electron decay is not supported");
       case 1:
-              auto softMass = qedqcd.displayMass(softsusy::mMuon);
-              if (!is_zero(softMass - mass_muon)) {
-                 WARNING("Difference in low energy muon mass and the one of PDG");
-              }
-              return hbar/time_muon;
+              return hbar/physical_input.get(Physical_input::muon_mean_life);
       case 2:
-              auto softMass = qedqcd.displayMass(softsusy::mTau);
-              if (!is_zero(softMass - mass_tau)) {
-                 WARNING("Difference in low energy tau mass and the one of PDG");
-              }
-              return hbar/time_tau;
+              return hbar/physical_input.get(Physical_input::tau_mean_life);
       default: throw std::invalid_argument("Unrecognized lepton");
    }
 }


### PR DESCRIPTION
**Before:** the formula for muon decay was always used. It means, that for tau decay the result should be something like 5 times lower, then in should be (decays to muon, electron, and quarks * 3 colors).

**Now:** brutal numbers from PGD of 2020 were hard coded in order to get correct results.

The only assumption, which is made: there are generation numbers, which distinguish between different leptons. This was the case also before.