### PR TITLE
supress clang-tidy warning about unsorted header includes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,3 +20,4 @@ Checks: >
     -readability-else-after-return,
     -readability-implicit-bool-conversion,
     -readability-isolate-declaration,
+    -llvm-include-order

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,8 @@ on:
       - development
     paths-ignore:
       - '*.rst'
+      - '.clang-tidy'
+      - '.clang-format'
       - 'AUTHORS'
       - 'COPYING'
       - 'doc/**'
@@ -21,6 +23,8 @@ on:
       - development
     paths-ignore:
       - '*.rst'
+      - '.clang-tidy'
+      - '.clang-format'
       - 'AUTHORS'
       - 'COPYING'
       - 'doc/**'


### PR DESCRIPTION
As I remember someone once tried to sort header includes and people didn't like it so we might suppress this warning.