### PR TITLE
missing entry 10 in HMIX block

### DIFF
--- a/model_files/MRSSM2/FlexibleSUSY.m.in
+++ b/model_files/MRSSM2/FlexibleSUSY.m.in
@@ -98,6 +98,23 @@ ExtraSLHAOutputBlocks = {
          {26, FlexibleSUSYObservable`BrLToLGamma[Fe[2] -> {Fe[1], VP}]},
          {27, FlexibleSUSYObservable`AMMUncertainty[Fe[2]]}
       }
+   },
+   {HMIX, {
+         {1,   \[Mu]},
+         {10,  ArcTan[vu/vd]},
+         {101, B[\[Mu]]},
+         {102, vd},
+         {103, vu},
+         {310, vT},
+         {201, MuD},
+         {202, MuU},
+         {203, B[MuD]},
+         {204, B[MuU]},
+         {301, LamSD},
+         {302, LamSU},
+         {303, LamTD},
+         {304, LamTU}
+      }
    }
 };
 


### PR DESCRIPTION
This PR adds an extra entry (number 10) to the `HMIX` block in the `MRSSM2`. Other entries will be identical to an autogenerated `HMIX` block. This entry is needed to pass spectrum file to CalcHEP.