### PR TITLE
replace hard coded Z-fermion vertex

### DIFF
--- a/templates/amm.cpp.in
+++ b/templates/amm.cpp.in
@@ -383,7 +383,7 @@ Lepton, Fermion, Scalar
          const double part1 = coeffA.real() * BarrZeeLoopFS(massRatioSquared);
          const double part2 = coeffB.real() * BarrZeeLoopFPS(massRatioSquared);
 
-         const double preFactor = Sqr(unit_charge(context))/(64*Power4(Pi)) * fermionChargeCount * fermionChargeCount
+         const double preFactor = Sqr(unit_charge(context))*4.*twoLoop * fermionChargeCount * fermionChargeCount
             * lepton_pole_mass<Lepton>(qedqcd@BarrZeeLeptonIdx@) / fermionMass;
 
          res += preFactor * (part1 + part2);
@@ -490,7 +490,7 @@ Lepton, Fermion, Scalar
                const double part1 = coeffA.real() * Sqr(scalarMass) / (Sqr(scalarMass) - Sqr(zMass)) * (BarrZeeLoopFS(massRatioSquared) - BarrZeeLoopFS(Sqr(fermionMass / zMass)));
                const double part2 = coeffB.real() * Sqr(scalarMass) / (Sqr(scalarMass) - Sqr(zMass)) * (BarrZeeLoopFPS(massRatioSquared) - BarrZeeLoopFPS(Sqr(fermionMass / zMass)));
 
-               const double preFactor = -1.0/(64*Power4(Pi)) * fermionChargeCount * gvm * gvf
+               const double preFactor = -4.0*twoLoop * fermionChargeCount * gvm * gvf
                   * lepton_pole_mass<Lepton>(qedqcd@BarrZeeLeptonIdx@) / fermionMass;
 
                res += preFactor * (part1 + part2);
@@ -560,7 +560,7 @@ Lepton, ChargedScalar, NeutralScalar
 
          const double massRatioSquared = Sqr(chargedScalarMass / neutralScalarMass);
 
-         const double preFactor = Sqr(unit_charge(context))/(64*Power4(Pi)) * scalarChargeCount * scalarChargeCount
+         const double preFactor = Sqr(unit_charge(context))*4.*twoLoop * scalarChargeCount * scalarChargeCount
             * lepton_pole_mass<Lepton>(qedqcd@BarrZeeLeptonIdx@) / (neutralScalarMass * neutralScalarMass);
 
          res += preFactor * coeff.real() * BarrZeeLoopS(massRatioSquared);
@@ -627,7 +627,7 @@ Lepton, Vector, Scalar
 
          const double massRatioSquared = Sqr(vectorMass / scalarMass);
 
-         const double preFactor = - Sqr(unit_charge(context))/(128*Power4(Pi)) * vectorChargeCount * vectorChargeCount
+         const double preFactor = - Sqr(unit_charge(context))*2.*twoLoop * vectorChargeCount * vectorChargeCount
             * lepton_pole_mass<Lepton>(qedqcd@BarrZeeLeptonIdx@) / (vectorMass * vectorMass);
 
          res += preFactor * coeff.real() * BarrZeeLoopV(massRatioSquared);

--- a/templates/amm.cpp.in
+++ b/templates/amm.cpp.in
@@ -463,9 +463,6 @@ Lepton, Fermion, Scalar
                const auto scalarMass = context.mass<Scalar>(scalarIndices);
                const auto leptonMass = context.mass<Lepton>(leptonIndices);
                const auto zMass = context.mass<VZ>({ });
