### PR TITLE
Move sort_decays_list

### DIFF
--- a/src/decays/decay.cpp
+++ b/src/decays/decay.cpp
@@ -115,6 +115,27 @@ const Decay& Decays_list::get_decay(
    return pos->second;
 }
 
+/**
+ * Sort decays of every particle according to their width
+ */
+std::vector<Decay> sort_decays_list(const Decays_list& decays_list) {
+   std::vector<Decay> decays_list_as_vector;
+   decays_list_as_vector.reserve(decays_list.size());
+   for (const auto& el : decays_list) {
+      decays_list_as_vector.push_back(el.second);
+   }
+
+   std::sort(
+      decays_list_as_vector.begin(),
+      decays_list_as_vector.end(),
+      [](const auto& d1, const auto& d2) {
+         return d1.get_width() > d2.get_width();
+      }
+   );
+
+   return decays_list_as_vector;
+}
+
 std::string strip_field_namespace(std::string const& s) {
    std::string result = s.substr(s.find_last_of(':')+1);
    if (s.find("bar") != std::string::npos) {

--- a/src/decays/decay.hpp
+++ b/src/decays/decay.hpp
@@ -95,6 +95,9 @@ private:
    double total_width{0.};
 };
 
+/// sort decays w.r.t. their width
+std::vector<Decay> sort_decays_list(const Decays_list&);
+
 std::string strip_field_namespace(std::string const&);
 
 template<typename FieldIn, typename FieldOut1, typename FieldOut2>

--- a/templates/slha_io.cpp.in
+++ b/templates/slha_io.cpp.in
@@ -56,32 +56,6 @@
 
 namespace flexiblesusy {
 
-namespace {
-
-/**
- * Sort decays of every particle according to their width
- *
- */
-std::vector<Decay> sort_decays_list(const Decays_list& decays_list) {
-   std::vector<Decay> decays_list_as_vector;
-   decays_list_as_vector.reserve(decays_list.size());
-   for (const auto& el : decays_list) {
-      decays_list_as_vector.push_back(el.second);
-   }
-
-   std::sort(
-      decays_list_as_vector.begin(),
-      decays_list_as_vector.end(),
-      [](const auto& d1, const auto& d2) {
-         return d1.get_width() > d2.get_width();
-      }
-   );
-
-   return decays_list_as_vector;
-}
-
-} // anonymous namespace
-
 @ModelName@_slha_io::@ModelName@_slha_io()
    : slha_io()
    , print_imaginary_parts_of_majorana_mixings(false)

--- a/templates/slha_io.cpp.in
+++ b/templates/slha_io.cpp.in
@@ -56,6 +56,32 @@
 
 namespace flexiblesusy {
 
+namespace {
+
+/**
+ * Sort decays of every particle according to their width
+ *
+ */
+std::vector<Decay> sort_decays_list(const Decays_list& decays_list) {
+   std::vector<Decay> decays_list_as_vector;
+   decays_list_as_vector.reserve(decays_list.size());
+   for (const auto& el : decays_list) {
+      decays_list_as_vector.push_back(el.second);
+   }
+
+   std::sort(
+      decays_list_as_vector.begin(),
+      decays_list_as_vector.end(),
+      [](const auto& d1, const auto& d2) {
+         return d1.get_width() > d2.get_width();
+      }
+   );
+
+   return decays_list_as_vector;
+}
+
+} // anonymous namespace
+
 @ModelName@_slha_io::@ModelName@_slha_io()
    : slha_io()
    , print_imaginary_parts_of_majorana_mixings(false)
@@ -407,28 +433,6 @@ void @ModelName@_slha_io::set_dcinfo(
           << FORMAT_SPINFO(9, SARAH_VERSION);
 
    slha_io.set_block(dcinfo);
-}
-
-/**
- * Sort decays of every particle according to their width
- *
- */
-std::vector<Decay> sort_decays_list(const Decays_list& decays_list) {
-   std::vector<Decay> decays_list_as_vector;
-   decays_list_as_vector.reserve(decays_list.size());
-   for (const auto& el : decays_list) {
-      decays_list_as_vector.push_back(el.second);
-   }
-
-   std::sort(
-      decays_list_as_vector.begin(),
-      decays_list_as_vector.end(),
-      [](const auto& d1, const auto& d2) {
-         return d1.get_width() > d2.get_width();
-      }
-   );
-
-   return decays_list_as_vector;
 }
 
 /**


### PR DESCRIPTION
to prevent a linker error when two model libraries are linked to one executable.

fixes #464