### PR TITLE
decays should't check for loop libraries if disable compile

### DIFF
--- a/configure
+++ b/configure
@@ -3551,6 +3551,10 @@ add_metaflags() {
    tcol_='FSEnableColors = '
    col_="${tcol_}$(test ${enable_colors} = 'yes' && echo 'True' || echo 'False');"
 
+   local tcol_ col_
+   tcol_='FSEnableCompile = '
+   col_="${tcol_}$(test ${enable_compile} = 'yes' && echo 'True' || echo 'False');"
+
    local c_=''
    local fs_=''
    for m in ${MODELS}; do

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -214,6 +214,7 @@ IMEXTPAR = {};
 FSCalculateDecays = False;
 FSDecayParticles = Automatic;
 FSEnableParallelism = True;
+FSEnableCompile;
 
 (* Standard Model input parameters (SLHA input parameters) *)
 (* {parameter, {"block", entry}, type}                     *)

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -488,7 +488,7 @@ ReplaceSymbolsInUserInput[rules_] :=
               {Unevaluated@FlexibleSUSY`HighPoleMassPrecision, Unevaluated@FlexibleSUSY`MediumPoleMassPrecision, Unevaluated@FlexibleSUSY`LowPoleMassPrecision};
 
            (* decay calculation require 3- and 4-point loop functions *)
-           If[FlexibleSUSY`FSCalculateDecays && DisjointQ[FSLoopLibraries, {FSLoopTools, FSCOLLIER}],
+           If[FlexibleSUSY`FSCalculateDecays && DisjointQ[FSLoopLibraries, {FSLoopTools, FSCOLLIER}] && FSEnableCompile,
               Utils`FSFancyWarning[
                  "Decay calculation requires a dedicated loop library.",
                  " Currently it's either LoopTools or Collier but",


### PR DESCRIPTION
We skip generation of decays if FlexibleSUSY was not configured with external loop library. But this check should be disabled if we disable compilation.

Closes #555.