### PR TITLE
remove comparison of decays from test_CMSSMSemiAnalytic_spectrum

### DIFF
--- a/test/test_CMSSMSemiAnalytic_spectrum.sh
+++ b/test/test_CMSSMSemiAnalytic_spectrum.sh
@@ -66,7 +66,8 @@ remove_mixing_and_input_blocks() {
         | $awk_cmd -f "$remove_block" -v block=EXTPAR \
         | $awk_cmd -f "$remove_block" -v block=SPINFO \
         | $awk_cmd -f "$remove_block" -v block=MODSEL \
-        | $awk_cmd -f "$remove_block" -v block=FlexibleSUSY
+        | $awk_cmd -f "$remove_block" -v block=FlexibleSUSY \
+        | $awk_cmd -f "$remove_block" -v block=DCINFO
 }
 
 remove_extra_blocks() {


### PR DESCRIPTION
This test passes if we don't compute decays as they deviate quite strongly between `CMSSM` and `CMSSMSemiAnalytic`
[test_CMSSMSemiAnalytic_spectrum_CMSSM.out.spc.txt](https://github.com/FlexibleSUSY/FlexibleSUSY/files/8907115/test_CMSSMSemiAnalytic_spectrum_CMSSM.out.spc.txt)
[test_CMSSMSemiAnalytic_spectrum.out.spc.txt](https://github.com/FlexibleSUSY/FlexibleSUSY/files/8907116/test_CMSSMSemiAnalytic_spectrum.out.spc.txt)
@Expander, I propose to disable comparison of decays unless you want to track the source of difference.
