### PR TITLE
Clearing cache for FeynArts and FormCalc for different version.

### DIFF
--- a/configure
+++ b/configure
@@ -2935,19 +2935,21 @@ EOF
    # Removing NPointFunctions, FormCalc, FeynArts output folders
    [ "${enable_feynarts}" = "yes" ] && {
       [ "${FEYNARTS_VERSION}" = "${oldVersion}" ] || {
-         local models="$(echo $MODELS | tr ',' ' ')"
-         for m in ${models}; do
-            local eigenstate=$(grep 'FSEigenstates' "models/$m/FlexibleSUSY.m" \
+         for m in "models"/*; do
+            [ -e "$m/FlexibleSUSY.m" ] || continue
+            [ -e "$m/start.m" ] || continue
+            local eigenstate=$(grep 'FSEigenstates' "$m/FlexibleSUSY.m" \
                        | sed 's/ //g' \
                        | sed 's/.*`\(.*\);/\1/')
-            local output=$(grep -m1 'OutputDirectory' "models/$m/start.m" \
+            local output=$(grep -m1 'OutputDirectory' "$m/start.m" \
                         | sed 's/ //g' \
                         | sed 's/.*\"\(.*\)\".*/\1/')
-            local dir="${output}/$m/${eigenstate}/FeynArts"
+            output=$(echo $m | sed "s/models/${output}/")
+            local dir="${output}/${eigenstate}/FeynArts"
             [ -d "${dir}" ] && { rm -rf ${dir}; }
-            dir="${output}/$m/${eigenstate}/FormCalc"
+            dir="${output}/${eigenstate}/FormCalc"
             [ -d "${dir}" ] && { rm -rf ${dir}; }
-            dir="${output}/$m/${eigenstate}/NPointFunctions"
+            dir="${output}/${eigenstate}/NPointFunctions"
             [ -d "${dir}" ] && { rm -rf ${dir}; }
          done
       }
@@ -3009,14 +3011,16 @@ EOF
 
    [ "${enable_formcalc}" = "yes" ] && {
       [ "${FORMCALC_VERSION}" = "${oldVersion}" ] || {
-         local models="$(echo $MODELS | tr ',' ' ')"
-         for m in ${models}; do
+         for m in "models"/*; do
+            [ -e "$m/FlexibleSUSY.m" ] || continue
+            [ -e "$m/start.m" ] || continue
             local eigenstate=$(grep 'FSEigenstates' "models/$m/FlexibleSUSY.m" \
                                | sed 's/ //g' \
                                | sed 's/.*`\(.*\);/\1/')
             local output=$(grep -m1 'OutputDirectory' "models/$m/start.m" \
                            | sed 's/ //g' \
                            | sed 's/.*\"\(.*\)\".*/\1/')
+            output=$(echo $m | sed "s/models/${output}/")
             local dir="${output}/$m/${eigenstate}/FormCalc"
             [ -d "${dir}" ] && { rm -rf ${dir}; }
             dir="${output}/$m/${eigenstate}/NPointFunctions"

--- a/configure
+++ b/configure
@@ -2885,6 +2885,8 @@ check_feynarts() {
     if test "x$enable_feynarts" = "xno"; then return; fi
 
     checking_msg "FeynArts installation"
+    local oldVersion=""
+    [ -f "${feynartsconfig}" ] && oldVersion=$(cat "${feynartsconfig}")
     rm -f ${feynartsconfig}
     "$MATH" <<EOF > /dev/null
 Needs["FeynArts\`"];
@@ -2929,6 +2931,27 @@ EOF
         message "   Please make sure Needs[\"FeynArts\`\"] works correctly."
         exit 1
     fi
+
+   # Removing NPointFunctions, FormCalc, FeynArts output folders
+   [ "${enable_feynarts}" = "yes" ] && {
+      [ "${FEYNARTS_VERSION}" = "${oldVersion}" ] || {
+         local models="$(echo $MODELS | tr ',' ' ')"
+         for m in ${models}; do
+            local eigenstate=$(grep 'FSEigenstates' "models/$m/FlexibleSUSY.m" \
+                       | sed 's/ //g' \
+                       | sed 's/.*`\(.*\);/\1/')
+            local output=$(grep -m1 'OutputDirectory' "models/$m/start.m" \
+                        | sed 's/ //g' \
+                        | sed 's/.*\"\(.*\)\".*/\1/')
+            local dir="${output}/$m/${eigenstate}/FeynArts"
+            [ -d "${dir}" ] && { rm -rf ${dir}; }
+            dir="${output}/$m/${eigenstate}/FormCalc"
+            [ -d "${dir}" ] && { rm -rf ${dir}; }
+            dir="${output}/$m/${eigenstate}/NPointFunctions"
+            [ -d "${dir}" ] && { rm -rf ${dir}; }
+         done
+      }
+   }
 }
 
 #_____________________________________________________________________
@@ -2936,6 +2959,8 @@ check_formcalc() {
     if test "x$enable_formcalc" = "xno"; then return; fi
 
     checking_msg "FormCalc installation"
+    local oldVersion=""
+    [ -f "${formcalcconfig}" ] && oldVersion=$(cat "${formcalcconfig}")
     rm -f ${formcalcconfig}
     "$MATH" <<EOF > /dev/null
 Needs["FormCalc\`"];
@@ -2979,6 +3004,26 @@ EOF
         message "   Please make sure Needs[\"FormCalc\`\"] works correctly."
         exit 1
     fi
+
+   # Removing NPointFunctions, FormCalc output folders
+
+   [ "${enable_formcalc}" = "yes" ] && {
+      [ "${FORMCALC_VERSION}" = "${oldVersion}" ] || {
+         local models="$(echo $MODELS | tr ',' ' ')"
+         for m in ${models}; do
+            local eigenstate=$(grep 'FSEigenstates' "models/$m/FlexibleSUSY.m" \
+                               | sed 's/ //g' \
+                               | sed 's/.*`\(.*\);/\1/')
+            local output=$(grep -m1 'OutputDirectory' "models/$m/start.m" \
+                           | sed 's/ //g' \
+                           | sed 's/.*\"\(.*\)\".*/\1/')
+            local dir="${output}/$m/${eigenstate}/FormCalc"
+            [ -d "${dir}" ] && { rm -rf ${dir}; }
+            dir="${output}/$m/${eigenstate}/NPointFunctions"
+            [ -d "${dir}" ] && { rm -rf ${dir}; }
+         done
+      }
+   }
 
     if test "x$enable_formcalc" != "xno"; then
         checking_msg "working FormCalc"


### PR DESCRIPTION
`NPointFunctions` relies of `FeynArts` and `FormCalc`.
Some output is cached.
If the version of `FeynArts` and `FormCalc` changes, then this cache should be removed for **all** models.

Connected to #369.