### PR TITLE
fixed wrong color factor in TTO decays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,8 @@ New features
 Fixed bugs
 ----------
 
-* Fixed wrong colour factor in decays of an SU(3) octet to triplet anti-triplet
-  and permutations of such.
+* Fixed wrong colour factor in decays of an SU(3) color octet to triplet
+  anti-triplet and permutations of such.
 
 FlexibleSUSY 2.8.0 [February, 23 2024]
 ======================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ New features
 * Calculate unitarity constraints in `$s\to \infty$` limit. This is a wrapper
   over SARAH results [`1805.07306 <https://arxiv.org/pdf/1805.07306.pdf>`_].
 
+Fixed bugs
+----------
+
+* Fixed wrong colour factor in decays of an SU(3) octet to triplet anti-triplet
+  and permutations of such.
+
 FlexibleSUSY 2.8.0 [February, 23 2024]
 ======================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,9 @@ New features
 Fixed bugs
 ----------
 
-* Fixed wrong colour factor in decays of an SU(3) color octet to triplet
-  anti-triplet and permutations of such.
+* Fixed wrong colour factor in decays with an external color octet, triplet,
+  anti-triplet combination, e.g. squark to quark and gluino or sgluon to squark
+  anti-squark.
 
 FlexibleSUSY 2.8.0 [February, 23 2024]
 ======================================

--- a/model_files/MRSSM2/FlexibleSUSY.m.in
+++ b/model_files/MRSSM2/FlexibleSUSY.m.in
@@ -121,7 +121,7 @@ ExtraSLHAOutputBlocks = {
 };
 
 FSCalculateDecays = True;
-FSDecayParticles = {hh, Ah, Hpm, sigmaO, phiO, Fu};
+FSDecayParticles = {hh, Ah, Hpm, sigmaO, phiO, Fu, Su};
 
 DefaultPoleMassPrecision = HighPrecision;
 HighPoleMassPrecision    = {hh, Ah, Hpm};

--- a/src/decays/decay.hpp
+++ b/src/decays/decay.hpp
@@ -202,7 +202,7 @@ constexpr double squared_color_generator() noexcept {
          (cxx_diagrams::fields::is_triplet_v<FieldIn> && cxx_diagrams::fields::is_octet_v<FieldOut2>)
          || (cxx_diagrams::fields::is_octet_v<FieldOut1> && cxx_diagrams::fields::is_triplet_v<FieldOut2>)
       ) {
-         return 4.;
+         return 16/3.;
       }
       else {
          static_assert(always_false<FieldIn, FieldOut1, FieldOut2>, "Unknow colour structure in decay");
@@ -221,7 +221,7 @@ constexpr double squared_color_generator() noexcept {
          (cxx_diagrams::fields::is_anti_triplet_v<FieldIn> && cxx_diagrams::fields::is_octet_v<FieldOut2>)
          || (cxx_diagrams::fields::is_octet_v<FieldOut1> && cxx_diagrams::fields::is_anti_triplet_v<FieldOut2>)
       ) {
-         return 4.;
+         return 16/3.;
       }
       else {
          static_assert(always_false<FieldIn, FieldOut1, FieldOut2>, "Unknow colour structure in decay");
@@ -239,7 +239,7 @@ constexpr double squared_color_generator() noexcept {
          (cxx_diagrams::fields::is_triplet_v<FieldOut1> && cxx_diagrams::fields::is_anti_triplet_v<FieldOut2>)
          || (cxx_diagrams::fields::is_anti_triplet_v<FieldOut1> && cxx_diagrams::fields::is_triplet_v<FieldOut2>)
       ) {
-         return 1./2.;
+         return 2.;
       }
       // 8 -> 8, 8 with identical particles in the final state
       // because of symmetry of the final state it must be proportional to d^2

--- a/test/test_MRSSM2_FlexibleDecay.cpp
+++ b/test/test_MRSSM2_FlexibleDecay.cpp
@@ -759,9 +759,10 @@ Block IMVCKM Q= 1.00000000E+03
 
    // scalar sgluon
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_phiO_to_VGVG(&m), 0.057227807158571162, 3e-11);
-   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_phiO_to_barFuFu(&m, 2, 2), 2.3251564031550308e-05, 2e-12);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_phiO_to_barFuFu(&m, 2, 2), 9.300625612620111e-05, 2e-12);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_phiO_to_SuconjSu(&m, 0, 0), 7.5178588442628946, 1e-16);
 
    // pseudoscalar sgluon
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_sigmaO_to_VGVG(&m), 0, 1e-16);
-   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_sigmaO_to_barFuFu(&m, 2, 2), 2.2644028086115904e-05, 8e-12);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_sigmaO_to_barFuFu(&m, 2, 2), 9.057611234446413e-05, 8e-12);
 }

--- a/test/test_MRSSM2_FlexibleDecay.cpp
+++ b/test/test_MRSSM2_FlexibleDecay.cpp
@@ -764,5 +764,7 @@ Block IMVCKM Q= 1.00000000E+03
 
    // pseudoscalar sgluon
    BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_sigmaO_to_VGVG(&m), 0, 1e-16);
-   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_sigmaO_to_barFuFu(&m, 2, 2), 9.057611234446413e-05, 8e-12);
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_sigmaO_to_barFuFu(&m, 2, 2), 9.057611234446413e-05, 1e-16);
+
+   BOOST_CHECK_CLOSE_FRACTION(decays_without_HO.partial_width_Su_to_GluFu(&m, 3, 0), 56.21133546983561, 1e-16);
 }


### PR DESCRIPTION
The color factor in decays where external states we a triple of octet-triplet-triplet was wrong. I've noticed it while comparing the output of FlexibleSUSY with the SModelS input created by micrOMEGAs. After the fix, we get:

**sgluon decay (to test 8->3 -3 decay)**
FlexibleSUSY
```
DECAY   3000021     1.08234431E+02   # phiO decays    
     3.94954231E-01   2    -1000002   1000002  # BR(phiO -> conjSu(1) Su(1))    
     3.94954128E-01   2    -1000004   1000004  # BR(phiO -> conjSu(2) Su(2))    
     2.09746938E-01   2    -1000006   1000006  # BR(phiO -> conjSu(3) Su(3))    
     1.47445791E-04   2          21        21  # BR(phiO -> VG VG)
```
micrOMEGAs
```
DECAY 3000021  1.218619E+02  # POc
     3.950904E-01   2   1000002 -1000002  #  ~su1,~Su1 
     3.950903E-01   2   1000004 -1000004  #  ~su2,~Su2 
     2.098192E-01   2   1000006 -1000006  #  ~su3,~Su3
```

**up-squark decay (to test 3->3 8 decay)**
FlexibleSUSY
```
DECAY   1000002     7.53035919E+01   # Su(1) decays
      9.60378016E-01   2    -1000021         2  # BR(Su(1) -> barGlu Fu(1))
      3.95378192E-02   2    -1000022         2  # BR(Su(1) -> barChi(1) Fu(1))
      8.41643524E-05   2    -1000023         2  # BR(Su(1) -> barChi(2) Fu(1))
```
micrOMEGAs
```
DECAY 1000002  7.450879E+01  # ~su1
    9.632671E-01   2   -1000021 2  #  ~Go,u1 
    3.666345E-02   2   -1000022 2  #  ~n1,u1 
    6.944967E-05   2   -1000023 2  #  ~n2,u1
```