### PR TITLE
HiggsTools only builds a shared library

### DIFF
--- a/configure
+++ b/configure
@@ -2211,12 +2211,12 @@ check_higgstools_libs() {
                 # assume that the linker will look in the default paths
                 HIGGSTOOLSLIBS="-L$higgstools_lib_dir -Wl,-rpath,$higgstools_lib_dir,-Bdynamic $HIGGSTOOLSLIBS_"
             fi
-       else
-	        message "Error: Cannot identify the type (static or shared) of"
-	        message "       HiggsTools library."
-	        exit 1
-	    fi
-       return 0
+        else
+	         message "Error: Cannot identify the type (static or shared) of"
+	         message "       HiggsTools library."
+	         exit 1
+	     fi
+        return 0
     fi
     return 0
 }

--- a/configure
+++ b/configure
@@ -2199,7 +2199,7 @@ check_higgstools_libs() {
                 # assume that the linker will look in the default paths
                 HIGGSTOOLSLIBS="-L$higgstools_lib_dir -Wl,-rpath,$higgstools_lib_dir,-Bstatic $HIGGSTOOLSLIBS_ -Wl,-Bdynamic"
             fi
-        elif [ "$extension" = "so" ] ; then
+        elif [ "$extension" = "so" ] || [ "$extension" = "dylib" ]; then
             if [ "x$enable_static" = xyes ] ; then
                message "Warning: Requested creation of statically link executable but"
                message "         HiggsTools was compiled as a shared library."

--- a/configure
+++ b/configure
@@ -2190,10 +2190,10 @@ check_higgstools_libs() {
         local HIGGSTOOLSLIBS_="-lHiggsTools"
         if [ -z "$higgstools_lib_dir" ]; then
             # assume that the linker will look in the default paths
-            HIGGSTOOLSLIBS="$HIGGSTOOLSLIBS_"
+            HIGGSTOOLSLIBS="-Wl,-Bdynamic -$HIGGSTOOLSLIBS_"
         else
             # assume that the linker will look in the default paths
-            HIGGSTOOLSLIBS="-L$higgstools_lib_dir -Wl,-rpath,$higgstools_lib_dir $HIGGSTOOLSLIBS_"
+            HIGGSTOOLSLIBS="-L$higgstools_lib_dir -Wl,-rpath,$higgstools_lib_dir,-Bdynamic $HIGGSTOOLSLIBS_"
         fi
         return 0
     fi

--- a/configure
+++ b/configure
@@ -2187,14 +2187,35 @@ check_higgstools_libs() {
             return 1
         fi
     else
+        local filename
+        filename=$(basename -- "$found_lib")
+        local extension="${filename##*.}"
         local HIGGSTOOLSLIBS_="-lHiggsTools"
-        if [ -z "$higgstools_lib_dir" ]; then
-            # assume that the linker will look in the default paths
-            HIGGSTOOLSLIBS="-Wl,-Bdynamic -$HIGGSTOOLSLIBS_"
-        else
-            # assume that the linker will look in the default paths
-            HIGGSTOOLSLIBS="-L$higgstools_lib_dir -Wl,-rpath,$higgstools_lib_dir,-Bdynamic $HIGGSTOOLSLIBS_"
-        fi
+        if [ "$extension" = "a" ] ; then
+            if [ -z "$higgstools_lib_dir" ]; then
+                # assume that the linker will look in the default paths
+                HIGGSTOOLSLIBS="-Wl,-Bstatic -$HIGGSTOOLSLIBS_ -Wl,-Bdynamic"
+            else
+                # assume that the linker will look in the default paths
+                HIGGSTOOLSLIBS="-L$higgstools_lib_dir -Wl,-rpath,$higgstools_lib_dir,-Bstatic $HIGGSTOOLSLIBS_ -Wl,-Bdynamic"
+            fi
+	    elif [ "$extension" = "so" ] ; then
+            if [ "x$enable_static" = xyes ] ; then
+	            message "Warning: Requested creation of statically link executable but"
+		        message "         HiggsTools was compiled as a shared library."
+	        fi
+	        if [ -z "$higgstools_lib_dir" ]; then
+                # assume that the linker will look in the default paths
+                HIGGSTOOLSLIBS="-Wl,-Bdynamic -$HIGGSTOOLSLIBS_"
+            else
+                # assume that the linker will look in the default paths
+                HIGGSTOOLSLIBS="-L$higgstools_lib_dir -Wl,-rpath,$higgstools_lib_dir,-Bdynamic $HIGGSTOOLSLIBS_"
+            fi
+	    else
+	        message "Error: Cannot identify the type (static or shared) of"
+	        message "       HiggsTools library."
+	        exit 1
+	    fi
         return 0
     fi
     return 0

--- a/configure
+++ b/configure
@@ -2199,24 +2199,24 @@ check_higgstools_libs() {
                 # assume that the linker will look in the default paths
                 HIGGSTOOLSLIBS="-L$higgstools_lib_dir -Wl,-rpath,$higgstools_lib_dir,-Bstatic $HIGGSTOOLSLIBS_ -Wl,-Bdynamic"
             fi
-	    elif [ "$extension" = "so" ] ; then
+        elif [ "$extension" = "so" ] ; then
             if [ "x$enable_static" = xyes ] ; then
-	            message "Warning: Requested creation of statically link executable but"
-		        message "         HiggsTools was compiled as a shared library."
-	        fi
-	        if [ -z "$higgstools_lib_dir" ]; then
+               message "Warning: Requested creation of statically link executable but"
+               message "         HiggsTools was compiled as a shared library."
+	         fi
+            if [ -z "$higgstools_lib_dir" ]; then
                 # assume that the linker will look in the default paths
                 HIGGSTOOLSLIBS="-Wl,-Bdynamic -$HIGGSTOOLSLIBS_"
             else
                 # assume that the linker will look in the default paths
                 HIGGSTOOLSLIBS="-L$higgstools_lib_dir -Wl,-rpath,$higgstools_lib_dir,-Bdynamic $HIGGSTOOLSLIBS_"
             fi
-	    else
+       else
 	        message "Error: Cannot identify the type (static or shared) of"
 	        message "       HiggsTools library."
 	        exit 1
 	    fi
-        return 0
+       return 0
     fi
     return 0
 }


### PR DESCRIPTION
I'll ask Henning to be sure but I think that HiggsTools only builds shared library. This PR fixes the problem even if we compile FS into static library. Ideally, I would like to switch back to static
```
-Wl,-Bdynamic -lHiggsTools -Wl,Bstatic"
```
if we are building static library but I cannot. After this library there are others which have to be linked dynamically
```
clang++ -static -o models/SM/run_SM.x  /tmp/FS/models/SM/run_SM.o  /tmp/FS/models/SM/libSM.a  /tmp/FS/model_specific/SM/libmodel_specific_SM.a  /tmp/FS/src/libflexisusy.a  /tmp/FS/src/loop_libraries/libcollier_wrapper.a  /tmp/FS/src/libfortran_utils.a -L/home/kotlarskiw/HEP-software/COLLIER-1.2.7/lib -Wl,-rpath,/home/kotlarskiw/HEP-software/COLLIER-1.2.7/lib -lcollier  -L/home/kotlarskiw/HEP-software/HiggsTools-1.0/lib -Wl,-rpath,/home/kotlarskiw/HEP-software/HiggsTools-1.0/lib,-Bdynamic -lHiggsTools  -L/usr/lib/x86_64-linux-gnu -lgsl -lgslcblas -lm -lsqlite3  -L/usr/lib/gcc/x86_64-linux-gnu/10/ -lgfortran -lm -Wl,--push-state,-z,muldefs,--whole-archive -lpthread -Wl,--pop-state -lquadmath -ldl /tmp/FS/src/libfortran_utils.a
```
but they don't switch to `-Bdynamic` themselves.