### PR TITLE
fix decay calculation via run_cmd

### DIFF
--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -2565,8 +2565,12 @@ if (show_decays && flexibledecay_settings.get(FlexibleDecay_settings::calculate_
 
 ExampleCalculateCmdLineDecays[] :=
 FlexibleSUSY`FSModelName <> "_decays decays;" <>
-"if (settings.get(Spectrum_generator_settings::calculate_sm_masses)) {
-   decays = " <> FlexibleSUSY`FSModelName <> "_decays(std::get<0>(models), qedqcd, physical_input, flexibledecay_settings);
+"decays = " <> FlexibleSUSY`FSModelName <> "_decays(std::get<0>(models), qedqcd, physical_input, flexibledecay_settings);
+const bool loop_library_for_decays =
+   (Loop_library::get_type() == Loop_library::Library::Collier) ||
+   (Loop_library::get_type() == Loop_library::Library::Looptools);
+if (spectrum_generator.get_exit_code() == 0 && loop_library_for_decays) {
+   decays.calculate_decays();
 }";
 
 WriteExampleCmdLineOutput[enableDecays_] :=

--- a/templates/run_cmd_line.cpp.in
+++ b/templates/run_cmd_line.cpp.in
@@ -88,6 +88,7 @@ int run_solver(int loop_library, const @ModelName@_input_parameters& input)
    settings.set(Spectrum_generator_settings::precision, 1.0e-4);
    settings.set(Spectrum_generator_settings::loop_library, loop_library);
    settings.set(Spectrum_generator_settings::calculate_bsm_masses, 1.0);
+   settings.set(Spectrum_generator_settings::calculate_sm_masses, 1.0);
 
    @ModelName@_spectrum_generator<solver_type> spectrum_generator;
    spectrum_generator.set_settings(settings);


### PR DESCRIPTION
`run_cmd_line_*` was never actually computing decays because it never called `calculate_decays()`. Since there is no switch in `run_cmd_line_*`  that controls whether we do or don't want decays calculated, I also had to add
```
settings.set(Spectrum_generator_settings::calculate_sm_masses, 1.0);
```
in all cases as decays need those masses.