### PR TITLE
replace const string& with string_view where possible

### DIFF
--- a/src/command_line_options.cpp
+++ b/src/command_line_options.cpp
@@ -134,8 +134,8 @@ void Command_line_options::reset()
  *
  * @return true if the string str starts with prefix, false otherwise
  */
-bool Command_line_options::starts_with(const std::string& str,
-                                       const std::string& prefix)
+bool Command_line_options::starts_with(std::string_view str,
+                                       std::string_view prefix)
 {
    return !str.compare(0, prefix.size(), prefix);
 }
@@ -151,7 +151,7 @@ bool Command_line_options::starts_with(const std::string& str,
  * @return true, if str starts with prefix, false otherwise
  */
 bool Command_line_options::get_parameter_value(const std::string& str,
-                                               const std::string& prefix,
+                                               std::string_view prefix,
                                                double& parameter)
 {
    if (starts_with(str, prefix)) {
@@ -172,7 +172,7 @@ bool Command_line_options::get_parameter_value(const std::string& str,
  * @return true, if str starts with prefix, false otherwise
  */
 bool Command_line_options::get_parameter_value(const std::string& str,
-                                               const std::string& prefix,
+                                               std::string_view prefix,
                                                int& parameter)
 {
    if (starts_with(str, prefix)) {

--- a/src/command_line_options.hpp
+++ b/src/command_line_options.hpp
@@ -60,12 +60,12 @@ public:
    void print_version(std::ostream&) const;
    void reset();
 
-   const std::string& get_database_output_file() const { return database_output_file; }
-   const std::string& get_slha_input_file() const { return slha_input_file; }
-   const std::string& get_slha_output_file() const { return slha_output_file; }
-   const std::string& get_program_name() const { return program; }
-   const std::string& get_rgflow_file() const { return rgflow_file; }
-   const std::string& get_spectrum_file() const { return spectrum_file; }
+   std::string_view get_database_output_file() { return database_output_file; }
+   std::string_view get_slha_input_file() { return slha_input_file; }
+   std::string_view get_slha_output_file() { return slha_output_file; }
+   std::string_view get_program_name() { return program; }
+   std::string_view get_rgflow_file() { return rgflow_file; }
+   std::string_view get_spectrum_file() { return spectrum_file; }
 
    static bool get_parameter_value(const std::string&, std::string_view, double&);
    static bool get_parameter_value(const std::string&, std::string_view, int&);

--- a/src/command_line_options.hpp
+++ b/src/command_line_options.hpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <iosfwd>
 #include <string>
+#include <string_view>
 
 namespace flexiblesusy {
 
@@ -66,9 +67,9 @@ public:
    const std::string& get_rgflow_file() const { return rgflow_file; }
    const std::string& get_spectrum_file() const { return spectrum_file; }
 
-   static bool get_parameter_value(const std::string&, const std::string&, double&);
-   static bool get_parameter_value(const std::string&, const std::string&, int&);
-   static bool starts_with(const std::string&, const std::string&);
+   static bool get_parameter_value(const std::string&, std::string_view, double&);
+   static bool get_parameter_value(const std::string&, std::string_view, int&);
+   static bool starts_with(std::string_view, std::string_view);
 
 private:
    bool do_exit{false};

--- a/src/decays/decay.hpp
+++ b/src/decays/decay.hpp
@@ -47,14 +47,14 @@ public:
    std::size_t get_final_state_size() const { return pids_out.size(); }
 
    double get_width() const { return width; }
-   std::string get_proc_string() const { return proc_string; }
+   std::string_view get_proc_string() const { return proc_string; }
    void set_width(double w) { width = w; }
 
 private:
    int pid_in{0};
    std::vector<int> pids_out{};
    double width{0.};
-   std::string proc_string;
+   std::string proc_string{};
 };
 
 std::size_t hash_decay(const Decay& decay);

--- a/templates/slha_io.cpp.in
+++ b/templates/slha_io.cpp.in
@@ -439,7 +439,7 @@ void @ModelName@_slha_io::set_decay_block(const Decays_list& decays_list, Flexib
          if (partial_width < 0 && !is_zero(branching_ratio, NEGATIVE_BR_TOLERANCE)) {
             std::stringstream ss;
             ss << std::scientific << partial_width;
-            throw std::runtime_error("Error in " + channel.get_proc_string() + ": partial width is negative (" + ss.str() + " GeV).");
+            throw std::runtime_error("Error in " + std::string(channel.get_proc_string()) + ": partial width is negative (" + ss.str() + " GeV).");
          }
          else if (partial_width < 0 && is_zero(branching_ratio, NEGATIVE_BR_TOLERANCE)) {
             branching_ratio = 0;


### PR DESCRIPTION
We should go through the code looking for uses of `const string&` and replace them with `string_view` where possible.

Possible uses for `string_view`:

- CppCoreGuidelines [recommends](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#example-better-still) to prefer construction of `string` from `string_view` instead of calling a copy constructor from another `string`.