### PR TITLE
H+ decay specializations

### DIFF
--- a/meta/Decays.m
+++ b/meta/Decays.m
@@ -2072,6 +2072,14 @@ SelectUpQuarkDownQuarkFinalState[decays_List] :=
            result
           ];
 
+SelectHiggsWFinalState[decays_List] :=
+    Module[{higgsSymbol = TreeMasses`GetHiggsBoson[], WpSymbol = If[GetElectricCharge[TreeMasses`GetWBoson[]] < 0, Susyno`LieGroups`conj[TreeMasses`GetWBoson[]], TreeMasses`GetWBoson[]],  result = {}},
+           If[higgsSymbol =!= Null && WpSymbol =!= Null,
+              result = SelectDecayByFinalState[{higgsSymbol, WpSymbol}, decays];
+             ];
+           result
+          ];
+
 SelectWWFinalState[decays_List] :=
     Module[{wBosonSymbol = TreeMasses`GetWBoson[], result = {}},
            If[wBosonSymbol =!= Null,
@@ -2403,6 +2411,16 @@ CreateChargedHiggsToUpQuarkDownQuarkPartialWidth[{higgsSymbol_, decaysList_}, mo
        {declaration, function}
     ];
 
+CreateChargedHiggsToHiggsW[{higgsSymbol_, decaysList_}, modelName_] :=
+    Module[{decay, declaration = "", function = ""},
+       decay = SelectHiggsWFinalState[decaysList];
+       If[decay =!= {},
+          decay = First[decay];
+          {declaration, function} = CreateIncludedPartialWidthSpecialization[decay, modelName];
+       ];
+       {declaration, function}
+    ];
+
 CreateHiggsDecayPartialWidthSpecializations[particleDecays_, modelName_] :=
     Module[{higgsDecays, specializations = {}},
            higgsDecays = GetHiggsBosonDecays[particleDecays];
@@ -2444,7 +2462,8 @@ CreateChargedHiggsDecayPartialWidthSpecializations[particleDecays_, modelName_] 
            If[chargedHiggsDecays =!= {},
               chargedHiggsDecays = First[chargedHiggsDecays];
               specializations = {
-                                 CreateChargedHiggsToUpQuarkDownQuarkPartialWidth[chargedHiggsDecays, modelName]
+                                 CreateChargedHiggsToUpQuarkDownQuarkPartialWidth[chargedHiggsDecays, modelName],
+                                 CreateChargedHiggsToHiggsW[chargedHiggsDecays, modelName]
                                  };
              ];
            specializations

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -561,6 +561,10 @@ CheckDecaysOptions[] :=
                FlexibleSUSY`FSDecayParticles = Intersection[TreeMasses`GetParticles[], FlexibleSUSY`FSDecayParticles]
             ]
          ]
