### PR TITLE
rename gm2 to amm

### DIFF
--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -2508,7 +2508,7 @@ WriteAMMClass[fields_List, files_List] :=
             (* we want to calculate an offset of g-2 compared to the SM *)
             discardSMcontributions = CConversion`CreateCBoolValue[True],
             graphs, diagrams, vertices, barZee = "", calculateForwadDeclaration, uncertaintyForwadDeclaration, leptonPoleMass,
-            BarrZeeLeptonIdx, gm2WrapperDecl, gm2WrapperDef, gm2UncWrapperDecl, gm2UncWrapperDef},
+            BarrZeeLeptonIdx, ammWrapperDecl, ammWrapperDef, ammUncWrapperDecl, ammUncWrapperDef},
 
       calculation =
          If[Length[fields] =!= 0,
@@ -2572,15 +2572,15 @@ TextFormatting`IndentText[
 
       BarrZeeLeptonIdx = If[GetParticleFromDescription["Leptons"] =!= Null, ",indices.at(0)", ""];
 
-      gm2WrapperDecl = StringRiffle[("double calculate_" <> CXXDiagrams`CXXNameOfField[#] <> "_gm2(const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates& model, const softsusy::QedQcd& qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", int idx", ""] <> ");")& /@ fields, "\n"];
-      gm2UncWrapperDecl = StringRiffle[("double calculate_" <> CXXDiagrams`CXXNameOfField[#] <> "_gm2_uncertainty(const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates& model, const softsusy::QedQcd& qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", int idx", ""] <> ");")& /@ fields, "\n"];
-      gm2WrapperDef = StringRiffle[
-("double calculate_" <> CXXDiagrams`CXXNameOfField[#] <> "_gm2(const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates& model, const softsusy::QedQcd& qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", int idx", ""] <> ") {
+      ammWrapperDecl = StringRiffle[("double calculate_" <> CXXDiagrams`CXXNameOfField[#] <> "_amm(const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates& model, const softsusy::QedQcd& qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", int idx", ""] <> ");")& /@ fields, "\n"];
+      ammUncWrapperDecl = StringRiffle[("double calculate_" <> CXXDiagrams`CXXNameOfField[#] <> "_amm_uncertainty(const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates& model, const softsusy::QedQcd& qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", int idx", ""] <> ");")& /@ fields, "\n"];
+      ammWrapperDef = StringRiffle[
+("double calculate_" <> CXXDiagrams`CXXNameOfField[#] <> "_amm(const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates& model, const softsusy::QedQcd& qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", int idx", ""] <> ") {
    return " <> FlexibleSUSY`FSModelName <> "_amm::calculate_amm<fields::" <> CXXDiagrams`CXXNameOfField[#] <> ">(model, qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", idx", ""] <> ");
 }")& /@ fields, "\n"
       ];
-      gm2UncWrapperDef = StringRiffle[
-("double calculate_" <> CXXDiagrams`CXXNameOfField[#] <> "_gm2_uncertainty(const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates& model, const softsusy::QedQcd& qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", int idx", ""] <> ") {
+      ammUncWrapperDef = StringRiffle[
+("double calculate_" <> CXXDiagrams`CXXNameOfField[#] <> "_amm_uncertainty(const " <> FlexibleSUSY`FSModelName <> "_mass_eigenstates& model, const softsusy::QedQcd& qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", int idx", ""] <> ") {
    return " <> FlexibleSUSY`FSModelName <> "_amm::calculate_amm_uncertainty<fields::" <> CXXDiagrams`CXXNameOfField[#] <> ">(model, qedqcd" <> If[GetParticleFromDescription["Leptons"] =!= Null, ", idx", ""] <> ");
 }")& /@ fields, "\n"
       ];
@@ -2597,10 +2597,10 @@ TextFormatting`IndentText[
          "@leptonPoleMass@" -> leptonPoleMass,
          "@BarrZeeLeptonIdx@" -> BarrZeeLeptonIdx,
          "@AMMBarZeeCalculation@" -> TextFormatting`IndentText[barZee],
-         "@gm2WrapperDecl@" -> gm2WrapperDecl,
-         "@gm2WrapperDef@" -> gm2WrapperDef,
-         "@gm2UncWrapperDecl@" -> gm2UncWrapperDecl,
-         "@gm2UncWrapperDef@" -> gm2UncWrapperDef,
+         "@ammWrapperDecl@" -> ammWrapperDecl,
+         "@ammWrapperDef@" -> ammWrapperDef,
+         "@ammUncWrapperDecl@" -> ammUncWrapperDecl,
+         "@ammUncWrapperDef@" -> ammUncWrapperDef,
          Sequence @@ GeneralReplacementRules[]
         }];
 
@@ -5163,12 +5163,12 @@ MakeFlexibleSUSY[OptionsPattern[]] :=
               ammFields,
               {{FileNameJoin[{$flexiblesusyTemplateDir, "amm.hpp.in"}],
                                FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_amm.hpp"}]},
-               {FileNameJoin[{$flexiblesusyTemplateDir, "lepton_gm2_wrapper.hpp.in"}],
-                               FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_lepton_gm2_wrapper.hpp"}]},
+               {FileNameJoin[{$flexiblesusyTemplateDir, "lepton_amm_wrapper.hpp.in"}],
+                               FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_lepton_amm_wrapper.hpp"}]},
                {FileNameJoin[{$flexiblesusyTemplateDir, "amm.cpp.in"}],
                                FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_amm.cpp"}]},
-               {FileNameJoin[{$flexiblesusyTemplateDir, "lepton_gm2_wrapper.cpp.in"}],
-                               FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_lepton_gm2_wrapper.cpp"}]}}];
+               {FileNameJoin[{$flexiblesusyTemplateDir, "lepton_amm_wrapper.cpp.in"}],
+                               FileNameJoin[{FSOutputDir, FlexibleSUSY`FSModelName <> "_lepton_amm_wrapper.cpp"}]}}];
 
            Print["Creating FFMasslessV form factor class for other observables ..."];
            FFMasslessVVertices =

--- a/templates/lepton_amm_wrapper.cpp.in
+++ b/templates/lepton_amm_wrapper.cpp.in
@@ -18,23 +18,23 @@
 
 
 /**
- * @file @ModelName@_muon_gm2_wrapper.cpp
+ * @file @ModelName@_muon_amm_wrapper.cpp
  *
  * This file was generated with FlexibleSUSY @FlexibleSUSYVersion@ and SARAH @SARAHVersion@ .
  */
 
-#include "@ModelName@_lepton_gm2_wrapper.hpp"
+#include "@ModelName@_lepton_amm_wrapper.hpp"
 #include "@ModelName@_amm.hpp"
 #include "cxx_qft/@ModelName@_qft.hpp"
 
 namespace flexiblesusy {
-namespace MRSSM2_lepton_gm2_wrapper {
+namespace @ModelName@_lepton_amm_wrapper {
 
 using namespace @ModelName@_cxx_diagrams;
 
-@gm2WrapperDef@
+@ammWrapperDef@
 
-@gm2UncWrapperDef@
+@ammUncWrapperDef@
 
 }
 }

--- a/templates/lepton_amm_wrapper.hpp.in
+++ b/templates/lepton_amm_wrapper.hpp.in
@@ -18,13 +18,13 @@
 
 
 /**
- * @file @ModelName@_gm2_wrapper.hpp
+ * @file @ModelName@_amm_wrapper.hpp
  *
  * This file was generated with FlexibleSUSY @FlexibleSUSYVersion@ and SARAH @SARAHVersion@ .
  */
 
-#ifndef @ModelName@_LEPTON_GM2_WRAPPER_H
-#define @ModelName@_LEPTON_GM2_WRAPPER_H
+#ifndef @ModelName@_LEPTON_AMM_WRAPPER_H
+#define @ModelName@_LEPTON_AMM_WRAPPER_H
 
 namespace softsusy {
    class QedQcd;
@@ -33,20 +33,20 @@ namespace softsusy {
 namespace flexiblesusy {
 class @ModelName@_mass_eigenstates;
 
-namespace @ModelName@_lepton_gm2_wrapper {
+namespace @ModelName@_lepton_amm_wrapper {
 /**
 * @fn calculate_amm
 * @brief Calculates \f$a = Delta(g-2)/2\f$ of the lepton.
 */
-@gm2WrapperDecl@
+@ammWrapperDecl@
 
 /**
 * @fn calculate_amm_uncertainty
 * @brief Calculates uncertainty of \f$\Delta a\f$ of the muon.
 */
-@gm2UncWrapperDecl@
+@ammUncWrapperDecl@
 
-} // namespace @ModelName@_gm2_wrapper
+} // namespace @ModelName@_amm_wrapper
 } // namespace flexiblesusy
 
 #endif

--- a/templates/module.mk
+++ b/templates/module.mk
@@ -43,8 +43,8 @@ BASE_TEMPLATES := \
 		$(DIR)/mass_eigenstates_decoupling_scheme.cpp.in \
 		$(DIR)/model.hpp.in \
 		$(DIR)/model_slha.hpp.in \
-		$(DIR)/lepton_gm2_wrapper.hpp.in \
-		$(DIR)/lepton_gm2_wrapper.cpp.in \
+		$(DIR)/lepton_amm_wrapper.hpp.in \
+		$(DIR)/lepton_amm_wrapper.cpp.in \
 		$(DIR)/observables.hpp.in \
 		$(DIR)/observables.cpp.in \
 		$(DIR)/physical.hpp.in \

--- a/templates/module.mk.in
+++ b/templates/module.mk.in
@@ -65,7 +65,7 @@ LIB@CLASSNAME@_SRC := \
 		$(DIR)/@CLASSNAME@_mass_eigenstates.cpp \
 		$(DIR)/@CLASSNAME@_mass_eigenstates_decoupling_scheme.cpp \
 		$(DIR)/@CLASSNAME@_model_slha.cpp \
-		$(DIR)/@CLASSNAME@_lepton_gm2_wrapper.cpp \
+		$(DIR)/@CLASSNAME@_lepton_amm_wrapper.cpp \
 		$(DIR)/@CLASSNAME@_observables.cpp \
 		$(DIR)/@CLASSNAME@_physical.cpp \
 		$(DIR)/@CLASSNAME@_slha_io.cpp \
@@ -109,7 +109,7 @@ LIB@CLASSNAME@_HDR := \
 		$(DIR)/@CLASSNAME@_mass_eigenstates_decoupling_scheme.hpp \
 		$(DIR)/@CLASSNAME@_model.hpp \
 		$(DIR)/@CLASSNAME@_model_slha.hpp \
-		$(DIR)/@CLASSNAME@_lepton_gm2_wrapper.hpp \
+		$(DIR)/@CLASSNAME@_lepton_amm_wrapper.hpp \
 		$(DIR)/@CLASSNAME@_observables.hpp \
 		$(DIR)/@CLASSNAME@_physical.hpp \
 		$(DIR)/@CLASSNAME@_slha_io.hpp \

--- a/test/test_MRSSM2_gmm2.cpp
+++ b/test/test_MRSSM2_gmm2.cpp
@@ -26,7 +26,7 @@
 #include "lowe.h"
 #include "wrappers.hpp"
 #include "MRSSM2_amm.hpp"
-#include "MRSSM2_lepton_gm2_wrapper.hpp"
+#include "MRSSM2_lepton_amm_wrapper.hpp"
 #include "cxx_qft/MRSSM2_qft.hpp"
 
 using namespace flexiblesusy;
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE( test_amu )
 
    auto amu = MRSSM2_amm::calculate_amm<Fe>(m, qedqcd, 1);
    BOOST_CHECK_CLOSE_FRACTION(amu, -8.1719300481437495e-11, 1e-7);
-   BOOST_CHECK_CLOSE_FRACTION(amu, MRSSM2_lepton_gm2_wrapper::calculate_Fe_gm2(m, qedqcd, 1), 1e-16);
+   BOOST_CHECK_CLOSE_FRACTION(amu, MRSSM2_lepton_amm_wrapper::calculate_Fe_amm(m, qedqcd, 1), 1e-16);
    double damu = MRSSM2_amm::calculate_amm_uncertainty<Fe>(m, qedqcd, 1);
    BOOST_CHECK_CLOSE_FRACTION(damu, 9.070380471705522e-13, 1e-7);
 
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE( test_amu )
 
    amu = MRSSM2_amm::calculate_amm<Fe>(m, qedqcd, 1);
    BOOST_CHECK_CLOSE_FRACTION(amu, 6.2743365882975202e-12, 1e-7);
-   BOOST_CHECK_CLOSE_FRACTION(amu, MRSSM2_lepton_gm2_wrapper::calculate_Fe_gm2(m, qedqcd, 1), 1e-16);
+   BOOST_CHECK_CLOSE_FRACTION(amu, MRSSM2_lepton_amm_wrapper::calculate_Fe_amm(m, qedqcd, 1), 1e-16);
 
    atau = MRSSM2_amm::calculate_amm<Fe>(m, qedqcd, 2);
    BOOST_CHECK_CLOSE_FRACTION(atau, 3.7317209742717716e-09, 1e-7);


### PR DESCRIPTION
Since we now call `FlexibleSUSY` calculation of g-2 `AMM` maybe it makes sense to rename remaining occurrences of `gm2` to `amm`. We only leave untouched `gm2` in names related to `GM2Calc`