### PR TITLE
added ColorMath reference to the list of references

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -88,6 +88,23 @@
     year          = "2021"
 }
 
+% ColorMath
+% \cite{Sjodahl:2012nk}
+@article{Sjodahl:2012nk,
+    author = {Sj\"odahl, Malin},
+    title = "{ColorMath - A package for color summed calculations in SU(Nc)}",
+    eprint = "1211.2099",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "LU-TP-12-40, MCNET-13-04",
+    doi = "10.1140/epjc/s10052-013-2310-4",
+    journal = "Eur. Phys. J. C",
+    volume = "73",
+    number = "2",
+    pages = "2310",
+    year = "2013"
+}
+
 % \cite{Harlander:2018yhj}
 @article{Harlander:2018yhj,
       author         = "Harlander, R. V. and Klappert, J. and Ochoa Franco, A. D.

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -3178,6 +3178,7 @@ FSCheckFlags[] :=
 
            If[FlexibleSUSY`FSCalculateDecays,
               References`AddReference["Athron:2021kve"];
+              References`AddReference["Sjodahl:2012nk"];
              ];
 
            If[FlexibleSUSY`UseYukawa3LoopQCD || FlexibleSUSY`FlexibleEFTHiggs,


### PR DESCRIPTION
Since we use a modified version of ColorMath in FlexibleDecay I think it's fair we add it to the auto-generated reference list if we compute decays.