### PR TITLE
print EFFHIGGSCOUPLINGS block

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,11 @@ New features
 
   Thanks to Felix Reichenbach and Alexander Voigt.
 
+* SLHA output now includes the `EFFHIGGSCOUPLINGS` block containing
+  loop-induced couplings of neutral Higgses. This block can be used by a SARAH
+  generated UFO and CalcHEP models (the latter one being also used by
+  micrOMEGAs).
+
 Fixed bugs
 ----------
 

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -2725,11 +2725,14 @@ const bool show_decays = !decays.get_problems().have_problem() ||
 if (show_decays && flexibledecay_settings.get(FlexibleDecay_settings::calculate_decays) && loop_library_for_decays) {
    slha_io.set_dcinfo(decays.get_problems());
    slha_io.set_decays(decays.get_decay_table(), flexibledecay_settings);
+   if (flexibledecay_settings.get(FlexibleDecay_settings::print_effc_block)) {
+      slha_io.set_effectivecouplings_block(decays.get_effhiggscouplings_block_input());
+   }
 }";
 
 ExampleCalculateCmdLineDecays[] :=
-FlexibleSUSY`FSModelName <> "_decays decays;" <>
-"decays = " <> FlexibleSUSY`FSModelName <> "_decays(std::get<0>(models), qedqcd, physical_input, flexibledecay_settings);
+FlexibleSUSY`FSModelName <> "_decays decays " <>
+"= " <> FlexibleSUSY`FSModelName <> "_decays(std::get<0>(models), qedqcd, physical_input, flexibledecay_settings);
 const bool loop_library_for_decays =
    (Loop_library::get_type() == Loop_library::Library::Collier) ||
    (Loop_library::get_type() == Loop_library::Library::Looptools);

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -2798,6 +2798,10 @@ WriteUserExample[inputParameters_List, files_List] :=
       spectrum_generator_settings.set(
          Spectrum_generator_settings::calculate_bsm_masses, 1.0);
    }
+   if (flexibledecay_settings.get(FlexibleDecay_settings::print_effc_block) && " <> FlexibleSUSY`FSModelName <> "_info::is_CP_violating_Higgs_sector) {
+      WARNING(\"Printing of EFFHIGGSCOUPLINGS block is disabled in models with CP-violating Higgs sector\");
+      flexibledecay_settings.set(FlexibleDecay_settings::print_effc_block, 0.);
+   }
 }",
               fillSLHAIO = "slha_io.fill(models, qedqcd, scales, observables, settings, flexibledecay_settings);"
              ];

--- a/src/always_false.hpp
+++ b/src/always_false.hpp
@@ -1,0 +1,30 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+#ifndef ALWAYS_FALSE_H
+#define ALWAYS_FALSE_H
+
+namespace flexiblesusy {
+
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2593r0.html
+template <typename... T>
+constexpr bool always_false = false;
+
+} // namespace flexiblesusy
+
+#endif

--- a/src/decays/decay.hpp
+++ b/src/decays/decay.hpp
@@ -27,6 +27,7 @@
 #include <boost/core/demangle.hpp>
 #include <boost/range/algorithm/equal.hpp>
 