-               const auto ThetaW = DERIVEDPARAMETER(ThetaW);
-               const double cw = Cos(ThetaW);
-               const double sw = Sin(ThetaW);
 
                if (is_zero(zMass - scalarMass, 3e-13)) {
                   continue;
@@ -481,9 +478,10 @@ Lepton, Fermion, Scalar
                const std::complex<double> zmzr = leptonZVertex.right();
                const std::complex<double> zmzl = leptonZVertex.left();
                const std::complex<double> zfzr = fermionZVertex.right();
+               const std::complex<double> zfzl = fermionZVertex.left();
 
                const double gvm = 0.5*(zmzr.real() + zmzl.real());
-               const double gvf = (0.5) * (zfzr.real()/unit_charge(context) - fermionChargeCount*sw/cw);
+               const double gvf = 0.5*(zfzr.real() + zfzl.real());
                const std::complex<double> coeffA = (zrf + zlf) * (zrm + zlm);
                const std::complex<double> coeffB = (zlf - zrf) * (zrm - zlm);
 
@@ -492,7 +490,7 @@ Lepton, Fermion, Scalar
                const double part1 = coeffA.real() * Sqr(scalarMass) / (Sqr(scalarMass) - Sqr(zMass)) * (BarrZeeLoopFS(massRatioSquared) - BarrZeeLoopFS(Sqr(fermionMass / zMass)));
                const double part2 = coeffB.real() * Sqr(scalarMass) / (Sqr(scalarMass) - Sqr(zMass)) * (BarrZeeLoopFPS(massRatioSquared) - BarrZeeLoopFPS(Sqr(fermionMass / zMass)));
 
-               const double preFactor = - unit_charge(context)/(64*Power4(Pi)) * fermionChargeCount * gvm * gvf
+               const double preFactor = -1.0/(64*Power4(Pi)) * fermionChargeCount * gvm * gvf
                   * lepton_pole_mass<Lepton>(qedqcd@BarrZeeLeptonIdx@) / fermionMass;
 
                res += preFactor * (part1 + part2);

--- a/test/test_CE6SSM_amm.cpp
+++ b/test/test_CE6SSM_amm.cpp
@@ -145,5 +145,5 @@ Block EXTPAR
    settings.set(Spectrum_generator_settings::calculate_amm, 2.0);
 
    amu = CE6SSM_amm::calculate_amm<Fe>(std::get<0>(models), qedqcd, settings, 1);
-   BOOST_CHECK_CLOSE_FRACTION(amu, 4.7615802422189462e-11, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(amu, 4.753233875825685e-11, 1e-7);
 }

--- a/test/test_MRSSM2_amm.cpp
+++ b/test/test_MRSSM2_amm.cpp
@@ -86,13 +86,13 @@ BOOST_AUTO_TEST_CASE( test_amu )
    settings.set(Spectrum_generator_settings::calculate_amm, 2.0);
 
    ae = MRSSM2_amm::calculate_amm<Fe>(m, qedqcd, settings, 0);
-   BOOST_CHECK_CLOSE_FRACTION(ae, -1.1509961403223395e-15, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(ae, -1.1528572931380434e-15, 1e-7);
 
    amu = MRSSM2_amm::calculate_amm<Fe>(m, qedqcd, settings, 1);
-   BOOST_CHECK_CLOSE_FRACTION(amu, -5.3889383787834972e-11, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(amu, -5.3968953868935609e-11, 1e-7);
 
    atau = MRSSM2_amm::calculate_amm<Fe>(m, qedqcd, settings, 2);
-   BOOST_CHECK_CLOSE_FRACTION(atau, -1.4200847904302034e-08, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(atau, -1.4223352839313197e-08, 1e-7);
 
    // neutralino dominance
 
@@ -117,11 +117,11 @@ BOOST_AUTO_TEST_CASE( test_amu )
    settings.set(Spectrum_generator_settings::calculate_amm, 2.0);
 
    ae = MRSSM2_amm::calculate_amm<Fe>(m, qedqcd, settings, 0);
-   BOOST_CHECK_CLOSE_FRACTION(ae, 7.9271723544599888e-16, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(ae, 7.9102513947685461e-16, 1e-7);
 
    amu = MRSSM2_amm::calculate_amm<Fe>(m, qedqcd, settings, 1);
-   BOOST_CHECK_CLOSE_FRACTION(amu, 3.4290840213640912e-11, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(amu, 3.4218497896247393e-11, 1e-7);
 
    atau = MRSSM2_amm::calculate_amm<Fe>(m, qedqcd, settings, 2);
-   BOOST_CHECK_CLOSE_FRACTION(atau, 1.1653887003170018e-08, 1e-7);
+   BOOST_CHECK_CLOSE_FRACTION(atau, 1.1633430821565949e-08, 1e-7);
 }

--- a/test/test_munuSSM_amm.cpp
+++ b/test/test_munuSSM_amm.cpp
@@ -148,11 +148,11 @@ Block YVIN
    settings.set(Spectrum_generator_settings::calculate_amm, 2.0);
 
    ae = munuSSM_amm::calculate_amm<Cha>(m, qedqcd, settings, 0);
-   BOOST_CHECK_CLOSE_FRACTION(ae, 1.5891673276315595e-11, 1e-6);
+   BOOST_CHECK_CLOSE_FRACTION(ae, 1.588748576865684e-11, 1e-6);
 
    amu = munuSSM_amm::calculate_amm<Cha>(m, qedqcd, settings, 1);
-   BOOST_CHECK_CLOSE_FRACTION(amu, 4.2684661421478245e-09, 1e-6);
+   BOOST_CHECK_CLOSE_FRACTION(amu, 4.2677731488826819e-09, 1e-6);
 
    atau = munuSSM_amm::calculate_amm<Cha>(m, qedqcd, settings, 2);
-   BOOST_CHECK_CLOSE_FRACTION(atau, 1.7171354180269422e-05, 1e-6);
+   BOOST_CHECK_CLOSE_FRACTION(atau, 1.717142461318717e-05, 1e-6);
 }


### PR DESCRIPTION
This change reproduces exactly the vertex originally written by Felix
```cpp
const double gvf = (0.5) * (zfzr.real()/unit_charge(context) - fermionChargeCount*sw/cw);
```
for leptons and quarks. It does give a different number for charginos though. And I think this might be ok. The original vertex looks like it always assumes that Z-couples to fermion via the covariant derivative (it always looks like a coupling of Z to SM-fermions). But this would not be ok for fermions like charginos.