### PR TITLE
Simplify error functions

### DIFF
--- a/meta/NPointFunctions.m
+++ b/meta/NPointFunctions.m
@@ -740,10 +740,6 @@ subkernel is launched for.
 @returns subkernel name.
 @note Mathematica 7 returns KernelObject[__], 11.3 returns {KernelObject[__]}
 @note for Mathematica 7 some functions have the same names as in SARAH`.`";
-LaunchSubkernelFor::errKernelLaunch=
-"Unable to launch subkernel(s) during calculations for
-`1`
-because of error:";
 LaunchSubkernelFor[message_String] /; $VersionNumber===7.0 :=
 Module[{kernelName},
    Off[Parallel`Preferences`add::shdw,
@@ -752,9 +748,7 @@ Module[{kernelName},
       Parallel`Preferences`tr::shdw,
       Parallel`Protected`processes::shdw,
       SubKernels`Description::shdw];
-   kernelName = Utils`EvaluateOrQuit[
-      LaunchKernels[1],
-      LaunchSubkernelFor::errKernelLaunch, message];
+   kernelName = LaunchKernels[1];
    On[Parallel`Preferences`add::shdw,
       Parallel`Preferences`set::shdw,
       Parallel`Preferences`list::shdw,
@@ -765,9 +759,7 @@ Module[{kernelName},
 ];
 LaunchSubkernelFor[message_String] :=
 Module[{kernelName},
-   kernelName = Utils`EvaluateOrQuit[
-      LaunchKernels[1],
-      LaunchSubkernelFor::errKernelLaunch, message];
+   kernelName = LaunchKernels[1];
    If[Head@kernelName === List, kernelName[[1]], kernelName]
 ];
 LaunchSubkernelFor // Utils`MakeUnknownInputDefinition;

--- a/test/test_Utils.m
+++ b/test/test_Utils.m
@@ -33,7 +33,7 @@ Block[{Quit, $Output = {OpenWrite[]}, out},
 evaluate ~ SetAttributes ~ {HoldAll};
 
 a;
-a//Utils`MakeUnknownInputDefinition;
+a // Utils`MakeUnknownInputDefinition;
 TestEquality[evaluate@a[1],
 "Global`a: errUnknownInput:
 Call
@@ -43,7 +43,7 @@ Wolfram Language kernel session terminated.\n"
 ];
 
 `subcontext`b;
-`subcontext`b//Utils`MakeUnknownInputDefinition;
+`subcontext`b // Utils`MakeUnknownInputDefinition;
 TestEquality[evaluate@`subcontext`b[1],
 "Global`subcontext`b: errUnknownInput:
 Call
@@ -53,7 +53,7 @@ Wolfram Language kernel session terminated.\n"
 ];
 
 `subcontext`subcontext`c;
-`subcontext`subcontext`c//Utils`MakeUnknownInputDefinition;
+`subcontext`subcontext`c // Utils`MakeUnknownInputDefinition;
 TestEquality[evaluate@`subcontext`subcontext`c[1],
 "Global`subcontext`subcontext`c: errUnknownInput:
 Call
@@ -63,7 +63,7 @@ Wolfram Language kernel session terminated.\n"
 ];
 
 d; d::usage="some text";
-d//Utils`MakeUnknownInputDefinition;
+d // Utils`MakeUnknownInputDefinition;
 TestEquality[evaluate@d[1],
 "Global`d: errUnknownInput:
 Usage:
@@ -76,11 +76,11 @@ Wolfram Language kernel session terminated.\n"
 ];
 
 e[x_,y_] = 3;
-e//Utils`MakeUnknownInputDefinition;
+e // Utils`MakeUnknownInputDefinition;
 TestEquality[evaluate@e[1],
 "Global`e: errUnknownInput:
-The behavior for case
-1) e[x_,y_]
+The behavior for case(s):
+1) e[x_, y_]
 is defined only.
 
 Call
@@ -90,11 +90,11 @@ Wolfram Language kernel session terminated.\n"
 ];
 
 f[x_Integer,y:{_String}:"`"] := Sin[345*x];
-f//Utils`MakeUnknownInputDefinition;
+f // Utils`MakeUnknownInputDefinition;
 TestEquality[evaluate@f[],
 "Global`f: errUnknownInput:
-The behavior for case
-1) f[x_Integer,y:{_String}:\"`\"]
+The behavior for case(s):
+1) f[x_Integer, y:{_String}:`]
 is defined only.
 
 Call
@@ -104,11 +104,11 @@ Wolfram Language kernel session terminated.\n"
 ];
 
 g[a_,3] := g[a,3] = 17;
-g//Utils`MakeUnknownInputDefinition;
+g // Utils`MakeUnknownInputDefinition;
 TestEquality[evaluate@g["monkey"],
 "Global`g: errUnknownInput:
-The behavior for case
-1) g[a_,3]
+The behavior for case(s):
+1) g[a_, 3]
 is defined only.
 
 Call
@@ -118,11 +118,11 @@ Wolfram Language kernel session terminated.\n"
 ];
 
 h /: Dot[h[2,x_,t:String:"34"], somethingelse] = "works";
-h//Utils`MakeUnknownInputDefinition;
+h // Utils`MakeUnknownInputDefinition;
 TestEquality[evaluate@h[1, 4],
 "Global`h: errUnknownInput:
-The behavior for case
-1) h/:h[2,x_,t:String:\"34\"].somethingelse
+The behavior for case(s):
+1) h[2, x_, t:String:34] . somethingelse
 is defined only.
 
 Call
@@ -132,11 +132,11 @@ Wolfram Language kernel session terminated.\n"
 ];
 
 i /: FUN[i[n_], i[m_]] := "";
-i//Utils`MakeUnknownInputDefinition;
+i // Utils`MakeUnknownInputDefinition;
 TestEquality[evaluate@FUN[i[n_], i[m_,1]],
 "Global`i: errUnknownInput:
-The behavior for case
-1) FUN[i[n_],i[m_]]
+The behavior for case(s):
+1) FUN[i[n_], i[m_]]
 is defined only.
 
 Call
@@ -144,8 +144,8 @@ i[n_]
 is not supported.
 Wolfram Language kernel session terminated.
 Global`i: errUnknownInput:
-The behavior for case
-1) FUN[i[n_],i[m_]]
+The behavior for case(s):
+1) FUN[i[n_], i[m_]]
 is defined only.
 
 Call

--- a/test/test_Utils.m
+++ b/test/test_Utils.m
@@ -20,97 +20,64 @@
 
 *)
 
-Global`time = AbsoluteTime[];
-
-(* THERE IS A NEED TO CHANGE BEHAVIOR OF LOCKED FILE **************************)
-fileName = FileNameJoin@{Directory[],"test","test_Utils.temp"};
-Off[Syntax::sntufn];
-subKernel = LaunchKernels[1];
-DistributeDefinitions[fileName];
-ParallelEvaluate[
-   Needs["Utils`",FileNameJoin@{Directory[],"meta","Utils.m"}];
-   Put[Definition@Utils`Private`internalAssertOrQuit,fileName];
-   code = StringJoin@Riffle[Drop[Utils`ReadLinesInFile@fileName,2],"\n"];
-   code=StringReplace[code,
-      {
-         "\\[Raw"~~Shortest@__~~"m"->"",
-         "Quit[1];"->"","FSFancyLine[];"->"",
-         "WriteString"~~__~~x:"StringJoin[Utils`Private`str]"~~"]":>
-            "(`test`out = `test`out<>"<>x<>")",
-         "\\nWolfram Language kernel session "->""
-      }
-   ];
-   fileHandle = OpenWrite@fileName;
-   fileHandle ~ WriteString ~ code;
-   Close@fileHandle;
-];
-CloseKernels@subKernel;
-On[Syntax::sntufn];
-(* LOAD TEST DEFINITIONS ******************************************************)
-`test`out="";
-Get@fileName;
-Attributes[Utils`Private`internalAssertOrQuit] = {HoldAll,Protected,Locked};
-DeleteFile@fileName;
-
-Off[SetDelayed::write,Attributes::locked];
 Needs["TestSuite`", "TestSuite.m"];
 Needs["Utils`", "Utils.m"];
-On[SetDelayed::write,Attributes::locked];
 
-(* TEST MULTIDIMENSIONAL CONTEXT***********************************************)
+evaluate[call_] :=
+Block[{Quit, $Output = {OpenWrite[]}, out},
+   call;
+   out = ReadString[$Output[[1, 1]]];
+   Close[$Output[[1]]];
+   out
+];
+evaluate ~ SetAttributes ~ {HoldAll};
+
 a;
 a//Utils`MakeUnknownInputDefinition;
-a[1];
-TestEquality[`test`out,
+TestEquality[evaluate@a[1],
 "Global`a: errUnknownInput:
 Call
 a[1]
-is not supported.terminated.\n"
+is not supported.
+Wolfram Language kernel session terminated.\n"
 ];
-`test`out="";
 
 `subcontext`b;
 `subcontext`b//Utils`MakeUnknownInputDefinition;
-`subcontext`b[1];
-TestEquality[`test`out,
+TestEquality[evaluate@`subcontext`b[1],
 "Global`subcontext`b: errUnknownInput:
 Call
 Global`subcontext`b[1]
-is not supported.terminated.\n"
+is not supported.
+Wolfram Language kernel session terminated.\n"
 ];
-`test`out="";
 
 `subcontext`subcontext`c;
 `subcontext`subcontext`c//Utils`MakeUnknownInputDefinition;
-`subcontext`subcontext`c[1];
-TestEquality[`test`out,
+TestEquality[evaluate@`subcontext`subcontext`c[1],
 "Global`subcontext`subcontext`c: errUnknownInput:
 Call
 Global`subcontext`subcontext`c[1]
-is not supported.terminated.\n"
+is not supported.
+Wolfram Language kernel session terminated.\n"
 ];
-`test`out="";
 
 d; d::usage="some text";
 d//Utils`MakeUnknownInputDefinition;
-d[1];
-TestEquality[`test`out,
+TestEquality[evaluate@d[1],
 "Global`d: errUnknownInput:
 Usage:
 some text
 
 Call
 d[1]
-is not supported.terminated.\n"
+is not supported.
+Wolfram Language kernel session terminated.\n"
 ];
-`test`out="";
-
-(* TEST INPUT TYPES ***********************************************************)
 
 e[x_,y_] = 3;
 e//Utils`MakeUnknownInputDefinition;
-e[1];
-TestEquality[`test`out,
+TestEquality[evaluate@e[1],
 "Global`e: errUnknownInput:
 The behavior for case
 1) e[x_,y_]
@@ -118,14 +85,13 @@ is defined only.
 
 Call
 e[1]
-is not supported.terminated.\n"
+is not supported.
+Wolfram Language kernel session terminated.\n"
 ];
-`test`out="";
 
 f[x_Integer,y:{_String}:"`"] := Sin[345*x];
 f//Utils`MakeUnknownInputDefinition;
-f[];
-TestEquality[`test`out,
+TestEquality[evaluate@f[],
 "Global`f: errUnknownInput:
 The behavior for case
 1) f[x_Integer,y:{_String}:\"`\"]
@@ -133,14 +99,13 @@ is defined only.
 
 Call
 f[]
-is not supported.terminated.\n"
+is not supported.
+Wolfram Language kernel session terminated.\n"
 ];
-`test`out="";
 
 g[a_,3] := g[a,3] = 17;
 g//Utils`MakeUnknownInputDefinition;
-g["monkey"];
-TestEquality[`test`out,
+TestEquality[evaluate@g["monkey"],
 "Global`g: errUnknownInput:
 The behavior for case
 1) g[a_,3]
@@ -148,14 +113,13 @@ is defined only.
 
 Call
 g[monkey]
-is not supported.terminated.\n"
+is not supported.
+Wolfram Language kernel session terminated.\n"
 ];
-`test`out="";
 
 h /: Dot[h[2,x_,t:String:"34"], somethingelse] = "works";
 h//Utils`MakeUnknownInputDefinition;
-h[1,4];
-TestEquality[`test`out,
+TestEquality[evaluate@h[1, 4],
 "Global`h: errUnknownInput:
 The behavior for case
 1) h/:h[2,x_,t:String:\"34\"].somethingelse
@@ -163,37 +127,35 @@ is defined only.
 
 Call
 h[1, 4]
-is not supported.terminated.\n"
+is not supported.
+Wolfram Language kernel session terminated.\n"
 ];
-`test`out="";
 
-i /: Print[i[n_], i[m_]] := "";
+i /: FUN[i[n_], i[m_]] := "";
 i//Utils`MakeUnknownInputDefinition;
-Print[i[n_], i[m_,1]];
-TestEquality[`test`out,
+TestEquality[evaluate@FUN[i[n_], i[m_,1]],
 "Global`i: errUnknownInput:
 The behavior for case
-1) Print[i[n_],i[m_]]
+1) FUN[i[n_],i[m_]]
 is defined only.
 
 Call
 i[n_]
-is not supported.terminated.
+is not supported.
+Wolfram Language kernel session terminated.
 Global`i: errUnknownInput:
 The behavior for case
-1) Print[i[n_],i[m_]]
+1) FUN[i[n_],i[m_]]
 is defined only.
 
 Call
 i[m_, 1]
-is not supported.terminated.\n"
+is not supported.
+Wolfram Language kernel session terminated.\n"
 ];
-`test`out="";
 
 TestEquality[FSPermutationSign[Cycles[{{1,2}}]], -1];
 TestEquality[FSPermutationSign[Cycles[{{1,3,2}}]], 1];
 TestEquality[FSPermutationSign[Cycles[{{1,3,2},{5,6}}]], -1];
-
-Print[StringJoin[">>test>> done in ",ToString@N[AbsoluteTime[]-Global`time,{Infinity,3}]," seconds.\n"]];
 
 PrintTestSummary[];


### PR DESCRIPTION
I wanted to extend a bit some functions, which I wrote long ago: `AssertOrQuit`, `MakeUnknownInputDefinitions`, `EvaluateOrQuit` (maybe it was even my first PR).

The `::usage` was unreadable, the code was a nightmare. One function even seems to be non-working now. 

This PR fixes it and make it user and developer friendly.