### PR TITLE
optimize creation of decay process name

### DIFF
--- a/src/decays/decay.cpp
+++ b/src/decays/decay.cpp
@@ -54,11 +54,11 @@ std::size_t hash_decay(const Decay& decay)
 }
 
 Decay::Decay(
-   int pid_in_, std::initializer_list<int> pids_out_, double width_, std::string const& proc_string_)
-   : pid_in(pid_in_)
-   , pids_out(pids_out_)
-   , width(width_)
-   , proc_string(proc_string_)
+   int pid_in_, std::initializer_list<int> pids_out_, double width_, std::string&& proc_string_)
+   : pid_in{pid_in_}
+   , pids_out{pids_out_}
+   , width{width_}
+   , proc_string{std::move(proc_string_)}
 {
    std::sort(pids_out.begin(), pids_out.end());
 }
@@ -74,9 +74,9 @@ void Decays_list::clear()
    total_width = 0.;
 }
 
-void Decays_list::set_decay(double width, std::initializer_list<int> pids_out, std::string const& proc_string)
+void Decays_list::set_decay(double width, std::initializer_list<int> pids_out, std::string&& proc_string)
 {
-   const Decay decay(initial_pdg, pids_out, width, proc_string);
+   const Decay decay(initial_pdg, pids_out, width, std::move(proc_string));
    const auto decay_hash = hash_decay(decay);
 
    const auto pos = decays.find(decay_hash);

--- a/src/decays/decay.cpp
+++ b/src/decays/decay.cpp
@@ -53,16 +53,6 @@ std::size_t hash_decay(const Decay& decay)
    return hash_pid_list(pid_in, pids_out);
 }
 
-Decay::Decay(
-   int pid_in_, std::initializer_list<int> pids_out_, double width_, std::string&& proc_string_)
-   : pid_in{pid_in_}
-   , pids_out{pids_out_}
-   , width{width_}
-   , proc_string{std::move(proc_string_)}
-{
-   std::sort(pids_out.begin(), pids_out.end());
-}
-
 Decays_list::Decays_list(int initial_pdg_)
    : initial_pdg(initial_pdg_)
 {
@@ -72,27 +62,6 @@ void Decays_list::clear()
 {
    decays.clear();
    total_width = 0.;
-}
-
-void Decays_list::set_decay(double width, std::initializer_list<int> pids_out, std::string&& proc_string)
-{
-   const Decay decay(initial_pdg, pids_out, width, std::move(proc_string));
-   const auto decay_hash = hash_decay(decay);
-
-   const auto pos = decays.find(decay_hash);
-   if (pos != std::end(decays)) {
-      total_width -= pos->second.get_width();
-      pos->second.set_width(width);
-   } else {
-      decays.insert(pos, std::make_pair(decay_hash, decay));
-   }
-
-   // some channels give small negative withs
-   // we later check if for channels with width < 0
-   // |width/total_width| < threshold
-   // for that it makes more sense to calculate total_width
-   // as the sum of |width|
-   total_width += std::abs(width);
 }
 
 const Decay& Decays_list::get_decay(

--- a/src/decays/decay.hpp
+++ b/src/decays/decay.hpp
@@ -33,7 +33,17 @@ namespace flexiblesusy {
 
 class Decay {
 public:
-   Decay(int, std::initializer_list<int>, double, std::string&&);
+
+template <typename T>
+   Decay(
+      int pid_in_, std::initializer_list<int> pids_out_, double width_, T&& proc_string_)
+      : pid_in{pid_in_}
+      , pids_out{pids_out_}
+      , width{width_}
+      , proc_string{std::forward<T>(proc_string_)}
+   {
+      std::sort(pids_out.begin(), pids_out.end());
+   }
    ~Decay() = default;
    Decay(const Decay&) = default;
    Decay(Decay&&) = default;
@@ -84,7 +94,29 @@ public:
    std::size_t size() const noexcept { return decays.size(); }
 
    void clear();
-   void set_decay(double width, std::initializer_list<int> products, std::string&&);
+
+   template <typename T>
+   void set_decay(double width, std::initializer_list<int> pids_out, T&& proc_string)
+   {
+      const Decay decay(initial_pdg, pids_out, width, std::forward<T>(proc_string));
+      const auto decay_hash = hash_decay(decay);
+
+      const auto pos = decays.find(decay_hash);
+      if (pos != std::end(decays)) {
+         total_width -= pos->second.get_width();
+         pos->second.set_width(width);
+      } else {
+         decays.insert(pos, std::make_pair(decay_hash, decay));
+      }
+
+      // some channels give small negative withs
+      // we later check if for channels with width < 0
+      // |width/total_width| < threshold
+      // for that it makes more sense to calculate total_width
+      // as the sum of |width|
+      total_width += std::abs(width);
+   }
+
    int get_particle_id() const { return initial_pdg; }
    const Decay& get_decay(std::initializer_list<int> products) const;
    double get_total_width() const { return total_width; }

--- a/src/decays/decay.hpp
+++ b/src/decays/decay.hpp
@@ -33,7 +33,7 @@ namespace flexiblesusy {
 
 class Decay {
 public:
-   Decay(int, std::initializer_list<int>, double, std::string const&);
+   Decay(int, std::initializer_list<int>, double, std::string&&);
    ~Decay() = default;
    Decay(const Decay&) = default;
    Decay(Decay&&) = default;
@@ -84,7 +84,7 @@ public:
    std::size_t size() const noexcept { return decays.size(); }
 
    void clear();
-   void set_decay(double width, std::initializer_list<int> products, std::string const&);
+   void set_decay(double width, std::initializer_list<int> products, std::string&&);
    int get_particle_id() const { return initial_pdg; }
    const Decay& get_decay(std::initializer_list<int> products) const;
    double get_total_width() const { return total_width; }


### PR DESCRIPTION
One thing that I'm still trying to figure out is whether
```cpp
A::A(T&& x) : x_{x} {}
```
is enough or does one have to explicitly call `std::move`
```cpp
A::A(T&& x) : x_{std::move(x)} {}
```