+#include "always_false.hpp"
 #include "cxx_qft/fields.hpp"
 
 namespace flexiblesusy {
@@ -134,18 +135,17 @@ std::string strip_field_namespace(std::string const&);
 
 template<typename Field>
 std::string field_as_string(std::array<int, Field::numberOfFieldIndices> const& idx) {
-   auto vector_to_idx = [](auto v) {
-      if (v.empty()) {
-         return std::string();
-      }
-      else {
-         // in the output we count particles from 1 (not 0)
-         return "(" + std::to_string(v[0]+1) + ")";
-      }
-   };
-
-   using boost::core::demangle;
-   return strip_field_namespace(demangle(typeid(Field).name())) + vector_to_idx(idx);
+   const std::string field = strip_field_namespace(boost::core::demangle(typeid(Field).name()));
+   if constexpr (Field::numberOfFieldIndices == 0) {
+      return field;
+   }
+   else if constexpr (Field::numberOfFieldIndices == 1) {
+      // in the output we count particles from 1 (not 0)
+      return field + "(" + std::to_string(idx[0]+1) + ")";
+   }
+   else {
+      static_assert(always_false<Field>, "Field is expected to have 0 or 1 index");
+   }
 }
 
 template<typename FieldIn, typename FieldOut1, typename FieldOut2>
@@ -154,27 +154,12 @@ std::string create_process_string(
       std::array<int, FieldOut1::numberOfFieldIndices> const out1,
       std::array<int, FieldOut2::numberOfFieldIndices> const out2) {
 
-   auto vector_to_idx = [](auto v) {
-      if (v.empty()) {
-         return std::string();
-      }
-      else {
-         // in the output we count particles from 1 (not 0)
-         return "(" + std::to_string(v[0]+1) + ")";
-      }
-   };
-
-   using boost::core::demangle;
    std::string process_string =
       field_as_string<FieldIn>(in) + " -> " +
       field_as_string<FieldOut1>(out1) + " " + field_as_string<FieldOut2>(out2);
 
    return process_string;
 }
-
-// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2593r0.html
-template <typename... T>
-constexpr bool always_false = false;
 
 // returns a squared color generator for a 3 point amplitude with FieldIn, FieldOut1 and FieldOut2
 // averaged over inital state colors

--- a/src/decays/decay.hpp
+++ b/src/decays/decay.hpp
@@ -132,6 +132,22 @@ std::vector<Decay> sort_decays_list(const Decays_list&);
 
 std::string strip_field_namespace(std::string const&);
 
+template<typename Field>
+std::string field_as_string(std::array<int, Field::numberOfFieldIndices> const& idx) {
+   auto vector_to_idx = [](auto v) {
+      if (v.empty()) {
+         return std::string();
+      }
+      else {
+         // in the output we count particles from 1 (not 0)
+         return "(" + std::to_string(v[0]+1) + ")";
+      }
+   };
+
+   using boost::core::demangle;
+   return strip_field_namespace(demangle(typeid(Field).name())) + vector_to_idx(idx);
+}
+
 template<typename FieldIn, typename FieldOut1, typename FieldOut2>
 std::string create_process_string(
       std::array<int, FieldIn::numberOfFieldIndices> const in,
@@ -150,10 +166,8 @@ std::string create_process_string(
 
    using boost::core::demangle;
    std::string process_string =
-         strip_field_namespace(demangle(typeid(FieldIn).name())) + vector_to_idx(in)
-         + " -> " +
-         strip_field_namespace(demangle(typeid(FieldOut1).name())) + vector_to_idx(out1) + " " +
-         strip_field_namespace(demangle(typeid(FieldOut2).name())) + vector_to_idx(out2);
+      field_as_string<FieldIn>(in) + " -> " +
+      field_as_string<FieldOut1>(out1) + " " + field_as_string<FieldOut2>(out2);
 
    return process_string;
 }

--- a/src/decays/flexibledecay_settings.cpp
+++ b/src/decays/flexibledecay_settings.cpp
@@ -33,6 +33,7 @@ const std::array<std::string, FlexibleDecay_settings::NUMBER_OF_OPTIONS> descrip
    "include higher order corrections in decays",
    "use Thomson alpha(0) instead of alpha(m) in decays to γγ and γZ",
    "off-shell decays into VV pair",
+   "print EFFHIGGSCOUPLINGS block"
 };
 
 bool is_integer(double value)
@@ -125,6 +126,8 @@ void FlexibleDecay_settings::set(Settings o, double value)
       assert_ge(value, 0, descriptions.at(o).c_str());
       assert_le(value, 2, descriptions.at(o).c_str());
       break;
+   case print_effc_block: // 1 [bool]
+      assert_bool(value, descriptions.at(o).c_str());
    default:
       break;
    }
@@ -152,6 +155,7 @@ void FlexibleDecay_settings::reset()
    values[include_higher_order_corrections] = 4.0;
    values[use_Thomson_alpha_in_Phigamgam_and_PhigamZ] = 1.0;
    values[offshell_VV_decays]               = 2.0;
