### PR TITLE
error in H and A to uubar higher order corrections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+FlexibleSUSY 2.X.X [X, X X]
+==================================
+
+Fixed bugs
+----------
+
+* [commit ]: Fixed incorect quark charge in some higher order QED corrections to :math:`$H \to u\bar{u}$` and :math:`$A \to u\bar{u}$`
+
 FlexibleSUSY 2.7.1 [June, 07 2022]
 ==================================
 

--- a/src/decays/H_SM_decays/decay_AH_to_uquq.inc
+++ b/src/decays/H_SM_decays/decay_AH_to_uquq.inc
@@ -94,13 +94,13 @@ double CLASSNAME::get_partial_width<AH, bar<uq>::type, uq>(
                4./3. * alpha_s_red * calc_DeltaAH(betaOS);
 
          const double deltaqq_QED_OS_P =
-               alpha_red * Sqr(dq::electric_charge) * calc_DeltaAH(betaOS);
+               alpha_red * Sqr(uq::electric_charge) * calc_DeltaAH(betaOS);
 
          double deltaqq_QCDxQED_DR = 0.;
          double deltaPhi2_P = 0.;
          if (static_cast<int>(flexibledecay_settings.get(FlexibleDecay_settings::include_higher_order_corrections)) > 1) {
             deltaqq_QCDxQED_DR =
-               deltaqq_QCDxQED*Sqr(dq::electric_charge)*alpha_red*alpha_s_red;
+               deltaqq_QCDxQED*Sqr(uq::electric_charge)*alpha_red*alpha_s_red;
             if ((indexOut1.at(0) < 2 || indexOut2.at(0) < 2)) {
                const double mtpole = qedqcd.displayPoleMt();
                const double lt = std::log(Sqr(mAHOS/mtpole));

--- a/src/decays/H_SM_decays/decay_H_to_uquq.inc
+++ b/src/decays/H_SM_decays/decay_H_to_uquq.inc
@@ -114,7 +114,7 @@ double CLASSNAME::get_partial_width<H, bar<uq>::type, uq>(
                4./3. * alpha_s_red * calc_DeltaAH(betaOS);
 
             deltaqq_QED_OS_P =
-               alpha_red * Sqr(dq::electric_charge) * calc_DeltaAH(betaOS);
+               alpha_red * Sqr(uq::electric_charge) * calc_DeltaAH(betaOS);
          }
 
          double deltaPhi2_S = 0.;
@@ -122,7 +122,7 @@ double CLASSNAME::get_partial_width<H, bar<uq>::type, uq>(
          double deltaqq_QCDxQED_DR = 0.;
          if (static_cast<int>(flexibledecay_settings.get(FlexibleDecay_settings::include_higher_order_corrections)) > 1) {
             deltaqq_QCDxQED_DR =
-               deltaqq_QCDxQED*Sqr(dq::electric_charge)*alpha_red*alpha_s_red;
+               deltaqq_QCDxQED*Sqr(uq::electric_charge)*alpha_red*alpha_s_red;
             if ((indexOut1.at(0) < 2 || indexOut2.at(0) < 2)) {
                const double mtpole = qedqcd.displayPoleMt();
                const double lt = std::log(Sqr(mHOS/mtpole));

--- a/test/test_MRSSM2_FlexibleDecay.cpp
+++ b/test/test_MRSSM2_FlexibleDecay.cpp
@@ -694,7 +694,7 @@ Block IMVCKM Q= 1.00000000E+03
                               0.0025634108458618405, 5e-12);
    // h -> c cbar
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_barFuFu(&m, 0, 1, 1),
-                              0.00012285838200009531, 2e-13);
+                              0.00012289267709167259, 2e-13);
    // QED corrections
    // BOOST_CHECK_CLOSE_FRACTION(decays.partial_width_hh_to_barFdFd(&m, 0, 2, 2),
    //                            2.6059181498481999E-003, 5e-15);
@@ -729,7 +729,7 @@ Block IMVCKM Q= 1.00000000E+03
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFdFd(&m, 1, 2, 2),
                               27.422426128468313, 5e-12);
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFuFu(&m, 1, 1, 1),
-                              6.5359182777429661e-07, 2e-13);
+                              6.5374236623950305e-07, 2e-13);
 
    // -----------------------------------------------------
    // decays without higher-order SM corrections

--- a/test/test_MSSMCPV_FlexibleDecay.cpp
+++ b/test/test_MSSMCPV_FlexibleDecay.cpp
@@ -826,7 +826,7 @@ Block ImMSOFT Q= 2.00000000E+03
                               0.0021707237775801919, 6e-13);
    // h -> c cbar
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_barFuFu(&m, 1, 1, 1),
-                              0.00010604105374890464, 2e-13);
+                              0.00010607114819048992, 2e-13);
    // h -> tau+ tau-
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_barFeFe(&m, 1, 2, 2),
                               0.00022695659608435093, 3e-13);

--- a/test/test_MSSM_FlexibleDecay.cpp
+++ b/test/test_MSSM_FlexibleDecay.cpp
@@ -657,7 +657,7 @@ Block MSOFT Q= 8.64566212E+02
                               0.0024454872837716721, 7e-13);
    // h -> c cbar
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_barFuFu(&m, 0, 1, 1),
-                              0.00011318500362355447, 3e-13);
+                              0.00011321683135547809, 3e-13);
    // h -> tau+ tau-
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_barFeFe(&m, 0, 2, 2),
                               0.00026234514953420564, 3e-13);
@@ -697,7 +697,7 @@ Block MSOFT Q= 8.64566212E+02
                               0.14370135383550148, 4e-13);
    // Ah -> c cbar
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFuFu(&m, 1, 1, 1),
-                              6.1486066780391835e-06, 3e-13);
+                              6.1500292100561543e-06, 3e-13);
    // Ah -> W+ W-
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_conjVWmVWm(&m, 1),
                               3.926795985114403e-05, 2e-12);

--- a/test/test_SM_FlexibleDecay.cpp
+++ b/test/test_SM_FlexibleDecay.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE( test_SM_FlexibleDecay )
                               0.0023811031255194888, 2e-15);
    // h -> c cbar
    BOOST_CHECK_CLOSE_FRACTION(decays_HO.partial_width_hh_to_barFuFu(&m, 1, 1),
-                              0.00011734084746332317, 2e-16);
+                              0.00011737301687946969, 2e-16);
    // h -> tau+ tau-
    BOOST_CHECK_CLOSE_FRACTION(decays_HO.partial_width_hh_to_barFeFe(&m, 2, 2),
                               0.00026184531343741851, 1e-15);

--- a/test/test_THDMII_FlexibleDecay.cpp
+++ b/test/test_THDMII_FlexibleDecay.cpp
@@ -272,7 +272,7 @@ Block UERMIX
                               0.00074272222469849497, 2e-13);
    // h -> c cbar
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_barFuFu(&m, 0, 1, 1),
-                              0.0001199276031491833, 6e-15);
+                              0.00011996054512932952, 6e-15);
    // h -> tau+ tau-
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_hh_to_barFeFe(&m, 0, 2, 2),
                               7.9645089645449552e-05, 1e-15);
@@ -302,7 +302,7 @@ Block UERMIX
                               1.0248504807742072, 2e-15);
    // Ah -> c cbar
    BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Ah_to_barFuFu(&m, 1, 1, 1),
-                              5.1682891827667072e-06, 2e-16);
+                              5.1697352441808561e-06, 2e-16);
 
    // -----------------------------------------------------
    // decays without higher-order SM corrections


### PR DESCRIPTION
Wrong QED quark charge was used in higher order corrections. The difference is at a level of 0.03%.