### PR TITLE
update required Mathematica version to 10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Requirements
 
 * C++ compiler (g++ >= 5.0.0 or clang++ >= 3.8.1 or icpc >= 17.0.0)
 * Fortran compiler (gfortran, ifort)
-* Mathematica (version 10.0 or higher)
+* Mathematica (version 10.1 or higher)
 * SARAH_ (version 4.11.0 or higher)
 * Boost_ (version 1.37.0 or higher)
 * `Eigen 3`_ (version 3.1 or higher)

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Requirements
 
 * C++ compiler (g++ >= 5.0.0 or clang++ >= 3.8.1 or icpc >= 17.0.0)
 * Fortran compiler (gfortran, ifort)
-* Mathematica (version 7.0 or higher)
+* Mathematica (version 10.0 or higher)
 * SARAH_ (version 4.11.0 or higher)
 * Boost_ (version 1.37.0 or higher)
 * `Eigen 3`_ (version 3.1 or higher)

--- a/configure
+++ b/configure
@@ -245,7 +245,7 @@ required_icpc_compiler_version="17.0.0"
 required_boost_version="1.37.0"
 
 # required Mathematica version
-required_mathematica_version="10"
+required_mathematica_version="10.1"
 
 # required SARAH version
 required_sarah_major="4"

--- a/configure
+++ b/configure
@@ -245,7 +245,7 @@ required_icpc_compiler_version="17.0.0"
 required_boost_version="1.37.0"
 
 # required Mathematica version
-required_mathematica_version="7"
+required_mathematica_version="10"
 
 # required SARAH version
 required_sarah_major="4"


### PR DESCRIPTION
because the symbol `StringPadRight` seems to be defined only from version 10 onward.