### PR TITLE
add 1D minimizer over a [a,b] range

### DIFF
--- a/src/gsl_min_fminimizer.cpp
+++ b/src/gsl_min_fminimizer.cpp
@@ -1,0 +1,41 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+#include "gsl_min_fminimizer.hpp"
+#include "error.hpp"
+#include <string>
+
+namespace flexiblesusy {
+
+GSL_min_fminimizer::GSL_min_fminimizer(
+   const gsl_min_fminimizer_type* type,
+   gsl_function* f, double start,
+   double end)
+{
+   solver = gsl_min_fminimizer_alloc(type);
+
+   if (!solver) {
+      throw OutOfMemoryError(
+         std::string("Cannot allocate gsl_multimin_fminimizer ") +
+         gsl_min_fminimizer_name(solver));
+   }
+
+   gsl_min_fminimizer_set(solver, f, 0.5*(end-start), start, end);
+}
+
+} // namespace flexiblesusy

--- a/src/gsl_min_fminimizer.hpp
+++ b/src/gsl_min_fminimizer.hpp
@@ -1,0 +1,51 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+#ifndef GSL_MIN_FMINIMIZER_H
+#define GSL_MIN_FMINIMIZER_H
+
+#include "gsl_vector.hpp"
+#include <gsl/gsl_min.h>
+
+namespace flexiblesusy {
+
+class GSL_min_fminimizer
+{
+public:
+   GSL_min_fminimizer(const gsl_min_fminimizer_type* type,
+                      gsl_function* f, double start,
+                      double end);
+   GSL_min_fminimizer(const GSL_min_fminimizer&) = delete;
+   GSL_min_fminimizer(GSL_min_fminimizer&&) = delete;
+   ~GSL_min_fminimizer() noexcept;
+   GSL_min_fminimizer& operator=(const GSL_min_fminimizer&) = delete;
+   GSL_min_fminimizer& operator=(GSL_min_fminimizer&&) = delete;
+
+   GSL_vector get_minimum_point() const;
+   double get_minimum_value() const;
+   int iterate();
+   void print_state(std::size_t iteration) const;
+   int test_residual(double precision) const noexcept;
+
+private:
+   gsl_min_fminimizer* solver = nullptr;
+};
+
+} // namespace flexiblesusy
+
+#endif

--- a/src/minimizer.hpp
+++ b/src/minimizer.hpp
@@ -27,6 +27,7 @@
 #include "ewsb_solver.hpp"
 #include "logger.hpp"
 #include "gsl_multimin_fminimizer.hpp"
+#include "gsl_min_fminimizer.hpp"
 #include "gsl_utils.hpp"
 #include "gsl_vector.hpp"
 
@@ -73,6 +74,7 @@ public:
    void set_max_iterations(std::size_t n) { max_iterations = n; }
    void set_solver_type(Solver_type t) { solver_type = t; }
    int minimize(const Vector_t&);
+   int minimize(double, double);
 
    // EWSB_solver interface methods
    virtual std::string name() const override { return "Minimizer"; }
@@ -163,6 +165,20 @@ int Minimizer<dimension>::minimize(const Vector_t& start)
    minimum_value = minimizer.get_minimum_value();
 
    return status;
+}
+
+template <std::size_t dimension>
+int Minimizer<dimension>::minimize(double start, double end) {
+   if (!function)
+      throw SetupError("Minimizer: function not callable");
+
+   // initialize function
+   gsl_function func;
+   func.function = gsl_function3;
+   func.params = &function;
+
+   GSL_min_fminimizer minimizer(solver_type_to_gsl_pointer(),
+                                     &func, start, end);
 }
 
 template <std::size_t dimension>

--- a/src/module.mk
+++ b/src/module.mk
@@ -25,6 +25,7 @@ LIBFLEXI_SRC := \
 		$(DIR)/global_thread_pool.cpp \
 		$(DIR)/gm2calc_interface.cpp \
 		$(DIR)/gsl_multimin_fminimizer.cpp \
+		$(DIR)/gsl_min_fminimizer.cpp \
 		$(DIR)/gsl_multiroot_fsolver.cpp \
 		$(DIR)/gsl_utils.cpp \
 		$(DIR)/gsl_vector.cpp \
@@ -107,6 +108,7 @@ LIBFLEXI_HDR := \
 		$(DIR)/gm2calc_interface.hpp \
 		$(DIR)/gsl.hpp \
 		$(DIR)/gsl_multimin_fminimizer.hpp \
+		$(DIR)/gsl_min_fminimizer.hpp \
 		$(DIR)/gsl_multiroot_fsolver.hpp \
 		$(DIR)/gsl_utils.hpp \
 		$(DIR)/gsl_vector.hpp \


### PR DESCRIPTION
Currently we only have a wrapper over a multidimensional minimizer that uses a gradient descent. This is not the most efficient thing to use if all you want is to minimize a 1d function. For this we should have a wrapper over `gsl_min_fminimizer_set`. This functionality will be needed both in PRs #446 and #524.

Idea for an implementation: create an overload for the
```cpp
int minimize(const Vector_t&);
```
function that works only in 1D and takes
```cpp
int minimize(double, double);
```