### PR TITLE
wrong masses in the non-decoupling scheme

### DIFF
--- a/meta/Decays.m
+++ b/meta/Decays.m
@@ -914,8 +914,7 @@ CreateDecaysCalculationFunction[decaysList_] :=
                  CConversion`ToValidCSymbolString[TreeMasses`GetMass[particle /. SARAH`bar|Susyno`LieGroups`conj->Identity]] <> ");\n" <>
                  "if (decay_mass" <> If[particleDim > 1, "(gI1)", ""] <> " > qedqcd.displayPoleMZ()) {\n" <>
                  TextFormatting`IndentText[
-                    "model.run_to(decay_mass" <> If[particleDim > 1, "(gI1)", ""] <>  ");\n" <>
-                    "model.solve_ewsb();\n"
+                    "model.run_to(decay_mass" <> If[particleDim > 1, "(gI1)", ""] <>  ");\n"
                  ] <> "}\n";
 
            body = StringJoin[CallPartialWidthCalculation /@ decayChannels];
@@ -956,6 +955,8 @@ CreateDecaysCalculationFunction[decaysList_] :=
                  "}\n" <>
                  "case 2: {\n" <>
                  TextFormatting`IndentText[
+                    "model.solve_ewsb_tree_level();\n" <>
+                    "model.calculate_DRbar_masses();\n" <>
                     "// decoupling scheme automatically reorders Goldstones to first\n" <>
                     "// positions in tree-level mass and mixing matrices. The\n" <>
                     "// non-decoupled model does not.\n" <>


### PR DESCRIPTION
I think there is a problem with the second branch of this `switch` statement
```cpp
   if (run_to_decay_particle_scale) {
      auto decay_mass = PHYSICAL(Mhh);
      if (decay_mass > qedqcd.displayPoleMZ()) {
         model.run_to(decay_mass);
         model.solve_ewsb();
      }
   }

   const int flag = 1;
   auto dec_model = [&] () -> std::unique_ptr<SM_mass_eigenstates_interface> {
      switch (flag) {
         case 1: {
            auto dm = std::make_unique<SM_mass_eigenstates_decoupling_scheme>(
               model.get_input());
            // fill_from BSM model has to be called before fill_from SM
            // both calls are required
            dm->fill_from(model);
            standard_model::Standard_model sm{};
            sm.initialise_from_input(qedqcd);
            // set loop level for RGE running to match RGE setting
            // of BSM model
            sm.set_loops(model.get_loops());
            if (run_to_decay_particle_scale) {
               auto decay_mass = PHYSICAL(Mhh);
               if (decay_mass > qedqcd.displayPoleMZ()) {
                  sm.run_to(decay_mass);
               }
            }
            sm.solve_ewsb_tree_level();
            sm.calculate_DRbar_masses();
            dm->fill_from(sm);
            return dm;
            break;
         }
         case 2: {
            // decoupling scheme automatically reorders Goldstones to first
            // positions in tree-level mass and mixing matrices. The
            // non-decoupled model does not.
            model.reorder_DRbar_masses();
            return std::make_unique<SM_mass_eigenstates>(model);
            break;
         }
         default:
            throw SetupError("flag value is not supported");
      }
   }();
```
In this case the `DRbar` masses are not recalculated after running to `decay_mass` scale and since I've written `solve_ewsb()` in the `if` statement, I think that vertices use 1-loop corrected vevs. Since for `flag = 1` we solve ewsb internally anyway, I've modified the first `if` to
```cpp
   if (run_to_decay_particle_scale) {
      auto decay_mass = PHYSICAL(Mhh);
      if (decay_mass > qedqcd.displayPoleMZ()) {
         model.run_to(decay_mass);
      }
   }
```
and tweaked `case 2` as
```cpp
         case 2: {
            model.solve_ewsb_tree_level();
            model.calculate_DRbar_masses();
            // decoupling scheme automatically reorders Goldstones to first
            // positions in tree-level mass and mixing matrices. The
            // non-decoupled model does not.
            model.reorder_DRbar_masses();
            return std::make_unique<SM_mass_eigenstates>(model);
            break;
         }
```