### PR TITLE
removed extra space in method call

### DIFF
--- a/templates/two_scale_high_scale_spectrum_generator.cpp.in
+++ b/templates/two_scale_high_scale_spectrum_generator.cpp.in
@@ -88,7 +88,7 @@ void @ModelName@_spectrum_generator<Two_scale>::run_except(const softsusy::QedQc
 
    high_scale_constraint.initialize();
    susy_scale_constraint.initialize();
-   low_scale_constraint .initialize();
+   low_scale_constraint.initialize();
 
    low_scale_constraint.set_SM_like_Higgs_index(
       settings.get(Spectrum_generator_settings::eft_higgs_index));

--- a/templates/two_scale_low_scale_spectrum_generator.cpp.in
+++ b/templates/two_scale_low_scale_spectrum_generator.cpp.in
@@ -86,7 +86,7 @@ void @ModelName@_spectrum_generator<Two_scale>::run_except(const softsusy::QedQc
    @ModelName@_low_scale_constraint<Two_scale>  low_scale_constraint(&model, qedqcd);
 
    susy_scale_constraint.initialize();
-   low_scale_constraint .initialize();
+   low_scale_constraint.initialize();
 
    low_scale_constraint.set_SM_like_Higgs_index(
       settings.get(Spectrum_generator_settings::eft_higgs_index));


### PR DESCRIPTION
Hi @Expander. I think there are some redundant spaces here. Not sure why it even worked in the first place...

Sorry. My bad. Forget I've asked. It's a valid C++ code [see here](https://stackoverflow.com/questions/15410428/a-space-before-function-call-in-c) You learn something every day...