### PR TITLE
fixed LFV decay output via mathlink

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+FlexibleSUSY 2.6.2 [July, 08 2021]
+==================================
+
+Changes
+-------
+
+Fixed bugs
+----------
+
+* [commit ]: Branching ratio of L'->LGamma was breaking printing of
+  observables via the mathlink interface.
+
 FlexibleSUSY 2.6.1 [July, 08 2021]
 ==================================
 

--- a/meta/FSMathLink.m
+++ b/meta/FSMathLink.m
@@ -20,7 +20,7 @@
 
 *)
 
-BeginPackage["FSMathLink`", {"CConversion`", "Parameters`", "Utils`"}];
+BeginPackage["FSMathLink`", {"CConversion`", "Parameters`", "Utils`", "TreeMasses`"}];
 
 GetNumberOfInputParameterRules::usage = "";
 GetNumberOfSpectrumEntries::usage = "";
@@ -203,6 +203,18 @@ ObsToStr[obs_] := "\"" <> ToString[obs] <> "\"";
 HeadToStr[sym_]    := "\"" <> ToString[sym] <> "\"";
 HeadsToStr[{}]     := "";
 HeadsToStr[l_List] := ", {" <> StringJoin[Riffle[HeadToStr /@ l, ", "]] <> "}";
+
+PutObservable[FlexibleSUSYObservable`BrLToLGamma[p1_[idx1_Integer]->{p2_[idx2_Integer], V_}], type_, link_String, heads_:{}] /; V === TreeMasses`GetPhoton[] := "
+MLPutFunction(link, \"Rule\", 2);
+MLPutFunction(link, \"FlexibleSUSYObservable`BrLToLGamma\", 1);
+MLPutFunction(link, \"Rule\", 2);
+MLPutFunction(link, \"" <> ToString[p1] <> "\", 1);
+MLPutInteger(link, " <> ToString[idx1] <> ");
+MLPutFunction(link, \"List\", 2);
+MLPutFunction(link, \"" <> ToString[p2] <> "\", 1);
+MLPutInteger(link, " <> ToString[idx2] <> ");
+MLPutSymbol(link, \"" <> ToString[V] <> "\");
+MLPutReal(link, OBSERVABLE(" <> ToString[p1] <> ToString[idx1] <> "_to_" <> ToString[p2] <> ToString[idx2] <> "_" <> ToString[V] <> "));"
 
 PutObservable[obs_[sub_], type_, link_String, heads_:{}] :=
     PutObservable[sub, type, link, Join[heads, {obs}]];

--- a/meta/Observables.m
+++ b/meta/Observables.m
@@ -73,7 +73,7 @@ GetObservableName[obs_ /; obs === FlexibleSUSYObservable`aMuonGM2Calc] := "a_muo
 GetObservableName[obs_ /; obs === FlexibleSUSYObservable`aMuonGM2CalcUncertainty] := "a_muon_gm2calc_uncertainty";
 GetObservableName[FlexibleSUSYObservable`EDM[p_[idx_]]] := GetObservableName[FlexibleSUSYObservable`EDM[p]] <> "_" <> ToString[idx];
 GetObservableName[FlexibleSUSYObservable`EDM[p_]]       := "edm_" <> CConversion`ToValidCSymbolString[p];
-GetObservableName[FlexibleSUSYObservable`BrLToLGamma[pIn_[_] -> {pOut_[_], spectator_}]] := CConversion`ToValidCSymbolString[pIn] <> "_to_" <> CConversion`ToValidCSymbolString[pOut] <> "_" <> CConversion`ToValidCSymbolString[spectator];
+GetObservableName[FlexibleSUSYObservable`BrLToLGamma[pIn_[idxIn_] -> {pOut_[idxOut_], spectator_}]] := CConversion`ToValidCSymbolString[pIn] <> ToString[idxIn] <> "_to_" <> CConversion`ToValidCSymbolString[pOut] <> ToString[idxOut] <> "_" <> CConversion`ToValidCSymbolString[spectator];
 GetObservableName[FlexibleSUSYObservable`BrLToLGamma[pIn_ -> {pOut_, spectator_}]] := CConversion`ToValidCSymbolString[pIn] <> "_to_" <> CConversion`ToValidCSymbolString[pOut] <> "_" <> CConversion`ToValidCSymbolString[spectator];
 GetObservableName[FlexibleSUSYObservable`FToFConversionInNucleus[pIn_[idxIn_] -> pOut_[idxOut_], nucleus_]] := CConversion`ToValidCSymbolString[pIn] <> "_to_" <> CConversion`ToValidCSymbolString[pOut] <> "_in_" <> ToString@nucleus;
 GetObservableName[obs_ /; obs === FlexibleSUSYObservable`bsgamma] := "b_to_s_gamma";

--- a/templates/observables.cpp.in
+++ b/templates/observables.cpp.in
@@ -43,7 +43,7 @@
 #define EDM0(p) edm_ ## p
 #define EDM1(p,idx) edm_ ## p ## _ ## idx
 #define LToLGamma0(pIn, pOut, spec) pIn ## _to_ ## pOut ## _ ## spec
-#define LToLGamma1(pIn,idxIn,pOut,idxOut,spec) pIn ## _to_ ## pOut ## _ ## spec
+#define LToLGamma1(pIn,idxIn,pOut,idxOut,spec) pIn ## idxIn ## _to_ ## pOut ## idxOut ## _ ## spec
 #define FToFConversion1(pIn,idxIn,pOut,idxOut,nuclei,qedqcd) pIn ## _to_ ## pOut ## _in_ ## nuclei
 #define BSGAMMA b_to_s_gamma
 


### PR DESCRIPTION
It's not pretty but I don't know if it makes sense to bother. To get output like
```mathematica
FlexibleSUSYObservable`BrLToLGamma[Fe[2] -> {Fe[0], VP}] -> 0.
```
I' ve added code that generates blocks like
```cpp
MLPutFunction(link, "Rule", 2);
MLPutFunction(link, "FlexibleSUSYObservable`BrLToLGamma", 1);
MLPutFunction(link, "Rule", 2);
MLPutFunction(link, "Fe", 1);
MLPutInteger(link, 1);
MLPutFunction(link, "List", 2);
MLPutFunction(link, "Fe", 1);
MLPutInteger(link, 0);
MLPutSymbol(link, "VP");
MLPutReal(link, OBSERVABLE(Fe1_to_Fe0_VP));
```