### PR TITLE
t quark decay specializations

### DIFF
--- a/src/decays/decay_functions.cpp
+++ b/src/decays/decay_functions.cpp
@@ -303,4 +303,21 @@ unsigned int number_of_active_flavours(softsusy::QedQcd const& qedqcd, double m)
    return nf;
 }
 
+/*
+ * Computes 1-loop QCD correction to t -> H^+ b + X in the limit mb -> 0
+ * as given in Eq. 2.5 of 2201.08139
+ */
+double Delta_t(double z) noexcept {
+   const double lnz = std::log(z);
+   const double ln1mz = std::log1p(-z);
+   return -2.*Li2(z) + z/(z-1.)*lnz + (1./z - 2.5)*ln1mz - lnz*ln1mz - 2.*zeta2 + 2.25;
+}
+
+// eq. 56 of 0906.3474
+double Delta_tW(double y) noexcept {
+   const double lny = std::log(y);
+   const double ln1my = std::log1p(-y);
+   return y/(Sqr(1.-y)*(1+2.*y))*(0.5*(1-y)*(5+9*y-6*Sqr(y))/y - 2./3.*Sqr(1-y)*(1+2*y)*Sqr(Pi)/y - Sqr(1-y)*(5+4*y)/y*ln1my - 4.*Sqr(1-y)*(1+2*y)/y*lny*ln1my - 4.*(1+y)*(1-2.*y)*lny - 4.*Sqr(1-y)*(1+2.*y)/y*Li2(y));
+}
+
 } // namespace flexiblesusy

--- a/src/decays/decay_functions.cpp
+++ b/src/decays/decay_functions.cpp
@@ -307,7 +307,7 @@ unsigned int number_of_active_flavours(softsusy::QedQcd const& qedqcd, double m)
  * Computes 1-loop QCD correction to t -> H^+ b + X in the limit mb -> 0
  * as given in Eq. 2.5 of 2201.08139
  */
