### PR TITLE
fix linking with libpython3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Fixed bugs
   anti-triplet combination, e.g. squark to quark and gluino or sgluon to squark
   anti-squark.
 
+* Fixed problem with linking with python3 library if it was installed in
+  a non-standard location.
+
 FlexibleSUSY 2.8.0 [February, 23 2024]
 ======================================
 

--- a/configure
+++ b/configure
@@ -2251,7 +2251,7 @@ check_python() {
         # on my system python3-includes returns -I/usr/include/python3.11 -I/usr/include/python3.11
         # remove duplicates
         PYTHONFLAGS=$(echo "$(${python3config_cmd} --includes)" | xargs -n1 | sort -u)
-        PYTHONLIBS="$(${python3config_cmd} --libs --embed)"
+        PYTHONLIBS="$(${python3config_cmd} --ldflags --embed)"
         result "found $python3config_cmd"
     fi
 }


### PR DESCRIPTION
Hey @Expander ,

This is just a guess but I think the problem that was reported in the last issue might be that `python3-config --libs --embed` doesn't return a lib directory, only libs themselves
```
-lpython3.10 -lcrypt -ldl  -lm -lm
```
in contrast to `python3-config --ldflags --embed` which gives
```
-L/usr/lib/python3.10/config-3.10-x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu -lpython3.10 -lcrypt -ldl  -lm -lm
```
This PR might be a potential fix to the reported bug.