+   values[print_effc_block]                 = 1.0;
 }
 bool is_integer(double value)
 {

--- a/src/decays/flexibledecay_settings.cpp
+++ b/src/decays/flexibledecay_settings.cpp
@@ -150,12 +150,12 @@ void FlexibleDecay_settings::set(const FlexibleDecay_settings::Settings_t& s)
  */
 void FlexibleDecay_settings::reset()
 {
-   values[calculate_decays]                 = 1.0;
-   values[min_br_to_print]                  = 1e-5;
-   values[include_higher_order_corrections] = 4.0;
+   values[calculate_decays]                           = 1.0;
+   values[min_br_to_print]                            = 1e-5;
+   values[include_higher_order_corrections]           = 4.0;
    values[use_Thomson_alpha_in_Phigamgam_and_PhigamZ] = 1.0;
-   values[offshell_VV_decays]               = 2.0;
-   values[print_effc_block]                 = 1.0;
+   values[offshell_VV_decays]                         = 2.0;
+   values[print_effc_block]                           = 0.0;
 }
 bool is_integer(double value)
 {

--- a/src/decays/flexibledecay_settings.hpp
+++ b/src/decays/flexibledecay_settings.hpp
@@ -28,12 +28,13 @@ class FlexibleDecay_settings {
 public:
    /// FlexibleDecay settings
    enum Settings : int {
-      calculate_decays,      ///< [0] calculate particle decays
-      min_br_to_print,       ///< [1]
-      include_higher_order_corrections, ///< [2] include higher order corrections in decays
+      calculate_decays,                           ///< [0] calculate particle decays
+      min_br_to_print,                            ///< [1]
+      include_higher_order_corrections,           ///< [2] include higher order corrections in decays
       use_Thomson_alpha_in_Phigamgam_and_PhigamZ, ///< [3]
-      offshell_VV_decays,    ///< [4]
-      NUMBER_OF_OPTIONS      ///< number of possible options
+      offshell_VV_decays,                         ///< [4]
+      print_effc_block,                           ///< [1]
+      NUMBER_OF_OPTIONS                           ///< number of possible options
    };
 
    using Settings_t = Eigen::Array<double,NUMBER_OF_OPTIONS,1>;

--- a/src/decays/specializations/Ah/decay_Ah_to_AA.inc
+++ b/src/decays/specializations/Ah/decay_Ah_to_AA.inc
@@ -23,5 +23,15 @@ double CLASSNAME::get_partial_width<PseudoscalarHiggs, Photon, Photon>(
       res *= Sqr(alpha_em_0/alpha_em);
    }
 
+   if (flexibledecay_settings.get(FlexibleDecay_settings::print_effc_block)) {
+      effhiggscouplings_block_input.push_back(
+         {
+            36 + 10*(in_idx.size()>0 ? in_idx.at(0)-1 : 0), 22, 22,
+            std::sqrt(res/(flux * ps * ps_symmetry)/(0.5*Power4(mAh))),
+            field_as_string<PseudoscalarHiggs>(in_idx) + "-" + field_as_string<Photon>(out1_idx) + "-" + field_as_string<Photon>(out2_idx)
+         }
+      );
+   }
+
    return res;
 }

--- a/src/decays/specializations/Ah/decay_Ah_to_AZ.inc
+++ b/src/decays/specializations/Ah/decay_Ah_to_AZ.inc
@@ -23,5 +23,14 @@ double CLASSNAME::get_partial_width<PseudoscalarHiggs, Photon, ZBoson>(
       res *= alpha_em_0/alpha_em;
    }
 
+   if (flexibledecay_settings.get(FlexibleDecay_settings::print_effc_block)) {
+      effhiggscouplings_block_input.push_back(
+         {
+            36 + 10*(in_idx.size()>0 ? in_idx.at(0) : 0), 22, 23, res,
+            field_as_string<PseudoscalarHiggs>(in_idx) + "-" + field_as_string<Photon>(out1_idx) + "-" + field_as_string<ZBoson>(out2_idx)
+         }
+      );
+   }
+
    return res;
 }

--- a/src/decays/specializations/Ah/decay_Ah_to_gg.inc
+++ b/src/decays/specializations/Ah/decay_Ah_to_gg.inc
@@ -77,5 +77,15 @@ double CLASSNAME::get_partial_width<PseudoscalarHiggs, Gluon, Gluon>(
       result += pseudoscalar_corr;
    }
 
+   if (flexibledecay_settings.get(FlexibleDecay_settings::print_effc_block)) {
+      effhiggscouplings_block_input.push_back(
+         {
+            36 + 10*(in_idx.size()>0 ? in_idx.at(0)-1 : 0), 21, 21,
+            std::sqrt(result/(flux * color_fact * ps * ps_symmetry)/(0.5*Power4(mAh))),
+            field_as_string<PseudoscalarHiggs>(in_idx) + "-" + field_as_string<Gluon>(out1_idx) + "-" + field_as_string<Gluon>(out2_idx)
+         }
+      );
+   }
+
    return result;
 }

--- a/src/decays/specializations/H/decay_H_to_AA.inc
+++ b/src/decays/specializations/H/decay_H_to_AA.inc
@@ -19,5 +19,15 @@ double CLASSNAME::get_partial_width<Higgs, Photon, Photon>(
       res *= Sqr(alpha_em_0/alpha_em);
    }
 
