### PR TITLE
fix discovery of python3*-config

### DIFF
--- a/configure
+++ b/configure
@@ -2238,7 +2238,8 @@ check_higgstools() {
 
 check_python() {
     checking_msg "python C/C++ extensions"
-    python3config_cmd=$(find $(echo "$PATH" | sed -e 's/:/ /g') -name "python3*-config" 2>/dev/null)
+    path_split=$(echo "$PATH" | sed -e 's/:/ /g')
+    python3config_cmd=$(find $path_split -name "python3*-config" 2>/dev/null)
     if test -z "$python3config_cmd" ; then
         result "no"
         message "Warning! Cannot find python3*-config. Some features (like the Lilith interface)"

--- a/configure
+++ b/configure
@@ -2237,7 +2237,7 @@ check_higgstools() {
 }
 
 check_python() {
-    checking_msg "python C/C++ extensions"
+    checking_msg "python3 C/C++ extensions"
     path_split=$(echo "$PATH" | sed -e 's/:/ /g')
     python3config_cmd=$(find $path_split -name "python3*-config" 2>/dev/null)
     if test -z "$python3config_cmd" ; then
@@ -2252,7 +2252,7 @@ check_python() {
         # remove duplicates
         PYTHONFLAGS=$(echo "$(${python3config_cmd} --includes)" | xargs -n1 | sort -u)
         PYTHONLIBS="$(${python3config_cmd} --libs --embed)"
-        result "yes"
+        result "found $python3config_cmd"
     fi
 }
 

--- a/configure
+++ b/configure
@@ -2238,7 +2238,7 @@ check_higgstools() {
 
 check_python() {
     checking_msg "python C/C++ extensions"
-    python3config_cmd=$(find /usr/bin -name "python3*-config")
+    python3config_cmd=$(find $(echo "$PATH" | sed -e 's/:/ /g') -name "python3*-config" 2>/dev/null)
     if test -z "$python3config_cmd" ; then
         result "no"
         message "Warning! Cannot find python3*-config. Some features (like the Lilith interface)"

--- a/configure
+++ b/configure
@@ -2237,7 +2237,7 @@ check_higgstools() {
 }
 
 check_python() {
-    checking_msg "python3 C/C++ extensions"
+    checking_msg "C++ python embedding"
     path_split=$(echo "$PATH" | sed -e 's/:/ /g')
     python3config_cmd=$(find $path_split -name "python3*-config" 2>/dev/null)
     if test -z "$python3config_cmd" ; then

--- a/configure
+++ b/configure
@@ -2238,16 +2238,19 @@ check_higgstools() {
 
 check_python() {
     checking_msg "python C/C++ extensions"
-    if test "$(command -v python3-config)" = "x" ; then
+    python3config_cmd=$(find /usr/bin -name "python3*-config")
+    if test -z "$python3config_cmd" ; then
         result "no"
-        message "Warning! Cannot find python3-config. Some features (like the Lilith interface)"
+        message "Warning! Cannot find python3*-config. Some features (like the Lilith interface)"
         message "         will be disabled."
         enable_lilith=no
     else
+        # pick 1st one that was found
+        python3config_cmd=$(echo $python3config_cmd | cut -d ' ' -f 1)
         # on my system python3-includes returns -I/usr/include/python3.11 -I/usr/include/python3.11
         # remove duplicates
-        PYTHONFLAGS=$(echo "$(python3-config --includes)" | xargs -n1 | sort -u)
-        PYTHONLIBS="$(python3-config --libs --embed)"
+        PYTHONFLAGS=$(echo "$(${python3config_cmd} --includes)" | xargs -n1 | sort -u)
+        PYTHONLIBS="$(${python3config_cmd} --libs --embed)"
         result "yes"
     fi
 }


### PR DESCRIPTION
This PR tries to make the discovery of `python3-config` more robust. On some systems there is no `python3-config` alias. Instead, only separate version for each python3 version exists, e.g. `python3.12-config`.