### PR TITLE
Bugfix: Time delay in update_module_mk

### DIFF
--- a/configure
+++ b/configure
@@ -3289,15 +3289,6 @@ update_module_mk() {
 
     [ -e "$model_file" ] || return
 
-    local mk_date model_date date_tolerance
-    mk_date="$(date -r "${mkfile}" +%s)"
-    model_date="$(date -r "${model_file}" +%s)"
-    date_tolerance="5" # Seconds
-    if [ "0" = "$(( $mk_date + $date_tolerance < $model_date ))" ] && \
-       [ "0" = "$(( $model_date < $mk_date - $date_tolerance ))" ]; then
-       return
-    fi
-
     message -n "   Updating model-specific modules in $mkfile ... "
     local ho
     ho="$(get_model_specific_corrections "$model_file" "$math_cmd")"


### PR DESCRIPTION
There is a built-in time delay of 5 seconds in `update_module_mk`, which causes problems: It may happen that the model-specific makefile module is not updated, which leads to a build error of the form:
~~~
Makefile:191: model_specific/@MODEL_SPECIFIC_MODULES@/module.mk: No such file or directory
make: *** No rule to make target 'model_specific/@MODEL_SPECIFIC_MODULES@/module.mk'.  Stop.
~~~
See for example #594 .

@uukhas You've created this time delay. What were the reasons for this?

This PR proposes to remove the time delay.