+   if (flexibledecay_settings.get(FlexibleDecay_settings::print_effc_block)) {
+      effhiggscouplings_block_input.push_back(
+         {
+            25 + 10*(in_idx.size()>0 ? in_idx.at(0) : 0), 22, 22,
+            std::sqrt(res/(flux * ps * ps_symmetry)/(0.5*Power4(mH))),
+            field_as_string<Higgs>(in_idx) + "-" + field_as_string<Photon>(out1_idx) + "-" + field_as_string<Photon>(out2_idx)
+         }
+      );
+   }
+
    return res;
 }

--- a/src/decays/specializations/H/decay_H_to_AZ.inc
+++ b/src/decays/specializations/H/decay_H_to_AZ.inc
@@ -19,5 +19,15 @@ double CLASSNAME::get_partial_width<Higgs, Photon, ZBoson>(
       res *= alpha_em_0/alpha_em;
    }
 
+   if (flexibledecay_settings.get(FlexibleDecay_settings::print_effc_block)) {
+      effhiggscouplings_block_input.push_back(
+         {
+            25 + 10*(in_idx.size()>0 ? in_idx.at(0) : 0), 22, 23,
+            std::sqrt(res/(flux * ps)/(0.5*Sqr(Sqr(mH)-Sqr(mZ)))),
+            field_as_string<Higgs>(in_idx) + "-" + field_as_string<Photon>(out1_idx) + "-" + field_as_string<ZBoson>(out2_idx)
+         }
+      );
+   }
+
    return res;
 }

--- a/src/decays/specializations/H/decay_H_to_gg.inc
+++ b/src/decays/specializations/H/decay_H_to_gg.inc
@@ -155,6 +155,16 @@ double CLASSNAME::get_partial_width<Higgs, Gluon, Gluon>(
       }
    }
 
+   if (flexibledecay_settings.get(FlexibleDecay_settings::print_effc_block)) {
+      effhiggscouplings_block_input.push_back(
+         {
+            25 + 10*(in_idx.size()>0 ? in_idx.at(0) : 0), 21, 21,
+            std::sqrt(result/(flux * color_fact * ps * ps_symmetry)/(0.5*Power4(mH))),
+            field_as_string<Higgs>(in_idx) + "-" + field_as_string<Gluon>(out1_idx) + "-" + field_as_string<Gluon>(out2_idx)
+         }
+      );
+   }
+
    return result;
 }
 

--- a/src/module.mk
+++ b/src/module.mk
@@ -66,6 +66,7 @@ LIBFLEXI_SRC := \
 		$(DIR)/zeta.cpp
 
 LIBFLEXI_HDR := \
+		$(DIR)/always_false.hpp \
 		$(DIR)/amm_loop_functions.hpp \
 		$(DIR)/array_view.hpp \
 		$(DIR)/basic_rk_integrator.hpp \

--- a/src/slha_format.cpp
+++ b/src/slha_format.cpp
@@ -40,5 +40,7 @@ const char * const spinfo_formatter = " %5d   %s\n";
 const char * const obsinfo_formatter = " %5d %5d   %s\n";
 /// SLHA line formatter for the DECAY block
 const char * const format_total_width = "%9d   %16.8E   # %s\n";
+/// SLHA line formatter for the EFFECTIVECOUPLINGS block
+const char * const format_effectivecouplings = "%9d   %9d   %9d   %16.8E   # %s\n";
 
 } // namespace flexiblesusy

--- a/src/slha_format.hpp
+++ b/src/slha_format.hpp
@@ -43,6 +43,8 @@ extern const char * const spinfo_formatter;
 extern const char * const obsinfo_formatter;
 /// SLHA line formatter for the DECAY block
 extern const char * const format_total_width;
