### PR TITLE
fixed missing include

### DIFF
--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -4,6 +4,7 @@
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
 #include <random>
+#include <array>
 
 /**
  * @file scan.hpp


### PR DESCRIPTION
This fixes the following error
```
Building test/test_scan.o
test/test_scan.cpp: In member function ‘void uniform_distribution_0_1::test_method()’:
test/test_scan.cpp:48:26: error: variable ‘std::array<double, 1000> a’ has initializer but incomplete type
   48 |    std::array<double, N> a{};
      |                          ^
test/test_scan.cpp: In member function ‘void uniform_distribution_start_stop::test_method()’:
test/test_scan.cpp:62:26: error: variable ‘std::array<double, 1000> a’ has initializer but incomplete type
   62 |    std::array<double, N> a{};
      |                          ^
make: *** [Makefile:252: test/test_scan.o] Błąd 1
```
No idea why it appeared just now but it seems reasonable that this include should be there.