+      ];
+      (* if present, replace H- with H+ since specializations are only for H+ *)
+      If[MemberQ[FlexibleSUSY`FSDecayParticles, TreeMasses`GetChargedHiggsBoson[]] && GetElectricCharge[TreeMasses`GetChargedHiggsBoson[]] < 0,
+         FlexibleSUSY`FSDecayParticles = FlexibleSUSY`FSDecayParticles /. TreeMasses`GetChargedHiggsBoson[] -> Susyno`LieGroups`conj[TreeMasses`GetChargedHiggsBoson[]];
       ]
    ];
 

--- a/src/decays/decay_functions.cpp
+++ b/src/decays/decay_functions.cpp
@@ -303,4 +303,14 @@ unsigned int number_of_active_flavours(softsusy::QedQcd const& qedqcd, double m)
    return nf;
 }
 
+/*
+ * Computes 1-loop QCD correction to H^+ -> t bbar + X in the limit mb -> 0
+ * as given in Eq. 2.6 of 2201.08139
+ */
+double Delta_Hp(double z) noexcept {
+   const double lnz = std::log(z);
+   const double ln1mz = std::log1p(-z);
+   return 2.*Li2(z) + lnz*ln1mz + (z-2.5)*(ln1mz-lnz) + 1./(z-1.)*lnz + 2.25;
+}
+
 } // namespace flexiblesusy

--- a/src/decays/decay_functions.hpp
+++ b/src/decays/decay_functions.hpp
@@ -20,9 +20,9 @@
 #define DECAY_FUNCTIONS_H
 
 #include <complex>
-#include "src/lowe.h"
+#include "lowe.h"
 #include "flexibledecay_settings.hpp"
-#include "src/wrappers.hpp"
+#include "wrappers.hpp"
 
 namespace flexiblesusy {
 
@@ -59,6 +59,9 @@ std::complex<double> f(double x) noexcept;
 unsigned int number_of_active_flavours(softsusy::QedQcd const&, double m) noexcept;
 
 static constexpr double deltaqq_QCDxQED = 691/24. - 6*zeta3 - Sqr(Pi);
+
+double Delta_Hp(double) noexcept;
+
 } // namespace flexiblesusy
 
 #endif

--- a/src/decays/specializations/Hp/decay_Hp_to_HWp.inc
+++ b/src/decays/specializations/Hp/decay_Hp_to_HWp.inc
@@ -1,0 +1,32 @@
+template <>
+double CLASSNAME::get_partial_width<Hp, Higgs, WpBoson>(
+   const context_base& context,
+   typename field_indices<Hp>::type const& indexIn,
+   typename field_indices<Higgs>::type const& indexOut1,
+   typename field_indices<WpBoson>::type const& indexOut2) const
+{
+
+   const double mHpOS = context.physical_mass<Hp>(indexIn);
+   const double mHOS = context.physical_mass<Higgs>(indexOut1);
+   const double mWOS = context.physical_mass<WpBoson>(indexOut2);
+
+   if (mHpOS >= mHOS + mWOS) {
+      const double xH = Sqr(mHOS/mHpOS);
+      const double xW = Sqr(mWOS/mHpOS);
+
+      const auto indices = concatenate(indexOut1, indexIn, indexOut2);
+      const auto gHpHWm = Vertex<Higgs, Hp, WmBoson>::evaluate(indices, context).value(0, 1);
+
+      return 1./(16.*Pi) * Cube(std::sqrt(KallenLambda(1., xH, xW))*mHpOS)/Sqr(mWOS) * std::norm(gHpHWm);
+   }
+   else if (mHpOS - mHOS > 6) {
+
+      const double omega   = Sqr(mHOS /mWOS);
+      const double omegapm = Sqr(mHpOS/mWOS);
+
+      return 0.;
+   }
+   else {
+      return 0.;
+   }
+}

--- a/src/decays/specializations/Hp/decay_Hp_to_dbaru.inc
+++ b/src/decays/specializations/Hp/decay_Hp_to_dbaru.inc
@@ -1,0 +1,41 @@
+template <>
+double CLASSNAME::get_partial_width<Hp, bar<DownTypeQuark>::type, UpTypeQuark>(
+   const context_base& context,
+   typename field_indices<Hp>::type const& indexIn,
+   typename field_indices<bar<DownTypeQuark>>::type const& indexOut1,
+   typename field_indices<UpTypeQuark>::type const& indexOut2) const
+{
+   const double mHp = context.physical_mass<Hp>(indexIn);
+   const double md = context.physical_mass<DownTypeQuark>(indexOut1);
+   const double mu = context.physical_mass<UpTypeQuark>(indexOut2);
+
+   // phase space without symmetry factor
+   const double ps = 1./(8.*Pi) * std::sqrt(KallenLambda(1., Sqr(mu/mHp), Sqr(md/mHp)));
+
+   static constexpr double color_factor = 3;
+
+   // matrix element squared
+   const auto mat_elem_sq = amplitude_squared<Hp, bar<DownTypeQuark>::type, UpTypeQuark>(
+      context, indexIn, indexOut1, indexOut2);
+
+   // flux * phase space factor * symmetry factor * color factor * |matrix element|^2
+   double result = 0.5/mHp * ps * color_factor * mat_elem_sq;
+
+   // higher order corrections
+   if (flexibledecay_settings.get(FlexibleDecay_settings::include_higher_order_corrections)) {
+      // H+ -> t bbar
+      if(indexOut1.at(0) == 2 && indexOut2.at(0) == 2) {
+         const double z = Sqr(mu/mHp);
+         static constexpr double CF = 4./3.;
+         // @todo: missing MSbar -> OS conversion factor?
+         const double corr = 1. + CF*get_alphas(context)/Pi*Delta_Hp(z);
+         // Delta_Hp has logarithmic singularity for z->0
+         if (corr > 0) {
+            result *= corr;
+         }
+      }
+   }
+
+   return result;
+}
+

--- a/test/test_MRSSM2_FlexibleDecay.cpp
+++ b/test/test_MRSSM2_FlexibleDecay.cpp
@@ -747,6 +747,11 @@ Block IMVCKM Q= 1.00000000E+03
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_hh_to_barFeFe(&m, 0, 2, 2),
                               0.00027252978357707359, 5e-12);
 
+   // Hp -> hh(1) W+
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_conjHpm_to_hhconjVWm(&m, 1, 1),
+                              0., 1e-16);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_conjHpm_to_hhconjVWm(&m, 1, 0),
+                              3.7435618344417529e-05, 1e-16);
    // ------------ loop-induces decays ------------
 
    // h -> gamma gamma

--- a/test/test_MSSM_FlexibleDecay.cpp
+++ b/test/test_MSSM_FlexibleDecay.cpp
@@ -763,4 +763,11 @@ Block MSOFT Q= 8.64566212E+02
    // hh(2) -> hh(1) hh(1)
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_hh_to_hhhh(&m, 1, 0, 0),
                               0.0055271603394791615, 5e-13);
+
+   // Hp -> hh(1) W+
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_conjHpm_to_hhconjVWm(&m, 1, 1),
+                              0., 1e-16);
+   // Hp -> hh(0) W+
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_conjHpm_to_hhconjVWm(&m, 1, 0),
+                              0.0010228054918600532, 3e-16);
 }

--- a/test/test_THDMII_FlexibleDecay.cpp
+++ b/test/test_THDMII_FlexibleDecay.cpp
@@ -337,4 +337,10 @@ Block UERMIX
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_Ah_to_VPVP(&m, 1), 2.5449279204866726e-06, 3e-12);
    // Ah -> gamma Z
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_Ah_to_VPVZ(&m, 1), 5.4527502926727843e-07, 8e-12);
+
+   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_conjHm_to_barFdFu(&m, 1, 2, 2), 0.98978161175305701, 1e-15);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_conjHm_to_barFdFu(&m, 1, 2, 2), 0.99148855001500602, 1e-15);
+
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_conjHm_to_hhconjVWm(&m, 1, 1), 3.3419065873612581, 1e-15);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_conjHm_to_hhconjVWm(&m, 1, 0), 0.085035905977153506, 1e-15);
 }


### PR DESCRIPTION
Add higher order corrections to $H^+$ decays. This will be useful for #446 but is independent of it so can be moved to a separate PR.

Notes:

- [ ] do 1-loop SM QCD correction to $H^+ \to t \bar b$ lack an $\overline{\text{MS}} \to$  OS conversion terms $2 \alpha_s C_F (3 \ln \frac{\mu^2}{m_t^2} + 4)$?