+/// SLHA line formatter for the EFFECTIVECOUPLINGS block
+extern const char * const format_effectivecouplings;
 
 namespace {
    /// maximum line length in SLHA output
@@ -171,6 +173,19 @@ std::string format_decay(double br, const Container& pids, const std::string& na
       const std::string name_ = (name);                                        \
       std::snprintf(buf, SLHA_MAX_LINE_LENGTH, format_total_width,             \
                     pdg_, width_, name_.c_str());                              \
+      return std::string(buf);                                                 \
+   }()
+
+#define FORMAT_EFFECTIVECOUPLINGS(pdg1, pdg2, pdg3, width, comment)            \
+   [&] {                                                                       \
+      char buf[SLHA_MAX_LINE_LENGTH];                                          \
+      const int pdg1_ = (pdg1);                                                \
+      const int pdg2_ = (pdg2);                                                \
+      const int pdg3_ = (pdg3);                                                \
+      const double width_ = (width);                                           \
+      const std::string comment_ = (comment);                                  \
+      std::snprintf(buf, SLHA_MAX_LINE_LENGTH, format_effectivecouplings,      \
+                    pdg1_, pdg2_, pdg3_, width_, comment_.c_str());            \
       return std::string(buf);                                                 \
    }()
 

--- a/src/slha_io.cpp
+++ b/src/slha_io.cpp
@@ -975,5 +975,15 @@ void SLHA_io::set_matrix_imag(const std::string& name, const std::complex<double
    set_block(detail::format_matrix_imag(block_head(name, scale), a, symbol, rows, cols));
 }
 
+void SLHA_io::set_effectivecouplings_block(const std::vector<std::tuple<int, int, int, double, std::string>>& effCouplings)
+{
+   std::ostringstream decay;
+   decay << "Block EFFHIGGSCOUPLINGS\n";
 
+   for (auto const& effC : effCouplings) {
+      decay << FORMAT_EFFECTIVECOUPLINGS(std::get<0>(effC),  std::get<1>(effC), std::get<2>(effC), std::get<3>(effC), std::get<4>(effC));
+   }
+
+   set_block(decay);
+}
 } // namespace flexiblesusy

--- a/src/slha_io.hpp
+++ b/src/slha_io.hpp
@@ -144,6 +144,7 @@ public:
    void set_block(const std::string&, const Eigen::MatrixBase<Derived>&, const std::string&, double scale = 0.);
    template <class Derived>
    void set_block_imag(const std::string&, const Eigen::MatrixBase<Derived>&, const std::string&, double scale = 0.);
+   void set_effectivecouplings_block(const std::vector<std::tuple<int, int, int, double, std::string>>&);
    void set_modsel(const Modsel&);
    void set_physical_input(const Physical_input&);
    void set_settings(const Spectrum_generator_settings&);

--- a/templates/decays/decays.hpp.in
+++ b/templates/decays/decays.hpp.in
@@ -65,6 +65,9 @@ public:
    void clear();
    void clear_problems();
    void calculate_decays();
+   std::vector<std::tuple<int, int, int, double, std::string>> get_effhiggscouplings_block_input() const {
+      return effhiggscouplings_block_input;
+   }
 
 @decaysGetters@
 @decaysCalculationPrototypes@
@@ -100,6 +103,7 @@ private:
                   typename cxx_diagrams::field_indices<FieldIn>::type const& indexIn,
                   typename cxx_diagrams::field_indices<FieldOut1>::type const& indexOut1,
                   typename cxx_diagrams::field_indices<FieldOut2>::type const& indexOut2) const;
+   std::vector<std::tuple<int, int, int, double, std::string>> effhiggscouplings_block_input {};
 };
 
 @calcAmplitudeSpecializationDecls@

--- a/templates/slha_io.cpp.in
+++ b/templates/slha_io.cpp.in
@@ -459,6 +459,11 @@ void @ModelName@_slha_io::set_decay_block(const Decays_list& decays_list, Flexib
    slha_io.set_block(decay);
 }
 
+void @ModelName@_slha_io::set_effectivecouplings_block(const std::vector<std::tuple<int, int, int, double, std::string>>& effCouplings)
+{
+   slha_io.set_effectivecouplings_block(effCouplings);
+}
+
 @setDecaysFunctions@
 @fillDecaysDataFunctions@
 

--- a/templates/slha_io.hpp.in
+++ b/templates/slha_io.hpp.in
@@ -81,6 +81,7 @@ public:
    void set_dcinfo(const std::vector<std::string>&, const std::vector<std::string>&);
 @setDecaysPrototypes@
    void set_extra(const @ModelName@_slha&, const @ModelName@_scales&, const @ModelName@_observables&, const flexiblesusy::Spectrum_generator_settings&);
+   void set_effectivecouplings_block(const std::vector<std::tuple<int, int, int, double, std::string>>& effCouplings);
    void set_input(const @ModelName@_input_parameters&);
    void set_modsel(const SLHA_io::Modsel&);
    void set_physical_input(const Physical_input&);


### PR DESCRIPTION
This replaces PR  #404. It provides an `EFFHIGGSCOUPLINGS` that is read by SARAH generated UFO and CalcHEP (so also micrOMEGAs) models
```
Block EFFHIGGSCOUPLINGS
       25          21          21     5.63154856E-05   # hh(1)-VG-VG
       25          22          22     2.52221041E-05   # hh(1)-VP-VP
       35          21          21     5.30370890E-05   # hh(2)-VG-VG
       ...
       36          21          21     2.92231712E-05   # Ah(2)-VG-VG
       36          22          22     1.01798470E-04   # Ah(2)-VP-VP
       ...
```