-double Delta_t(double z) {
+double Delta_tHpd(double z) {
    const double lnz = std::log(z);
    if (z < 0 || z >= 1) {
       throw std::invalid_argument("z must belong to [0, 1)");

--- a/src/decays/decay_functions.cpp
+++ b/src/decays/decay_functions.cpp
@@ -307,10 +307,25 @@ unsigned int number_of_active_flavours(softsusy::QedQcd const& qedqcd, double m)
  * Computes 1-loop QCD correction to t -> H^+ b + X in the limit mb -> 0
  * as given in Eq. 2.5 of 2201.08139
  */
-double Delta_t(double z) noexcept {
+double Delta_t(double z) {
    const double lnz = std::log(z);
-   const double ln1mz = std::log1p(-z);
-   return -2.*Li2(z) + z/(z-1.)*lnz + (1./z - 2.5)*ln1mz - lnz*ln1mz - 2.*zeta2 + 2.25;
+   if (z < 0 || z >= 1) {
+      throw std::invalid_argument("z must belong to [0, 1)");
+   }
+   else if (is_zero(z)) {
+      return 1.25 - Sqr(Pi)/3.;
+   }
+   else if (z < 1e-10) {
+      return 1.25 - Sqr(Pi)/3.
+         + Sqr(z)    * (5.0/12.0  - 1.0/2.0*lnz)
+         + Cube(z)   * (13.0/36.0 - 2.0/3.0*lnz)
+         + Power4(z) * (3.0/10.0  - 3.0/4.0*lnz)
+         + Power5(z) * (19.0/75.0 - 4.0/5.0*lnz);
+   }
+   else {
+      const double ln1mz = std::log1p(-z);
+      return -2.*Li2(z) + z/(z-1.)*lnz + (1./z - 2.5)*ln1mz - lnz*ln1mz - 2.*zeta2 + 2.25;
+   }
 }
 
 // eq. 56 of 0906.3474

--- a/src/decays/decay_functions.hpp
+++ b/src/decays/decay_functions.hpp
@@ -59,6 +59,9 @@ std::complex<double> f(double x) noexcept;
 unsigned int number_of_active_flavours(softsusy::QedQcd const&, double m) noexcept;
 
 static constexpr double deltaqq_QCDxQED = 691/24. - 6*zeta3 - Sqr(Pi);
+
+double Delta_t(double) noexcept;
+double Delta_tW(double) noexcept;
 } // namespace flexiblesusy
 
 #endif

--- a/src/decays/decay_functions.hpp
+++ b/src/decays/decay_functions.hpp
@@ -60,7 +60,7 @@ unsigned int number_of_active_flavours(softsusy::QedQcd const&, double m) noexce
 
 static constexpr double deltaqq_QCDxQED = 691/24. - 6*zeta3 - Sqr(Pi);
 
-double Delta_t(double);
+double Delta_tHpd(double);
 double Delta_tW(double) noexcept;
 } // namespace flexiblesusy
 

--- a/src/decays/decay_functions.hpp
+++ b/src/decays/decay_functions.hpp
@@ -60,7 +60,7 @@ unsigned int number_of_active_flavours(softsusy::QedQcd const&, double m) noexce
 
 static constexpr double deltaqq_QCDxQED = 691/24. - 6*zeta3 - Sqr(Pi);
 
-double Delta_t(double) noexcept;
+double Delta_t(double);
 double Delta_tW(double) noexcept;
 } // namespace flexiblesusy
 

--- a/src/decays/specializations/u/decay_u_to_dHp.inc
+++ b/src/decays/specializations/u/decay_u_to_dHp.inc
@@ -21,7 +21,7 @@ double CLASSNAME::get_partial_width<UpTypeQuark, DownTypeQuark, Hp>(
    // higher order corrections
    if (flexibledecay_settings.get(FlexibleDecay_settings::include_higher_order_corrections)) {
       // t -> b H^+
-      if(indexIn.at(0) == 2 && indexOut1.at(0) == 2) {
+      if(indexIn.at(0) == 2) {
          const double z = Sqr(mHp/mu);
          static constexpr double CF = 4./3.;
          // @todo: missing MSbar -> OS conversion term?

--- a/src/decays/specializations/u/decay_u_to_dHp.inc
+++ b/src/decays/specializations/u/decay_u_to_dHp.inc
@@ -25,7 +25,7 @@ double CLASSNAME::get_partial_width<UpTypeQuark, DownTypeQuark, Hp>(
          const double z = Sqr(mHp/mu);
          static constexpr double CF = 4./3.;
          // @todo: missing MSbar -> OS conversion term?
-         result *= 1. + CF*get_alphas(context)/Pi*Delta_t(z);
+         result *= 1. + CF*get_alphas(context)/Pi*Delta_tHpd(z);
       }
    }
 

--- a/src/decays/specializations/u/decay_u_to_dHp.inc
+++ b/src/decays/specializations/u/decay_u_to_dHp.inc
@@ -1,0 +1,34 @@
+template <>
+double CLASSNAME::get_partial_width<UpTypeQuark, DownTypeQuark, Hp>(
+   const context_base& context,
+   typename field_indices<UpTypeQuark>::type const& indexIn,
+   typename field_indices<DownTypeQuark>::type const& indexOut1,
+   typename field_indices<Hp>::type const& indexOut2) const
+{
+   const double mu = context.physical_mass<UpTypeQuark>(indexIn);
+   const double md = context.physical_mass<DownTypeQuark>(indexOut1);
+   const double mHp = context.physical_mass<Hp>(indexOut2);
+
+   const double ps = 1./(8.*Pi) * std::sqrt(KallenLambda(1., Sqr(md/mu), Sqr(mHp/mu)));
+
+   // matrix element squared
+   const auto mat_elem_sq = amplitude_squared<UpTypeQuark, DownTypeQuark, Hp>(
+      context, indexIn, indexOut1, indexOut2);
+
+   // flux * phase space factor * symmetry factor * color factor * |matrix element|^2
+   double result = 0.5/mu * ps * mat_elem_sq;
+
+   // higher order corrections
+   if (flexibledecay_settings.get(FlexibleDecay_settings::include_higher_order_corrections)) {
+      // t -> b H^+
+      if(indexIn.at(0) == 2 && indexOut1.at(0) == 2) {
+         const double z = Sqr(mHp/mu);
+         static constexpr double CF = 4./3.;
+         // @todo: missing MSbar -> OS conversion term?
+         result *= 1. + CF*get_alphas(context)/Pi*Delta_t(z);
+      }
+   }
+
+   return result;
+}
+

--- a/src/decays/specializations/u/decay_u_to_dWp.inc
+++ b/src/decays/specializations/u/decay_u_to_dWp.inc
@@ -1,0 +1,34 @@
+template <>
+double CLASSNAME::get_partial_width<UpTypeQuark, DownTypeQuark, WpBoson>(
+   const context_base& context,
+   typename field_indices<UpTypeQuark>::type const& indexIn,
+   typename field_indices<DownTypeQuark>::type const& indexOut1,
+   typename field_indices<WpBoson>::type const& indexOut2) const
+{
+   const double mu = context.physical_mass<UpTypeQuark>(indexIn);
+   const double md = context.physical_mass<DownTypeQuark>(indexOut1);
+   const double mWp = context.physical_mass<WpBoson>(indexOut2);
+
+
+   const double ps = 1./(8.*Pi) * std::sqrt(KallenLambda(1., Sqr(md/mu), Sqr(mWp/mu)));
+
+   // matrix element squared
+   const auto mat_elem_sq = amplitude_squared<UpTypeQuark, DownTypeQuark, WpBoson>(
+      context, indexIn, indexOut1, indexOut2);
+
+   // flux * phase space factor * |matrix element|^2
+   double result = 0.5/mu * ps * mat_elem_sq;
+
+   // higher order corrections
+   if (flexibledecay_settings.get(FlexibleDecay_settings::include_higher_order_corrections)) {
+      // t -> b W^+
+      if(indexIn.at(0) == 2 && indexOut1.at(0) == 2) {
+         const double y = Sqr(mWp/mu);
+         static constexpr double CF = 4./3.;
+         result *= 1. + get_alphas(context)/(2.*Pi)*CF*Delta_tW(y);
+      }
+   }
+
+   return result;
+}
+

--- a/test/test_THDMII_FlexibleDecay.cpp
+++ b/test/test_THDMII_FlexibleDecay.cpp
@@ -338,3 +338,283 @@ Block UERMIX
    // Ah -> gamma Z
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_Ah_to_VPVZ(&m, 1), 5.4527502926727843e-07, 8e-12);
 }
+
+BOOST_AUTO_TEST_CASE( test_THDMII_FlexibleDecay_Fu )
+{
+
+  char const * const slha_input = R"(
+Block SPINFO
+     1   FlexibleSUSY
+     2   2.7.1
+     5   THDMII
+     9   4.14.5
+Block MODSEL                 # Select model
+#   12    1000                # parameter output scale (GeV)
+Block FlexibleSUSY
+    0   1.000000000e-04      # precision goal
+    1   0                    # max. iterations (0 = automatic)
+    2   0                    # algorithm (0 = all, 1 = two_scale, 2 = semi_analytic)
+    3   1                    # calculate SM pole masses
+    4   1                    # pole mass loop order
+    5   1                    # EWSB loop order
+    6   2                    # beta-functions loop order
+    7   2                    # threshold corrections loop order
+    8   0                    # Higgs 2-loop corrections O(alpha_t alpha_s)
+    9   0                    # Higgs 2-loop corrections O(alpha_b alpha_s)
+   10   0                    # Higgs 2-loop corrections O((alpha_t + alpha_b)^2)
+   11   0                    # Higgs 2-loop corrections O(alpha_tau^2)
+   12   0                    # force output
+   13   1                    # Top pole mass QCD corrections (0 = 1L, 1 = 2L, 2 = 3L)
+   14   1.000000000e-11      # beta-function zero threshold
+   15   0                    # calculate observables (a_muon, ...)
+   16   0                    # force positive majorana masses
+   17   0                    # pole mass renormalization scale (0 = SUSY scale)
+   18   0                    # pole mass renormalization scale in the EFT (0 = min(SUSY scale, Mt))
+   19   0                    # EFT matching scale (0 = SUSY scale)
+   20   2                    # EFT loop order for upwards matching
+   21   1                    # EFT loop order for downwards matching
+   22   0                    # EFT index of SM-like Higgs in the BSM model
+   23   1                    # calculate BSM pole masses
+   24   123111321            # individual threshold correction loop orders
+   25   0                    # ren. scheme for Higgs 3L corrections (0 = DR, 1 = MDR)
+   26   1                    # Higgs 3-loop corrections O(alpha_t alpha_s^2)
+   27   1                    # Higgs 3-loop corrections O(alpha_b alpha_s^2)
+   28   1                    # Higgs 3-loop corrections O(alpha_t^2 alpha_s)
+   29   1                    # Higgs 3-loop corrections O(alpha_t^3)
+   30   1                    # Higgs 4-loop corrections O(alpha_t alpha_s^3)
+   31   1                    # loop library (0 = softsusy)
+Block FlexibleSUSYInput
+    0   0.00729735           # alpha_em(0)
+    1   125.09               # Mh pole
+Block SMINPUTS               # Standard Model inputs
+    1   1.279340000e+02      # alpha^(-1) SM MSbar(MZ)
+    2   1.166378700e-05      # G_Fermi
+    3   1.176000000e-01      # alpha_s(MZ) SM MSbar
+    4   9.118760000e+01      # MZ(pole)
+    5   4.200000000e+00      # mb(mb) SM MSbar
+    6   1.733000000e+02      # mtop(pole)
+    7   1.777000000e+00      # mtau(pole)
+    8   0.000000000e+00      # mnu3(pole)
+   11   5.109989020e-04      # melectron(pole)
+   12   0.000000000e+00      # mnu1(pole)
+   13   1.056583570e-01      # mmuon(pole)
+   14   0.000000000e+00      # mnu2(pole)
+   21   4.750000000e-03      # md(2 GeV) MS-bar
+   22   2.400000000e-03      # mu(2 GeV) MS-bar
+   23   1.040000000e-01      # ms(2 GeV) MS-bar
+   24   1.270000000e+00      # mc(mc) MS-bar
+Block FlexibleDecay
+   0   1                    # calculate decays (0 = no, 1 = yes)
+   1   1e-5                 # minimum BR to print
+   2   4                    # include higher order corrections in decays (0 = LO, 1 = NLO, 2 = NNLO, 3 = N^3LO, 4 = N^4LO )
+   3   1                    # use Thomson alpha(0) instead of alpha(m) in decays to γγ and γZ
+   4   2                    # off-shell decays into VV pair
+Block MINPAR
+     1     1.00000000E+00   # Lambda1IN
+     2     1.00000000E-01   # Lambda2IN
+     3     1.00000000E-01   # Lambda3IN
+     4     1.40000000E+00   # Lambda4IN
+     5    -2.00000000E+00   # Lambda5IN
+     6     0.00000000E+00   # Lambda6IN
+     7     0.00000000E+00   # Lambda7IN
+     8     1.00000000E+03   # M122IN
+    10     1.00000000E+01   # TanBeta
+Block EXTPAR
+     0     1.26000000E+02   # Qin
+Block gauge Q= 1.26000000E+02
+     1     3.57963613E-01   # g1 * 0.7745966692414834
+     2     6.48747931E-01   # g2
+     3     1.18539599E+00   # g3
+Block Yu Q= 1.26000000E+02
+  1  1     7.76636978E-06   # Yu(1,1)
+  1  2     0.00000000E+00   # Yu(1,2)
+  1  3     0.00000000E+00   # Yu(1,3)
+  2  1     0.00000000E+00   # Yu(2,1)
+  2  2     3.55148848E-03   # Yu(2,2)
+  2  3     0.00000000E+00   # Yu(2,3)
+  3  1     0.00000000E+00   # Yu(3,1)
+  3  2     0.00000000E+00   # Yu(3,2)
+  3  3     9.63110908E-01   # Yu(3,3)
+Block Yd Q= 1.26000000E+02
+  1  1     1.53566618E-04   # Yd(1,1)
+  1  2     0.00000000E+00   # Yd(1,2)
+  1  3     0.00000000E+00   # Yd(1,3)
+  2  1     0.00000000E+00   # Yd(2,1)
+  2  2     3.36230088E-03   # Yd(2,2)
+  2  3     0.00000000E+00   # Yd(2,3)
+  3  1     0.00000000E+00   # Yd(3,1)
+  3  2     0.00000000E+00   # Yd(3,2)
+  3  3     1.59627385E-01   # Yd(3,3)
+Block Ye Q= 1.26000000E+02
+  1  1     2.87186679E-05   # Ye(1,1)
+  1  2     0.00000000E+00   # Ye(1,2)
+  1  3     0.00000000E+00   # Ye(1,3)
+  2  1     0.00000000E+00   # Ye(2,1)
+  2  2     5.93811047E-03   # Ye(2,2)
+  2  3     0.00000000E+00   # Ye(2,3)
+  3  1     0.00000000E+00   # Ye(3,1)
+  3  2     0.00000000E+00   # Ye(3,2)
+  3  3     9.98756154E-02   # Ye(3,3)
+Block HMIX Q= 1.26000000E+02
+    31     1.00000000E+00   # Lambda1
+    32     9.99999528E-02   # Lambda2
+    33     9.99999995E-02   # Lambda3
+    34     1.40000004E+00   # Lambda4
+    35    -2.00000006E+00   # Lambda5
+    36     0.00000000E+00   # Lambda6
+    37     0.00000000E+00   # Lambda7
+    20     2.21888336E+04   # M112
+    21    -7.82622452E+03   # M222
+    22     1.00000002E+03   # M122
+   102     2.48159126E+01   # v1
+   103     2.46705170E+02   # v2
+Block MASS
+        24     8.02713269E+01   # VWm
+        37     1.66774025E+02   # Hm(2)
+        25     9.80600789E+01   # hh(1)
+        35     1.33333796E+02   # hh(2)
+        36     3.67770623E+02   # Ah(2)
+        21     0.00000000E+00   # VG
+        12     0.00000000E+00   # Fv(1)
+        14     0.00000000E+00   # Fv(2)
+        16     0.00000000E+00   # Fv(3)
+         1     4.89579906E-03   # Fd(1)
+         3     9.41545026E-02   # Fd(2)
+         5     3.70600693E+00   # Fd(3)
+         2     2.54814161E-03   # Fu(1)
+         4     8.88799873E-01   # Fu(2)
+         6     1.72007218E+02   # Fu(3)
+        11     5.27930963E-04   # Fe(1)
+        13     1.07085887E-01   # Fe(2)
+        15     1.78254668E+00   # Fe(3)
+        22     0.00000000E+00   # VP
+        23     9.12503814E+01   # VZ
+Block PSEUDOSCALARMIX
+  1  1     9.61845774E-02   # ZA(1,1)
+  1  2     9.95363515E-01   # ZA(1,2)
+  2  1     9.95363515E-01   # ZA(2,1)
+  2  2    -9.61845774E-02   # ZA(2,2)
+Block SCALARMIX
+  1  1    -9.07933093E-01   # ZH(1,1)
+  1  2    -4.19115137E-01   # ZH(1,2)
+  2  1     4.19115137E-01   # ZH(2,1)
+  2  2    -9.07933093E-01   # ZH(2,2)
+Block CHARGEMIX
+  1  1     9.70756700E-02   # ZP(1,1)
+  1  2     9.95277004E-01   # ZP(1,2)
+  2  1     9.95277004E-01   # ZP(2,1)
+  2  2    -9.70756700E-02   # ZP(2,2)
+Block UULMIX
+  1  1     1.00000000E+00   # Re(Vu(1,1))
+  1  2     0.00000000E+00   # Re(Vu(1,2))
+  1  3     0.00000000E+00   # Re(Vu(1,3))
+  2  1     0.00000000E+00   # Re(Vu(2,1))
+  2  2     1.00000000E+00   # Re(Vu(2,2))
+  2  3     0.00000000E+00   # Re(Vu(2,3))
+  3  1     0.00000000E+00   # Re(Vu(3,1))
+  3  2     0.00000000E+00   # Re(Vu(3,2))
+  3  3     1.00000000E+00   # Re(Vu(3,3))
+Block UDLMIX
+  1  1     1.00000000E+00   # Re(Vd(1,1))
+  1  2     0.00000000E+00   # Re(Vd(1,2))
+  1  3     0.00000000E+00   # Re(Vd(1,3))
+  2  1     0.00000000E+00   # Re(Vd(2,1))
+  2  2     1.00000000E+00   # Re(Vd(2,2))
+  2  3     0.00000000E+00   # Re(Vd(2,3))
+  3  1     0.00000000E+00   # Re(Vd(3,1))
+  3  2     0.00000000E+00   # Re(Vd(3,2))
+  3  3     1.00000000E+00   # Re(Vd(3,3))
+Block UURMIX
+  1  1     1.00000000E+00   # Re(Uu(1,1))
+  1  2     0.00000000E+00   # Re(Uu(1,2))
+  1  3     0.00000000E+00   # Re(Uu(1,3))
+  2  1     0.00000000E+00   # Re(Uu(2,1))
+  2  2     1.00000000E+00   # Re(Uu(2,2))
+  2  3     0.00000000E+00   # Re(Uu(2,3))
+  3  1     0.00000000E+00   # Re(Uu(3,1))
+  3  2     0.00000000E+00   # Re(Uu(3,2))
+  3  3     1.00000000E+00   # Re(Uu(3,3))
+Block UDRMIX
+  1  1     1.00000000E+00   # Re(Ud(1,1))
+  1  2     0.00000000E+00   # Re(Ud(1,2))
+  1  3     0.00000000E+00   # Re(Ud(1,3))
+  2  1     0.00000000E+00   # Re(Ud(2,1))
+  2  2     1.00000000E+00   # Re(Ud(2,2))
+  2  3     0.00000000E+00   # Re(Ud(2,3))
+  3  1     0.00000000E+00   # Re(Ud(3,1))
+  3  2     0.00000000E+00   # Re(Ud(3,2))
+  3  3     1.00000000E+00   # Re(Ud(3,3))
+Block UELMIX
+  1  1     1.00000000E+00   # Re(Ve(1,1))
+  1  2     0.00000000E+00   # Re(Ve(1,2))
+  1  3     0.00000000E+00   # Re(Ve(1,3))
+  2  1     0.00000000E+00   # Re(Ve(2,1))
+  2  2     1.00000000E+00   # Re(Ve(2,2))
+  2  3     0.00000000E+00   # Re(Ve(2,3))
+  3  1     0.00000000E+00   # Re(Ve(3,1))
+  3  2     0.00000000E+00   # Re(Ve(3,2))
+  3  3     1.00000000E+00   # Re(Ve(3,3))
+Block UERMIX
+  1  1     1.00000000E+00   # Re(Ue(1,1))
+  1  2     0.00000000E+00   # Re(Ue(1,2))
+  1  3     0.00000000E+00   # Re(Ue(1,3))
+  2  1     0.00000000E+00   # Re(Ue(2,1))
+  2  2     1.00000000E+00   # Re(Ue(2,2))
+  2  3     0.00000000E+00   # Re(Ue(2,3))
+  3  1     0.00000000E+00   # Re(Ue(3,1))
+  3  2     0.00000000E+00   # Re(Ue(3,2))
+  3  3     1.00000000E+00   # Re(Ue(3,3))
+)";
+
+   std::stringstream istr(slha_input);
+
+   THDMII_slha_io slha_io;
+   slha_io.read_from_stream(istr);
+
+   softsusy::QedQcd qedqcd;
+   Physical_input physical_input;
+   THDMII_input_parameters input;
+   Spectrum_generator_settings settings;
+   FlexibleDecay_settings flexibledecay_settings;
+
+   // extract the input parameters from spectrum string
+   try {
+      slha_io.fill(settings);
+      slha_io.fill(qedqcd);
+      slha_io.fill(physical_input);
+      slha_io.fill(input);
+   } catch (const Error& error) {
+      BOOST_TEST_MESSAGE(error.what());
+      BOOST_TEST(false);
+   }
+
+   THDMII_slha m(input);
+   slha_io.fill(m);
+   m.calculate_DRbar_masses();
+   m.reorder_DRbar_masses();
+
+   // -----------------------------------------------------
+   // decays with higher-order SM corrections
+
+   THDMII_decays decays_with_HO(m, qedqcd, physical_input, flexibledecay_settings);
+
+   // t -> b W+
+   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Fu_to_FdconjVWm(&m, 2, 2),
+                              1.3126680510713284, 1e-15);
+   // t -> b H+
+   BOOST_CHECK_CLOSE_FRACTION(decays_with_HO.partial_width_Fu_to_FdconjHm(&m, 2, 2, 1),
+                              0.0002547752608001567, 1e-15);
+
+   // -----------------------------------------------------
+   // decays without higher-order SM corrections
+
+   flexibledecay_settings.set(FlexibleDecay_settings::include_higher_order_corrections, 0.0);
+   THDMII_decays decays_without_HO(m, qedqcd, physical_input, flexibledecay_settings);
+
+   // t -> b W+
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_Fu_to_FdconjVWm(&m, 2, 2),
+                              1.4497611564261081, 1e-15);
+   // t -> b H+
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_Fu_to_FdconjHm(&m, 2, 2, 1),
+                              0.0002434754566083071, 1e-15);
+}


### PR DESCRIPTION
Add higher order corrections to $t$ decays. This will be useful for #446 but is independent of it so can be moved to a separate PR.

Notes:

- [ ] do 1-loop SM QCD correction to $t \to b H^+$ lack an $\overline{\text{MS}} \to$  OS conversion terms $2 \alpha_s C_F (3 \ln \frac{\mu^2}{m_t^2} + 4)$?