### PR TITLE
make sure that no one calls decay for a goldstone

### DIFF
--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -3065,6 +3065,8 @@ WriteUtilitiesClass[massMatrices_List, betaFun_List, inputParameters_List, extra
                             "@setParticleMultipletNameAndIndexFromPDG@" -> IndentText[setParticleMultipletNameAndIndexFromPDG],
                             "@isCPViolatingHiggsSector@"       -> CreateCBoolValue @ SA`CPViolationHiggsSector,
                             "@useDecaysData@"                   -> useDecaysData,
+                            "@numberOfNeutralGoldstones@"       -> IndentText["static constexpr int number_of_neutral_goldstones = " <> ToString[TreeMasses`GetDimensionStartSkippingGoldstones[TreeMasses`GetPseudoscalarHiggsBoson[]]-1] <> ";"],
+                            "@numberOfChargedGoldstones@"       -> IndentText["static constexpr int number_of_charged_goldstones = " <> ToString[TreeMasses`GetDimensionStartSkippingGoldstones[TreeMasses`GetChargedHiggsBoson[]]-1] <> ";"],
                             Sequence @@ GeneralReplacementRules[]
                           } ];
           ];

--- a/src/decays/H_SM_decays/decay_AH_to_AA.inc
+++ b/src/decays/H_SM_decays/decay_AH_to_AA.inc
@@ -5,6 +5,10 @@ double CLASSNAME::get_partial_width<AH, A, A>(
       const typename field_indices<A>::type& out1_idx,
       const typename field_indices<A>::type& out2_idx) const
 {
+   if (in_idx.at(0) < info::number_of_neutral_goldstones) {
+      throw OutOfBoundsError("Error in " + create_process_string<AH,A,A>(in_idx, out1_idx, out2_idx) + " decay. Decaying particle is a Goldstone.");
+   }
+
    const auto amp = calculate_amplitude<AH, A, A>(context, in_idx, out1_idx, out2_idx);
    const double mH = context.physical_mass<AH>(in_idx);
    constexpr double ps {1./(8.*Pi)};

--- a/src/decays/H_SM_decays/decay_AH_to_AZ.inc
+++ b/src/decays/H_SM_decays/decay_AH_to_AZ.inc
@@ -5,6 +5,10 @@ double CLASSNAME::get_partial_width<AH, A, Z>(
       const typename field_indices<A>::type& out1_idx,
       const typename field_indices<Z>::type& out2_idx) const
 {
+   if (in_idx.at(0) < info::number_of_neutral_goldstones) {
+      throw OutOfBoundsError("Error in " + create_process_string<AH,A,Z>(in_idx, out1_idx, out2_idx) + " decay. Decaying particle is a Goldstone.");
+   }
+
    const auto amp = calculate_amplitude<AH, A, Z>(context, in_idx, out1_idx, out2_idx);
    const double mH = context.physical_mass<AH>(in_idx);
    const double mZ = qedqcd.displayPoleMZ();

--- a/src/decays/H_SM_decays/decay_AH_to_GG.inc
+++ b/src/decays/H_SM_decays/decay_AH_to_GG.inc
@@ -5,6 +5,10 @@ double CLASSNAME::get_partial_width<AH, G, G>(
       const typename field_indices<G>::type& out1_idx,
       const typename field_indices<G>::type& out2_idx) const
 {
+   if (in_idx.at(0) < info::number_of_neutral_goldstones) {
+      throw OutOfBoundsError("Error in " + create_process_string<AH,G,G>(in_idx, out1_idx, out2_idx) + " decay. Decaying particle is a Goldstone.");
+   }
+
    const auto amp = calculate_amplitude<AH, G, G>(context, in_idx, out1_idx, out2_idx);
    const double mAh = context.physical_mass<AH>(in_idx);
    constexpr double ps {1./(8.*Pi)};

--- a/src/decays/H_SM_decays/decay_AH_to_dqdq.inc
+++ b/src/decays/H_SM_decays/decay_AH_to_dqdq.inc
@@ -9,6 +9,10 @@ double CLASSNAME::get_partial_width<AH, bar<dq>::type, dq>(
    typename field_indices<dq>::type const& indexOut2
    ) const
 {
+   if (indexIn.at(0) < info::number_of_neutral_goldstones) {
+      throw OutOfBoundsError("Error in " + create_process_string<AH,bar<dq>::type, dq>(indexIn, indexOut1, indexOut2) + " decay. Decaying particle is a Goldstone.");
+   }
+
    // get HBBbar vertex
    // we don't use amplitude_squared here because we need both this vertex
    // both with running and pole masses

--- a/src/decays/H_SM_decays/decay_AH_to_leplep.inc
+++ b/src/decays/H_SM_decays/decay_AH_to_leplep.inc
@@ -7,6 +7,9 @@ double CLASSNAME::get_partial_width<AH, bar<lep>::type, lep>(
    typename field_indices<bar<lep>::type>::type const& indexOut1,
    typename field_indices<lep>::type const& indexOut2) const
 {
+   if (indexIn.at(0) < info::number_of_neutral_goldstones) {
+      throw OutOfBoundsError("Error in " + create_process_string<AH,bar<lep>::type, lep>(indexIn, indexOut1, indexOut2) + " decay. Decaying particle is a Goldstone.");
+   }
 
    const double mAHOS = context.physical_mass<AH>(indexIn);
    const double mL1OS = context.physical_mass<bar<lep>::type>(indexOut1);

--- a/src/decays/H_SM_decays/decay_AH_to_uquq.inc
+++ b/src/decays/H_SM_decays/decay_AH_to_uquq.inc
@@ -8,6 +8,10 @@ double CLASSNAME::get_partial_width<AH, bar<uq>::type, uq>(
    typename field_indices<uq>::type const& indexOut2
    ) const
 {
+   if (indexIn.at(0) < info::number_of_neutral_goldstones) {
+      throw OutOfBoundsError("Error in " + create_process_string<AH,bar<uq>::type, uq>(indexIn, indexOut1, indexOut2) + " decay. Decaying particle is a Goldstone.");
+   }
+
    // get AHBBbar vertex
    // we don't use amplitude_squared here because we need both this vertex
    // both with running and pole masses

--- a/templates/info.hpp.in
+++ b/templates/info.hpp.in
@@ -38,6 +38,8 @@ namespace @ModelName@_info {
 @inputParameterEnum@
 @extraParameterEnum@
 @gaugeCouplingNormalizationDecls@
+@numberOfNeutralGoldstones@
+@numberOfChargedGoldstones@
 
    extern const std::array<int, NUMBER_OF_PARTICLES> particle_multiplicities;
    extern const std::array<std::string, NUMBER_OF_PARTICLES> particle_names;

--- a/test/test_MRSSM2_FlexibleDecay.cpp
+++ b/test/test_MRSSM2_FlexibleDecay.cpp
@@ -730,10 +730,10 @@ Block FlexibleSUSYLowEnergy Q= 1.00000000E+03
 
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_VGVG(&m, 1), 0.00029502623532270532, 8e-14);
 
-   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFdFd(&m, 0, 2, 2),
-                              0.0018327846210855049, 5e-12);
-   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFuFu(&m, 0, 1, 1),
-                              9.139211136105259e-05, 2e-13);
+   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFdFd(&m, 1, 2, 2),
+                              27.558400433360585, 5e-12);
+   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFuFu(&m, 1, 1, 1),
+                              6.5403200582277049e-07, 2e-13);
 
    // -----------------------------------------------------
    // decays without higher-order SM corrections

--- a/test/test_MSSMCPV_FlexibleDecay.cpp
+++ b/test/test_MSSMCPV_FlexibleDecay.cpp
@@ -788,7 +788,7 @@ Block ImMSOFT Q= 2.00000000E+03
    // without 2L QCD for squark
    // BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_VPVP(&m, 0), 6.3284545616000571e-06, 4e-11);
    // with 2L QCD for squark
-   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_VPVP(&m, 1), 5.3089300093115946e-06, 5e-10);
+   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_VPVP(&m, 1), 5.3089300093115946e-06, 7e-10);
    // h -> gamma Z
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_VPVZ(&m, 1), 5.1994372474535712e-07, 7e-11);
 
@@ -808,7 +808,7 @@ Block ImMSOFT Q= 2.00000000E+03
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_hh_to_barFeFe(&m, 1, 2, 2),
                               0.00022454719336516455, 3e-13);
    // h -> gamma gamma
-   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_hh_to_VPVP(&m, 1), 5.2382389517397406e-06, 5e-10);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_hh_to_VPVP(&m, 1), 5.2382389517397406e-06, 7e-10);
 
    // h -> gluon gluon
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_hh_to_VGVG(&m, 1), 6.1972398675528688e-05, 2e-10);

--- a/test/test_MSSM_FlexibleDecay.cpp
+++ b/test/test_MSSM_FlexibleDecay.cpp
@@ -697,8 +697,8 @@ Block MSOFT Q= 8.61574711E+02
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFeFe(&m, 1, 2, 2),
                               0.14370134308297239, 4e-13);
    // Ah -> c cbar
-   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFuFu(&m, 0, 1, 1),
-                              9.3015080450372116e-05, 3e-13);
+   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFuFu(&m, 1, 1, 1),
+                              6.1486061511096085e-06, 3e-13);
    // Ah -> W+ W-
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_conjVWmVWm(&m, 1),
                               3.9267959281226782e-05, 2e-12);

--- a/test/test_THDMII_FlexibleDecay.cpp
+++ b/test/test_THDMII_FlexibleDecay.cpp
@@ -299,11 +299,11 @@ Block UERMIX
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_VPVP(&m, 1), 3.5731537311554876e-06, 3e-12);
 
    // Ah -> b bbar
-   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFdFd(&m, 0, 2, 2),
-                              0.0018671335954316421, 2e-15);
+   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFdFd(&m, 1, 2, 2),
+                              1.0248504778252014, 2e-15);
    // Ah -> c cbar
-   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFuFu(&m, 0, 1, 1),
-                              9.3482696650389066e-05, 2e-16);
+   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFuFu(&m, 1, 1, 1),
+                              5.1682891794454512e-06, 2e-16);
 
    // -----------------------------------------------------
    // decays without higher-order SM corrections


### PR DESCRIPTION
Hi @Expander 

IMO this PR should go before others we are now discussing (#409, #410). Here's what was fishy. In an autogenerated code we made sure that we do not generate decays of Goldstone bosons. But you can still call them by hand, as was done in some test. This PR makes sure it cannot happen. If you try this, you'll get something like

```
unknown location(0): fatal error: in "test_MRSSM2_FlexibleDecay": flexiblesusy::OutOfBoundsError: Error in Ah(0)->{barFd(2),Fd(2)} decay. Decaying particle is a Goldstone.
```

I have implemented a simplest way to get the number of Goldstones in a multiplet but I'm happy to change it if you want it.

PS. I'm not 100% sure how it was related to the fact that after change of SM mW some Ah decays became 0. Only charged Goldstone should be controlled directly by mW.