### PR TITLE
disable shellcheck warnings SC3037 and SC3043

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Check scripts
         run: |
            echo "We assume, that shell understands 'local' command!"
-           shellcheck -e SC2039 -e SC3037 -e SC3043 -S warning configure createmodel install-sarah createaddon config/*.sh utils/*.sh test/test_*.sh
+           shellcheck -e SC3037 -e SC3043 -S warning configure createmodel install-sarah createaddon config/*.sh utils/*.sh test/test_*.sh

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Check scripts
         run: |
            echo "We assume, that shell understands 'local' command!"
-           shellcheck -e SC2039 -S warning configure createmodel install-sarah createaddon config/*.sh utils/*.sh test/test_*.sh
+           shellcheck -e SC2039 -e SC3037 -e SC3043 -S warning configure createmodel install-sarah createaddon config/*.sh utils/*.sh test/test_*.sh


### PR DESCRIPTION
```
SC3037 (warning): In POSIX sh, echo flags are undefined
SC3043 (warning): In POSIX sh, 'local' is undefined
```