### PR TITLE
link COLLIER, LoopTools and TSIL with rpath

### DIFF
--- a/configure
+++ b/configure
@@ -2272,7 +2272,7 @@ check_looptools_libs() {
          # assume that the linker will look in the default paths
          LOOPTOOLSLIBS="$LOOPTOOLSLIBS_"
       else
-         LOOPTOOLSLIBS="-L$looptools_lib_dir $LOOPTOOLSLIBS_"
+         LOOPTOOLSLIBS="-L$looptools_lib_dir -Wl,-rpath,$looptools_lib_dir $LOOPTOOLSLIBS_"
       fi
 
       # check dependency on libquadmath by searching for cabsq in liblooptools
@@ -2356,7 +2356,7 @@ check_collier_libs() {
          # assume that the linker will look in the default paths
          COLLIERLIBS=" $COLLIERLIBS_ "
       else
-         COLLIERLIBS="$ABSBASEDIR/src/loop_libraries/libcollier_wrapper.a -L$collier_lib_dir $COLLIERLIBS_"
+         COLLIERLIBS="$ABSBASEDIR/src/loop_libraries/libcollier_wrapper.a -L$collier_lib_dir -Wl,-rpath,$collier_lib_dir $COLLIERLIBS_"
       fi
    fi
 }
@@ -2555,7 +2555,7 @@ check_tsil_libs() {
             # assume that the linker will look in the default paths
             TSILLIBS="$TSILLIBS_"
         else
-            TSILLIBS="-L$tsil_lib_dir $TSILLIBS_"
+            TSILLIBS="-L$tsil_lib_dir -Wl,-rpath,$tsil_lib_dir $TSILLIBS_"
         fi
     fi
     return 0


### PR DESCRIPTION
to not require the user to set `LD_LIBRARY_PATH` every time