### PR TITLE
removed duplicate lines in lowNMSSM model files

### DIFF
--- a/model_files/lowNMSSM/FlexibleSUSY.m.in
+++ b/model_files/lowNMSSM/FlexibleSUSY.m.in
@@ -68,8 +68,6 @@ SUSYScaleInput = {
     {mq2[1,1], mq1Input^2},
     {mq2[2,2], mq2Input^2},
     {mq2[3,3], mq3Input^2},
-    {me2[1,1], me1Input^2},
-    {me2[2,2], me2Input^2},
     {T[Yu][3,3], AtInput Yu[3,3]},
     {T[Yd][3,3], AbInput Yd[3,3]},
     {T[Ye][3,3], ATauInput Ye[3,3]}

--- a/model_files/lowNMSSMTanBetaAtMZ/FlexibleSUSY.m.in
+++ b/model_files/lowNMSSMTanBetaAtMZ/FlexibleSUSY.m.in
@@ -67,8 +67,6 @@ SUSYScaleInput = {
     {mq2[1,1], mq1Input^2},
     {mq2[2,2], mq2Input^2},
     {mq2[3,3], mq3Input^2},
-    {me2[1,1], me1Input^2},
-    {me2[2,2], me2Input^2},
     {T[Yu][3,3], AtInput Yu[3,3]},
     {T[Yd][3,3], AbInput Yd[3,3]},
     {T[Ye][3,3], ATauInput Ye[3,3]}


### PR DESCRIPTION
Some lines where duplicated in low scale NMSSM model files
```mathematica
SUSYScaleInput = {    
    .....  
    {me2[1,1], me1Input^2},    
    {me2[2,2], me2Input^2},    
    {me2[3,3], me3Input^2},    
    ...
    {me2[1,1], me1Input^2},    
    {me2[2,2], me2Input^2},    
    ...
};    
```