### PR TITLE
removed unused input in MSSMMuBMu

### DIFF
--- a/model_files/MSSMMuBMu/FlexibleSUSY.m.in
+++ b/model_files/MSSMMuBMu/FlexibleSUSY.m.in
@@ -3,10 +3,6 @@ FSEigenstates = SARAH`EWSB;
 FSDefaultSARAHModel = MSSM;
 OnlyLowEnergyFlexibleSUSY = True;
 
-MINPAR = {
-    {4, Sign[\[Mu]]}
-};
-
 EXTPAR = {
     {0, MSUSY},
     {1, M1Input},

--- a/model_files/MSSMMuBMu/LesHouches.in.MSSMMuBMu
+++ b/model_files/MSSMMuBMu/LesHouches.in.MSSMMuBMu
@@ -51,8 +51,6 @@ Block SMINPUTS               # Standard Model inputs
    22   2.400000000e-03      # mu(2 GeV) MS-bar
    23   1.040000000e-01      # ms(2 GeV) MS-bar
    24   1.270000000e+00      # mc(mc) MS-bar
-Block MINPAR                 # Input parameters
-    4   1                    # SignMu
 Block EXTPAR
     0   2000                 # Ms
     1   2000                 # M1(MSUSY)


### PR DESCRIPTION
Since in this model `\mu` is an input, I don't think we also need to input a sign of `\mu`.