### PR TITLE
working decays of octet to gg

### DIFF
--- a/meta/CXXDiagrams.m
+++ b/meta/CXXDiagrams.m
@@ -674,14 +674,11 @@ ColourFactorForIndexedDiagramFromGraph[indexedDiagram_, graph_] :=
 		If[(Times @@ colorMathExpressions) === 1, 1,
 			ColorMathToSARAHConvention[
             With[{colorFac = ColorMath`CSimplify[Times @@ colorMathExpressions]},
-               If[!FreeQ[colorFac, Superscript[CMo, {__}]],
-                  (* RemoveFD converts f and d color structures into a sum of ColorMath`o *)
-                  ColorMath`CSimplify[Times @@ colorMathExpressions, RemoveFD -> False],
-                  (* on the other hand, without RemoveFD -> True expression
-                          {ct94450, ct94453}ct94448           {ct94450, ct94453, ct94454}
-                     4 CMt                                 CMf
-                                                   ct94455
-                     is not simplified *)
+               If[ColorMath`ContainsO[colorFac],
+                  ColorMath`SortIndices[
+                     colorFac /.
+                        Superscript[ColorMath`CMo, idx_List] /; Length[idx]===3 :> ColorMath`TR/2 (0 I Superscript[ColorMath`CMf, idx] + Superscript[ColorMath`CMd, idx])
+                  ],
                   colorFac
                ]
             ]
@@ -1655,9 +1652,10 @@ ExtractColourFactor[SARAH`Lam[ctIndex1_, ctIndex2_, ctIndex3_]] := 2;
 ExtractColourFactor[colourfactor_ * SARAH`Delta[ctIndex1_, ctIndex2_] /; NumericQ[colourfactor]] := colourfactor;
 ExtractColourFactor[SARAH`Delta[ctIndex1_, ctIndex2_]] := 1;
 ExtractColourFactor[colourfactor_ /; NumericQ[colourfactor]] := colourfactor;
+(* currently from 8->88 we only handle symmetric structure (i.e d, not f) *)
+(* ExtractColourFactor[colourfactor_ * Superscript[CMf, {ctIndex1_, ctIndex2_, ctIndex3_}] /; NumericQ[colourfactor]] := colourfactor; *)
+ExtractColourFactor[colourfactor_ * Superscript[CMd, {ctIndex1_, ctIndex2_, ctIndex3_}] /; NumericQ[colourfactor]] := colourfactor;
 (* cases for 8->88 amplitudes
-ExtractColourFactor[colourfactor_ * Superscript[CMf, {ctIndex1_, ctIndex2_, ctIndex3_}] /; NumericQ[colourfactor]] := ?;
-ExtractColourFactor[colourfactor_ * Superscript[CMd, {ctIndex1_, ctIndex2_, ctIndex3_}] /; NumericQ[colourfactor]] := ?;
 ExtractColourFactor[colourfactor1_ * Superscript[CMf, {ctIndex1_, ctIndex2_, ctIndex3_} + colourfactor2_ * Superscript[CMd, {ctIndex1_, ctIndex2_, ctIndex3_}] /; NumericQ[colourfactor1]] && NumericQ[colourfactor2]] := ?;
 *)
 ExtractColourFactor[args___] :=

--- a/meta/ColorMath.m
+++ b/meta/ColorMath.m
@@ -22,6 +22,8 @@ CMdelta::usage = "";
 CMDelta::usage = "";
 CMo::usage = "";
 CMd::usage = "";
+ContainsO::usage = "";
+SortIndices::usage = "";
 
 Begin["Private`"];
 Unprotect[Conjugate];
@@ -135,9 +137,9 @@ CM\[CapitalDelta][G1$_, G2$_] := Superscript[CM\[CapitalDelta], {G1$, G2$}]
  
 CMf[G1$_, G2$_, G3$_] := Superscript[CMf, {G1$, G2$, G3$}]
  
-d[G1$_, G2$_, G3$_] := Superscript[CMd, {G1$, G2$, G3$}]
+CMd[G1$_, G2$_, G3$_] := Superscript[CMd, {G1$, G2$, G3$}]
  
-o[Gs$_] := Superscript[CMo, Gs$]
+CMo[Gs$_] := Superscript[CMo, Gs$]
  
 AllPairs[CMExpr$_] := Select[FindSymbols[CMExpr$], 
      Count[FindSymbols[CMExpr$], #1] == 2 & ]

--- a/meta/Decays.m
+++ b/meta/Decays.m
@@ -324,23 +324,16 @@ IsColorInvariantDecay[initialParticle_, finalState_List] :=
               finalStateReps = Sort[TreeMasses`GetColorRepresentation /@ finalState];
               Switch[initialStateRep,
                      S, result = ((finalStateReps === {S, S}) ||
-                                  (finalStateReps === {T, T}) ||
-                                  (finalStateReps === {-T, -T}) ||
                                   (finalStateReps === Sort[{-T, T}]) ||
                                   (finalStateReps === {O, O}));,
-                     T|-T, result = ((finalStateReps === Sort[{T, S}]) ||
-                                     (finalStateReps === Sort[{-T, S}]) ||
+                     T|-T, result = ((finalStateReps === Sort[{initialStateRep, S}]) ||
                                      (finalStateReps === Sort[{O, T}]) ||
                                      (finalStateReps === Sort[{O, -T}]));,
                      O, result = ((finalStateReps === Sort[{O, S}]) ||
-                                  (finalStateReps === {T, T}) ||
-                                  (finalStateReps === {-T, -T}) ||
                                   (finalStateReps === Sort[{-T, T}])
-                                  (* uncomment to enable O -> OO decays once
-                                     the handling of multiple color structures
-                                     is introduced
-                                  || (finalStateReps === Sort[{O, O}])*));,
-                     _, result = True; (* unhandled case *)
+                                  (* for now we only handle octet decays to symmetric final state *)
+                                  || (finalStateReps === {O, O} && SameQ@@finalState));,
+                     _, result = False; (* unhandled case *)
                     ];
              ];
            result

--- a/model_files/MRSSM2/FlexibleSUSY.m.in
+++ b/model_files/MRSSM2/FlexibleSUSY.m.in
@@ -99,7 +99,7 @@ ExtraSLHAOutputBlocks = {
 };
 
 FSCalculateDecays = True;
-FSDecayParticles = {hh, Ah, Hpm};
+FSDecayParticles = {hh, Ah, Hpm, sigmaO, phiO};
 
 DefaultPoleMassPrecision = HighPrecision;
 HighPoleMassPrecision    = {hh, Ah, Hpm};

--- a/templates/decays/decays.hpp.in
+++ b/templates/decays/decays.hpp.in
@@ -250,6 +250,33 @@ std::enable_if_t<
 >
 squared_color_generator() {return 1./2.;}
 
+// 8 -> 8, 8 with identical particles in the final state
+// because of symmetry of the final state it must be proportional to d^2
+template<typename FieldIn, typename FieldOut1, typename FieldOut2>
+constexpr
+std::enable_if_t<
+@ModelName@_cxx_diagrams::fields::is_octet_v<FieldIn> &&
+@ModelName@_cxx_diagrams::fields::is_octet_v<FieldOut1> &&
+@ModelName@_cxx_diagrams::fields::is_octet_v<FieldOut2> &&
+std::is_same<FieldOut1, FieldOut2>::value
+, double>
+// color:   d^2 = (2 (4 - 5 Nc^2 + Nc^4) TR)/Nc = 40/3
+// average: 1/8
+squared_color_generator() {return 40/24.;}
+
+// 8 -> 8, 8 with differnt particles in the final state
+template<typename FieldIn, typename FieldOut1, typename FieldOut2>
+constexpr
+std::enable_if_t<
+@ModelName@_cxx_diagrams::fields::is_octet_v<FieldIn> &&
+@ModelName@_cxx_diagrams::fields::is_octet_v<FieldOut1> &&
+@ModelName@_cxx_diagrams::fields::is_octet_v<FieldOut2> &&
+!std::is_same<FieldOut1, FieldOut2>::value
+, double>
+// color:   f^2 = 2 Nc (-1 + Nc^2) TR = 24
+// average: 1/8
+squared_color_generator() {return 3.;}
+
 // generic decay of FieldIn -> FieldOut1 FieldOut2
 template<typename FieldIn, typename FieldOut1, typename FieldOut2>
 double @ModelName@_decays::get_partial_width(

--- a/test/test_MRSSM2_FlexibleDecay.cpp
+++ b/test/test_MRSSM2_FlexibleDecay.cpp
@@ -760,4 +760,12 @@ Block FlexibleSUSYLowEnergy Q= 1.00000000E+03
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_hh_to_VGVG(&m, 0), 0.00012423136936565911, 7e-11);
    // h -> gamma Z
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_hh_to_VPVZ(&m, 0), 6.391735378735319e-06, 5e-11);
+
+   // scalar sgluon
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_phiO_to_VGVG(&m), 7.5701751945543629e-09, 3e-11);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_phiO_to_barFuFu(&m, 2, 2), 2.2040853636396876e-05, 2e-12);
+
+   // pseudoscalar sgluon
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_sigmaO_to_VGVG(&m), 0, 1e-16);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_sigmaO_to_barFuFu(&m, 2, 2), 2.1375623871457065e-11, 8e-12);
 }


### PR DESCRIPTION
This PR partially solves the issue #260. For decays to a symmetric final state we can predict that the amplitude is only proportional to d. In the MRSSM this allows to generate sgluon -> gg decays.