### PR TITLE
enable calculation of b-physics wilson coefficients

### DIFF
--- a/meta/Observables/BrDLToDL/FlexibleSUSY.m
+++ b/meta/Observables/BrDLToDL/FlexibleSUSY.m
@@ -1,0 +1,115 @@
+FlexibleSUSY`WriteClass[obs:FlexibleSUSYObservable`BrDLToDL, slha_, files_] :=
+Module[
+   {
+      observables = DeleteDuplicates@Cases[Observables`GetRequestedObservables@slha, _obs],
+      prototypes = "", definitions = "", npfHeaders = "", npfDefinitions = "",
+      fieldsFFV = {}, verticesFFV = {}, additionalVertices = {}
+   },
+
+   If[observables =!= {} && FlexibleSUSY`FSFeynArtsAvailable && FlexibleSUSY`FSFormCalcAvailable,
+      Utils`PrintHeadline["Creating " <> SymbolName@obs <> " class ..."];
+      observables = DeleteDuplicates[observables /. f_@_Integer -> f@_];
+      fieldsFFV   = Cases[observables, Rule[{q_[_], _}, _] :> q, Infinity];
+      verticesFFV = Cases[observables, Rule[{_, l_[_]}, _] :> {SARAH`bar@l, l, TreeMasses`GetPhoton[]}, Infinity];
+      {additionalVertices, npfDefinitions, prototypes, definitions} = create@observables;
+      npfHeaders  = NPointFunctions`CreateCXXHeaders[];
+   ];
+
+   WriteOut`ReplaceInFiles[
+      files,
+      {
+         "@calculate_prototypes@"  -> prototypes,
+         "@calculate_definitions@" -> definitions,
+         "@npf_headers@"           -> npfHeaders,
+         "@npf_definitions@"       -> npfDefinitions,
+         "@include_guard@"         -> SymbolName@obs,
+         "@namespace@"             -> Observables`GetObservableNamespace@obs,
+         "@filename@"              -> Observables`GetObservableFileName@obs,
+         Sequence@@FlexibleSUSY`Private`GeneralReplacementRules[]
+      }
+   ];
+
+   {
+      "FFV fields" -> DeleteDuplicates@fieldsFFV,
+      "C++ vertices" -> DeleteDuplicates@Join[verticesFFV, additionalVertices]
+   }
+];
+
+create[manyObservables:{__FlexibleSUSYObservable`BrDLToDL}] := {
+   DeleteDuplicates[Join@@#[[All,1]]],
+   StringRiffle[#[[All, 2]], "\n\n"],
+   StringRiffle[#[[All, 3]], "\n\n"],
+   StringRiffle[#[[All, 4]], "\n\n"]
+}&[create/@DeleteDuplicates[manyObservables /. Rule[_Integer, _Integer] -> Rule[_, _]]];
+
+create[obs:FlexibleSUSYObservable`BrDLToDL[{qd_[_], lep_[_]} -> _, contr_, loopN_]] :=
+Module[{npfVertices, npfDefinition, calculateDefinition, prototype,
+   keep, npf, fields, sp, dc, basis},
+   keep = If[Head@contr === List, contr, {contr}];
+   Print["Contributions: ", SymbolName/@keep];
+   Print["Loop level: ", loopN];
+   npf = NPointFunctions`NPointFunction[
+      {qd, lep},
+      {qd, lep},
+      NPointFunctions`UseCache            -> True,
+      NPointFunctions`OnShellFlag         -> True,
+      NPointFunctions`ZeroExternalMomenta -> NPointFunctions`ExceptLoops,
+      NPointFunctions`LoopLevel           -> loopN,
+      NPointFunctions`Regularize          -> FlexibleSUSY`FSRenormalizationScheme,
+      NPointFunctions`Observable          -> obs,
+      NPointFunctions`KeepProcesses       -> keep
+   ];
+   npf = npf /. {
+      SARAH`sum[__] -> 0,
+      LoopTools`B0i[i_, _, mm__] :> LoopTools`B0i[i, 0, mm],
+      LoopTools`C0i[i_, Repeated[_, {3}], mm__] :> LoopTools`C0i[i, Sequence@@Array[0&, 3], mm],
+      LoopTools`D0i[i_, Repeated[_, {6}], mm__] :> LoopTools`D0i[i, Sequence@@Array[0&, 6], mm]
+   };
+   fields = Flatten@NPointFunctions`GetProcess@npf;
+   sp[i_] := SARAH`DiracSpinor[fields[[i]], 0, 0];
+   dc[a_, b__, c_] := NPointFunctions`DiracChain[sp@a, b, sp@c];
+   basis = With[{l = SARAH`Lorentz, R = 6, L = 7},
+      {
+         "S_LL" -> dc[3,L,1] dc[4,L,2],
+         "S_LR" -> dc[3,L,1] dc[4,R,2],
+         "S_RL" -> dc[3,R,1] dc[4,L,2],
+         "S_RR" -> dc[3,R,1] dc[4,R,2],
+         "V_LL" -> dc[3,R,l@1,1] dc[4,R,l@1,2],
+         "V_LR" -> dc[3,R,l@1,1] dc[4,L,l@1,2],
+         "V_RL" -> dc[3,L,l@1,1] dc[4,R,l@1,2],
+         "V_RR" -> dc[3,L,l@1,1] dc[4,L,l@1,2],
+         "T_LL" -> dc[3,-L,l@1,l@2,1] dc[4,-L,l@1,l@2,2],
+         "T_RR" -> dc[3,-R,l@1,l@2,1] dc[4,-R,l@1,l@2,2]
+      }
+   ];
+   npf = WilsonCoeffs`InterfaceToMatching[npf, basis];
+   npfVertices = NPointFunctions`VerticesForNPointFunction@npf;
+   npfDefinition = NPointFunctions`CreateCXXFunctions[npf, "@class@", SARAH`Delta, basis, True][[2]];
+   prototype = CConversion`CreateCType@Observables`GetObservableType@obs <>
+      " " <> Observables`GetObservablePrototype@obs;
+
+   {calculateDefinition, npfDefinition} = FixedPoint[
+      StringReplace[#,
+         {
+            "@Qd@"    -> CConversion`ToValidCSymbolString@qd,
+            "@Lep@"   -> CConversion`ToValidCSymbolString@lep,
+            "@Ph@"    -> CConversion`ToValidCSymbolString@SARAH`Photon,
+            "@loopN@" -> CConversion`ToValidCSymbolString@loopN,
+            "@contr@" -> CConversion`ToValidCSymbolString@contr,
+            "@class@" -> "@Qd@@Lep@_to_@Qd@@Lep@_@contr@@loopN@",
+            "@photon_penguin@" -> If[loopN === 1, "calculate_@Qd@_@Qd@_@Ph@_form_factors", "zero"]
+         }
+      ]&,
+      {
+         prototype <> " {
+         return forge<
+            fields::@Qd@, fields::@Lep@, fields::@Ph@,
+            @photon_penguin@,
+            npointfunctions::@class@
+         >(qi, qo, li, model, qedqcd);\n}",
+         npfDefinition
+      }
+   ];
+
+   {npfVertices, npfDefinition, prototype <> ";", calculateDefinition}
+];

--- a/meta/Observables/BrDLToDL/FlexibleSUSY.m
+++ b/meta/Observables/BrDLToDL/FlexibleSUSY.m
@@ -11,7 +11,7 @@ Module[
       observables = DeleteDuplicates[observables /. f_@_Integer -> f@_];
       fieldsFFV   = Cases[observables, Rule[{q_[_], _}, _] :> q, Infinity];
       verticesFFV = Cases[observables, Rule[{_, l_[_]}, _] :> {SARAH`bar@l, l, TreeMasses`GetPhoton[]}, Infinity];
-      {additionalVertices, npfDefinitions, prototypes, definitions} = create@observables;
+      {additionalVertices, npfDefinitions, prototypes, definitions} = Create@observables;
       npfHeaders  = NPointFunctions`CreateCXXHeaders[];
    ];
 
@@ -35,14 +35,14 @@ Module[
    }
 ];
 
-create[manyObservables:{__FlexibleSUSYObservable`BrDLToDL}] := {
+Create[manyObservables:{__FlexibleSUSYObservable`BrDLToDL}] := {
    DeleteDuplicates[Join@@#[[All,1]]],
    StringRiffle[#[[All, 2]], "\n\n"],
    StringRiffle[#[[All, 3]], "\n\n"],
    StringRiffle[#[[All, 4]], "\n\n"]
-}&[create/@DeleteDuplicates[manyObservables /. Rule[_Integer, _Integer] -> Rule[_, _]]];
+}&[Create/@DeleteDuplicates[manyObservables /. Rule[_Integer, _Integer] -> Rule[_, _]]];
 
-create[obs:FlexibleSUSYObservable`BrDLToDL[{qd_[_], lep_[_]} -> _, contr_, loopN_]] :=
+Create[obs:FlexibleSUSYObservable`BrDLToDL[{qd_[_], lep_[_]} -> _, contr_, loopN_]] :=
 Module[{npfVertices, npfDefinition, calculateDefinition, prototype,
    keep, npf, fields, sp, dc, basis},
    keep = If[Head@contr === List, contr, {contr}];

--- a/meta/Observables/BrDLToDL/NPointFunctions.m
+++ b/meta/Observables/BrDLToDL/NPointFunctions.m
@@ -1,0 +1,79 @@
+topologies[0] = {
+   {Vectors, Scalars} -> treeAll
+};
+
+topologies[1] = {
+   {Vectors, Scalars} -> penguinT,
+   Boxes -> boxAll
+};
+
+diagrams[0, Absent] = {
+   Vectors -> {
+      treeAll -> {"remove vector bosons", FreeQ[TreeFields@##, FeynArts`V]&}
+   },
+   Scalars -> {
+      treeAll -> {"remove scalar bosons", FreeQ[TreeFields@##, FeynArts`S]&}
+   }
+};
+
+diagrams[1, Present] = {
+   Vectors -> {
+      penguinT -> {"remove external quarks", FreeQ[LoopFields@##, FieldPattern[#, 1|3]]&},
+      penguinT -> {"remove loop vectors", FreeQ[LoopFields@##, FeynArts`V]&}
+   },
+   Scalars -> {
+      penguinT -> {"remove external quarks", FreeQ[LoopFields@##, FieldPattern[#, 1|3]]&},
+      penguinT -> {"remove loop vectors", FreeQ[LoopFields@##, FeynArts`V]&}
+   },
+   Boxes -> {
+      boxAll -> {"remove external quarks", FreeQ[LoopFields@##, FieldPattern[#, 1|2|3|4]]&},
+      boxAll -> {"remove loop vectors", FreeQ[LoopFields@##, FeynArts`V]&}
+   }
+};
+
+diagrams[1, Absent] = {
+   Vectors -> {
+      penguinT -> {"remove tree vectors", FreeQ[TreeFields@##, FeynArts`V]&}
+   },
+   Scalars -> {
+      penguinT -> {"remove tree scalars", FreeQ[TreeFields@##, FeynArts`S]&}
+   }
+};
+
+amplitudes[0, Present] = {
+   Vectors -> {
+      treeAll -> {"remove photons", FreeQ[{##}, InternalMass[FeynArts`V, 5] -> 0]&}
+   }
+};
+
+amplitudes[1, Present] = {
+   Vectors -> {
+      penguinT -> {"remove tree photons", FreeQ[{##}, InternalMass[FeynArts`V, 5] -> 0]&}
+   }
+};
+
+order[] = {3, 1, 4, 2};
+
+regularization[1] = {
+   boxS -> D,
+   boxU -> D
+};
+
+momenta[1] = {
+   penguinT -> 2,
+   boxS -> 2,
+   boxU -> 2
+};
+
+sum[1] = {
+   inSelfT  -> {"skip initial quark", {6, Field[#, 1]&}},
+   outSelfT -> {"skip final quark",   {6, Field[#, 3]&}}
+};
+
+chains[1] = {
+   {ExceptLoops} -> {1[k[4], ___] -> 0, 2[k[1], ___] -> 0}
+};
+
+mass[1] = {
+   inSelfT -> {"keep initial quark mass untouched", Hold :> ExternalMass[1]}
+};

--- a/meta/Observables/BrDLToDL/Observables.m
+++ b/meta/Observables/BrDLToDL/Observables.m
@@ -1,0 +1,8 @@
+Observables`DefineObservable[
+FlexibleSUSYObservable`BrDLToDL[{qd_[qI_], lep_[lI_]} -> {qd_[qO_], lep_[lI_]}, contr_, loopN_],
+   GetObservableType        -> {13},
+   GetObservableName        -> "qdqIleplI_to_qdqOleplI_contr_loopN",
+   GetObservableDescription -> "qd$(qI+1) lep$(lI+1) -> qd$(qO+1) lep$(lI+1) contr at loopN loops",
+   CalculateObservable      -> "calculate_qdlep_qdlep_contr_loopN(qI, qO, lI, model, qedqcd)",
+   GetObservablePrototype   -> "calculate_qdlep_qdlep_contr_loopN(int qi, int qo, int li, auto model, auto qedqcd)"
+];

--- a/meta/Observables/BrDLToDL/WriteOut.m
+++ b/meta/Observables/BrDLToDL/WriteOut.m
@@ -1,0 +1,26 @@
+WriteOut`WriteObservable[
+   "FWCOEF",
+   obs:FlexibleSUSYObservable`BrDLToDL[{qd_[qI_], lep_[lI_]} -> {_[qO_], _}, __]
+] :=
+StringReplace[
+   {
+      "qd,    4322, exp, num_value, \"D_L\"",
+      "qd,    4422, exp, num_value, \"D_R\"",
+      "qdlep, 3131, exp, num_value, \"S_LL\"",
+      "qdlep, 3132, exp, num_value, \"S_LR\"",
+      "qdlep, 3231, exp, num_value, \"S_RL\"",
+      "qdlep, 3232, exp, num_value, \"S_RR\"",
+      "qdlep, 4141, exp, num_value, \"V_LL\"",
+      "qdlep, 4142, exp, num_value, \"V_LR\"",
+      "qdlep, 4241, exp, num_value, \"V_RL\"",
+      "qdlep, 4242, exp, num_value, \"V_RR\"",
+      "qdlep, 4343, exp, num_value, \"T_LL\"",
+      "qdlep, 4444, exp, num_value, \"T_RR\""
+   },
+   {
+      "num_value" -> "Re(observables." <> Observables`GetObservableName@obs <> ")",
+      "exp"       -> "9, 9, 2",
+      "qd"        -> StringJoin[{qO, qI} /. {0 -> "01", 1 -> "03", 2 -> "05"}],
+      "lep"       -> StringJoin[{lI, lI} /. {0 -> "11", 1 -> "13", 2 -> "15"}]
+   }
+];

--- a/meta/Observables/BrLTo3L/FlexibleSUSY.m
+++ b/meta/Observables/BrLTo3L/FlexibleSUSY.m
@@ -16,7 +16,7 @@ Module[
       fermions =     {SARAH`bar@#, #} &/@ observables[[All, 1]];
       ffvV = Flatten/@Tuples@{fermions, {TreeMasses`GetPhoton[]}};
 
-      {npfV, npfDefinitions, obsPrototypes, obsDefinitions} = create@observables;
+      {npfV, npfDefinitions, obsPrototypes, obsDefinitions} = Create@observables;
    ];
 
    WriteOut`ReplaceInFiles[files,
@@ -38,14 +38,14 @@ Module[
    }
 ];
 
-create[manyObservables:{__FlexibleSUSYObservable`BrLTo3L}] := {
+Create[manyObservables:{__FlexibleSUSYObservable`BrLTo3L}] := {
    DeleteDuplicates[Join@@#[[All,1]]],
    StringRiffle[#[[All, 2]], "\n\n"],
    StringRiffle[#[[All, 3]], "\n\n"],
    StringRiffle[#[[All, 4]], "\n\n"]
-}&[create/@DeleteDuplicates[manyObservables /. Rule[_, {_, _, _}] -> Rule[_, {_, _, _}]]];
+}&[Create/@DeleteDuplicates[manyObservables /. Rule[_, {_, _, _}] -> Rule[_, {_, _, _}]]];
 
-create[obs:FlexibleSUSYObservable`BrLTo3L[lep_, __, loopN_]] :=
+Create[obs:FlexibleSUSYObservable`BrLTo3L[lep_, __, loopN_]] :=
 Module[{npfVertices = {}, npfCode = "", prototype, definition, scalars, vectors, boxes},
    {{npfVertices, npfCode}, {scalars, vectors, boxes}} = generate@obs;
 

--- a/meta/Observables/LToLConversion/FlexibleSUSY.m
+++ b/meta/Observables/LToLConversion/FlexibleSUSY.m
@@ -31,7 +31,7 @@ Module[{
       fieldsFFV = {#, #} &/@ observables[[All, 1]];
       verticesFFV = Flatten/@Tuples@{{SARAH`bar@#, #}&/@TreeMasses`GetSMQuarks[], {TreeMasses`GetPhoton[]}};
 
-      {additionalVertices, npfDefinitions, prototypes, definitions} = create@observables;
+      {additionalVertices, npfDefinitions, prototypes, definitions} = Create@observables;
    ];
 
    WriteOut`ReplaceInFiles[
@@ -55,14 +55,14 @@ Module[{
    }
 ];
 
-create[manyObservables:{__FlexibleSUSYObservable`LToLConversion}] := {
+Create[manyObservables:{__FlexibleSUSYObservable`LToLConversion}] := {
    DeleteDuplicates[Join@@#[[All,1]]],
    StringRiffle[#[[All, 2]], "\n\n"],
    StringRiffle[#[[All, 3]], "\n\n"],
    StringRiffle[#[[All, 4]], "\n\n"]
-}&[create/@DeleteDuplicates[manyObservables /. Rule[_Integer, _Integer] -> Rule[_, _]]];
+}&[Create/@DeleteDuplicates[manyObservables /. Rule[_Integer, _Integer] -> Rule[_, _]]];
 
-create[obs:FlexibleSUSYObservable`LToLConversion[in_, __, con_, loopN_]] :=
+Create[obs:FlexibleSUSYObservable`LToLConversion[in_, __, con_, loopN_]] :=
 Module[{npfVertices, npfDefinition, calculateDefinition, prototype},
    {npfVertices, npfDefinition} = generate@obs;
 

--- a/model_files/CMSSMCKM/FlexibleSUSY.m.in
+++ b/model_files/CMSSMCKM/FlexibleSUSY.m.in
@@ -98,7 +98,8 @@ ExtraSLHAOutputBlocks = {
          {26, FlexibleSUSYObservable`BrLToLGamma[Fe, 2 -> 1]},
          {27, FlexibleSUSYObservable`bsgamma}
       }
-   }
+   },
+   {FWCOEF, {{1, FlexibleSUSYObservable`BrDLToDL[{Fd[3], Fe[2]} -> {Fd[2], Fe[2]}, {Boxes}, 1]}}}
 };
 
 FSCalculateDecays = True;

--- a/model_files/MRSSM2CKM/FlexibleSUSY.m.in
+++ b/model_files/MRSSM2CKM/FlexibleSUSY.m.in
@@ -96,7 +96,8 @@ ExtraSLHAOutputBlocks = {
          {26, FlexibleSUSYObservable`BrLToLGamma[Fe, 2 -> 1]},
          {27, FlexibleSUSYObservable`bsgamma}
       }
-   }
+   },
+   {FWCOEF, {{1, FlexibleSUSYObservable`BrDLToDL[{Fd[3], Fe[2]} -> {Fd[2], Fe[2]}, {Boxes}, 1]}}}
 };
 
 FSCalculateDecays = True;

--- a/templates/observables/br_d_l_to_d_l.cpp.in
+++ b/templates/observables/br_d_l_to_d_l.cpp.in
@@ -1,0 +1,267 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+/**
+ * @file @ModelName@_@filename@.cpp
+ *
+ * This file was generated at @DateAndTime@ with FlexibleSUSY
+ * @FlexibleSUSYVersion@ and SARAH @SARAHVersion@
+ */
+
+#include <valarray>
+#include <complex>
+#include <fstream>
+#include <iomanip>
+
+#include "@ModelName@_mass_eigenstates.hpp"
+#include "cxx_qft/@ModelName@_qft.hpp"
+
+#include "@ModelName@_@filename@.hpp"
+#include "@ModelName@_FFV_form_factors.hpp"
+#include "json.hpp"
+#include "wrappers.hpp"
+
+@npf_headers@
+
+namespace flexiblesusy {
+
+namespace @ModelName@_cxx_diagrams {
+namespace npointfunctions {
+
+@npf_definitions@
+
+} // namespace npointfunctions
+} // namespace @ModelName@_cxx_diagrams
+
+namespace {
+
+std::valarray<std::complex<double>> zero(
+   int generationIndex1,
+   int generationIndex2,
+   const @ModelName@_mass_eigenstates&,
+   bool){
+   std::valarray<std::complex<double>> res {0.0, 0.0, 0.0, 0.0};
+   return res;
+}
+
+/**
+ * @brief Writes Wilson coefficients in a WCxf format [1712.05298] for
+ *        WET [https://wcxf.github.io/assets/pdf/WET.flavio.pdf].
+ * @tparam Down Type of a down quark.
+ */
+template <class Down>
+void write_btosmumu(
+   const Eigen::Array<std::complex<double>, 10, 1>& coeffs,
+   const @ModelName@_cxx_diagrams::context_base& context,
+   const softsusy::QedQcd& qedqcd) {
+
+   const auto complex_CKM = qedqcd.get_complex_ckm();
+
+   const std::complex<double> Vtb (complex_CKM(2, 2));
+   const std::complex<double> Vts (complex_CKM(2, 1));
+   const auto GF = qedqcd.displayFermiConstant();
+   const auto normalization = 4.*GF/Sqrt(2.) * Vtb*Conj(Vts) *
+      Sqr(unit_charge(context))*oneOver16PiSqr;
+
+   if (is_zero(std::abs(normalization))) {
+      ERROR("btosmumu: Normalization factor is vanishing.");
+      exit(EXIT_FAILURE);
+   }
+
+   const auto mb = context.mass<Down>({2});
+
+   // Dear reader, be aware of vector bosons (in loops) for b -> s mu mu.
+   // Some scheme dependence might be important.
+
+   // Compare to the basis in <DLDL/main.m>.
+   // They put SL on the first positions, we put BL.
+
+   // Here is the place for C7_bs = -1/2 A2R / normalization
+   // Here is the place for C7p_bs = -1/2 A2L / normalization
+
+   const auto C9_bsmumu   = (coeffs[5] + coeffs[4])/2. / normalization;
+   const auto C9p_bsmumu  = (coeffs[7] + coeffs[6])/2. / normalization;
+
+   const auto C10_bsmumu  = (coeffs[5] - coeffs[4])/2. / normalization;
+   const auto C10p_bsmumu = (coeffs[7] - coeffs[6])/2. / normalization;
+
+   const auto CS_bsmumu   = (coeffs[3] + coeffs[2])/2. / normalization / mb;
+   const auto CSp_bsmumu  = (coeffs[1] + coeffs[0])/2. / normalization / mb;
+
+   const auto CP_bsmumu   = (coeffs[3] - coeffs[2])/2. / normalization / mb;
+   const auto CPp_bsmumu  = (coeffs[1] - coeffs[0])/2. / normalization / mb;
+
+   // TODO(all): Where are sigma-sigma operators?
+
+   nlohmann::json j;
+   j["eft"] = "WET";
+   j["basis"] = "flavio";
+   j["scale"] = dynamic_cast<@ModelName@_mass_eigenstates const&>(context.model).get_scale();
+   j["values"] = {
+      {"C9_bsmumu",   {{"Re", Re(C9_bsmumu)},   {"Im", Im(C9_bsmumu)}}},
+      {"C9p_bsmumu",  {{"Re", Re(C9p_bsmumu)},  {"Im", Im(C9p_bsmumu)}}},
+      {"C10_bsmumu",  {{"Re", Re(C10_bsmumu)},  {"Im", Im(C10_bsmumu)}}},
+      {"C10p_bsmumu", {{"Re", Re(C10p_bsmumu)}, {"Im", Im(C10p_bsmumu)}}},
+      {"CS_bsmumu",   {{"Re", Re(CS_bsmumu)},   {"Im", Im(CS_bsmumu)}}},
+      {"CSp_bsmumu",  {{"Re", Re(CSp_bsmumu)},  {"Im", Im(CSp_bsmumu)}}},
+      {"CP_bsmumu",   {{"Re", Re(CP_bsmumu)},   {"Im", Im(CP_bsmumu)}}},
+      {"CPp_bsmumu",  {{"Re", Re(CPp_bsmumu)},  {"Im", Im(CPp_bsmumu)}}},
+   };
+   std::ofstream wc_json("WET_bsmumu.json");
+   wc_json << std::setw(4) << j << std::endl;
+   wc_json.close();
+
+}
+
+} // anonymous namespace
+
+using namespace @ModelName@_cxx_diagrams;
+using namespace @ModelName@_FFV_form_factors;
+
+namespace @namespace@ {
+
+typedef std::valarray<std::complex<double>>  (*ffv_function)
+   (int, int, const @ModelName@_mass_eigenstates&, bool);
+
+typedef std::array<std::complex<double>, 10> (*npf_function)
+   (const @ModelName@_mass_eigenstates&, const std::array<int,4>&, const std::array<Eigen::Vector4d,0>&);
+
+/**
+ * @tparam    L     Type of a lepton field.
+ * @tparam    A     Type of a photon field.
+ * @tparam    T     Type of a form factors.
+ * @param[in] model Mass eigenstates.
+ * @param[in] ff    Lepton-photon form factors.
+ * @param[in] g     Generation index for quarks.
+ * @return Set of four-fermion coefficients from photon penguin amplitudes
+ *         (without overall i; with appropriate embedding).
+ */
+template <class L, class A, class T>
+Eigen::Array<std::complex<double>,10,1> embed_photon(
+   const @ModelName@_mass_eigenstates& model, const T& ff, int g) {
+
+   // Get lepton-photon couplings (without i):
+   context_base context {model};
+   using vertex = Vertex<typename L::lorentz_conjugate, L, A>;
+   const auto value =  vertex::evaluate({g, g}, context);
+   const auto lL =  value.left();
+   const auto lR =  value.right();
+
+   Eigen::Array<std::complex<double>,10,1> res{};
+   // Term from eq. (t.1) will contribute to four-fermion vector coefficients.
+   // Minus comes from the form_factors embedding into four-fermion amplitude:
+   res[4] = - ff[0] * lL;
+   res[5] = - ff[0] * lR;
+   res[6] = - ff[1] * lL;
+   res[7] = - ff[1] * lR;
+   return res;
+};
+
+/**
+ * @tparam    Name  Function name for npf function.
+ * @param[in] model Mass eigenstates.
+ * @param[in] in    Generation index for incoming quark.
+ * @param[in] out   Generation index for outgoing quark.
+ * @param[in] g     Generation index for leptons.
+ * @return Set of four-fermion coefficients for amplitudes without photon
+ *         penguins (without overall i; with fixed signs for tensor operators
+ *         defined in meta/NPointFunctions/DLDL/main.m).
+ */
+template <npf_function Name>
+Eigen::Array<std::complex<double>,10,1> fix_tensors_sign(
+   const @ModelName@_mass_eigenstates& model, int in, int out, int g) {
+   const auto npf = Name(model,
+         std::array<int,4>{in, g, out, g},
+         std::array<Eigen::Vector4d, 0>{});
+   Eigen::Array<std::complex<double>,10,1> res(npf.data());
+   res[8] = - res[8];
+   res[9] = - res[9];
+   return res;
+};
+
+/**
+ * Form factors are defined via the following formula (q = pj - pi > 0; see
+ * eq. (3.4) of 1902.06650 (up to electric charge);
+ * pi - momenta[going from blob] of outgoing lepton,
+ * pj - momenta[going into blob] of incoming lepton):
+ *    <pi, q| T exp(i L_@ModelName@ dx)|pj> =
+ *    i * ubari
+ *          q^2 gamma_mu (A1_X * P_X)                                  (t.1)
+ *          + (zero after embedding term)                              (t.2)
+ *          + i mj sigma_munu q^nu (A2_X * P_X)                        (t.3)
+ *        uj e^*mu
+ * @note Form factors below are ordered as A1_L, A1_R, A2_L, A2_R.
+ * @note NPF function returns such result, that G4 = i * npf.
+ * @note Match to a low energy effective model with the same covariant derivative
+ *       for photon, as in @ModelName@, using eq. (t.3).
+ *       Minus comes from the form_factors embedding into four-fermion
+ *       amplitude, because we use descending ordering for external fermions
+ *          <out:l4,q3| T exp(i L_@ModelName@ dx) |in:l2,q1> =: G4
+ * @note For four fermion coefficient matching minus comes from the G4
+ *       definition, because
+ *          <out:l4,q3| T exp(i L_low dx) |in:l2,q1> = -i * C_XY [3X1]*[4Y2].
+ * @tparam    Lepton   Type of a lepton fields.
+ * @tparam    Photon   Type of a photon field.
+ * @tparam    photon   Function name for photon form factors.
+ * @tparam    npf      Function name for npf function for up-quark contribution.
+ * @param[in] dIn     Generation index for incoming quark.
+ * @param[in] dOut    Generation index for outgoing quark.
+ * @param[in] lInOut  Generation index for leptons.
+ * @param[in] model  Mass eigenstates.
+ * @param[in] parameters Parameters for the observable calculation.
+ * @param[in] qedqcd Reference to low-energy data.
+ * @return A dummy zero observable and Wilson coefficients.
+ */
+template<class Down, class Lepton, class Photon, ffv_function photon, npf_function npf>
+Eigen::Array<std::complex<double>, 13, 1> forge(
+   int dIn, int dOut, int lInOut,
+   const @ModelName@_mass_eigenstates& model,
+   const softsusy::QedQcd& qedqcd) {
+
+   context_base context {model};
+
+   const auto form_factors = photon(dIn, dOut, model, true);
+   const auto photon_l = embed_photon<Lepton, Photon>(model, form_factors, lInOut);
+   const auto npf_l = fix_tensors_sign<npf>(model, dIn, dOut, lInOut);
+
+   // Matching
+   const auto DL = - 0.5 * form_factors[2];
+   const auto DR = - 0.5 * form_factors[3];
+   const auto CXY = - photon_l - npf_l;
+
+   if (dIn == 2 && dOut == 1 && lInOut == 1) {
+      write_btosmumu<Down>(CXY, context, qedqcd);
+   } else {
+      // TODO(all): Implement :)
+      ERROR("dltodl: Unimplemented combination of external particles.");
+      exit(EXIT_FAILURE);
+   }
+
+
+   Eigen::Array<std::complex<double>,13,1> res;
+   res << 0.0, // We need only Wilson coefficients now.
+          DL,      DR,
+          CXY[0], CXY[1], CXY[2], CXY[3],
+          CXY[4], CXY[5], CXY[6], CXY[7],
+          CXY[8], CXY[9];
+   return res;
+}
+@calculate_definitions@
+
+} // namespace @namespace@
+} // namespace flexiblesusy

--- a/templates/observables/br_d_l_to_d_l.cpp.in
+++ b/templates/observables/br_d_l_to_d_l.cpp.in
@@ -106,7 +106,7 @@ void write_btosmumu(
    const auto CP_bsmumu   = (coeffs[3] - coeffs[2])/(2.*mb*normalization);
    const auto CPp_bsmumu  = (coeffs[1] - coeffs[0])/(2.*mb*normalization);
 
-   // TODO(all): Where are sigma-sigma operators?
+   // @todo(all): The sigma-sigma operators are missing
 
    nlohmann::json j;
    j["eft"] = "WET";
@@ -247,7 +247,7 @@ Eigen::Array<std::complex<double>, 13, 1> forge(
    if (dIn == 2 && dOut == 1 && lInOut == 1) {
       write_btosmumu<Down>(CXY, context, qedqcd);
    } else {
-      // TODO(all): Implement :)
+      // @todo(all): Implement
       ERROR("dltodl: Unimplemented combination of external particles.");
       exit(EXIT_FAILURE);
    }

--- a/templates/observables/br_d_l_to_d_l.cpp.in
+++ b/templates/observables/br_d_l_to_d_l.cpp.in
@@ -94,17 +94,17 @@ void write_btosmumu(
    // Here is the place for C7_bs = -1/2 A2R / normalization
    // Here is the place for C7p_bs = -1/2 A2L / normalization
 
-   const auto C9_bsmumu   = (coeffs[5] + coeffs[4])/2. / normalization;
-   const auto C9p_bsmumu  = (coeffs[7] + coeffs[6])/2. / normalization;
+   const auto C9_bsmumu   = (coeffs[5] + coeffs[4])/(2.*normalization);
+   const auto C9p_bsmumu  = (coeffs[7] + coeffs[6])/(2.*normalization);
 
-   const auto C10_bsmumu  = (coeffs[5] - coeffs[4])/2. / normalization;
-   const auto C10p_bsmumu = (coeffs[7] - coeffs[6])/2. / normalization;
+   const auto C10_bsmumu  = (coeffs[5] - coeffs[4])/(2.*normalization);
+   const auto C10p_bsmumu = (coeffs[7] - coeffs[6])/(2.*normalization);
 
-   const auto CS_bsmumu   = (coeffs[3] + coeffs[2])/2. / normalization / mb;
-   const auto CSp_bsmumu  = (coeffs[1] + coeffs[0])/2. / normalization / mb;
+   const auto CS_bsmumu   = (coeffs[3] + coeffs[2])/(2.*mb*normalization);
+   const auto CSp_bsmumu  = (coeffs[1] + coeffs[0])/(2.*mb*normalization);
 
-   const auto CP_bsmumu   = (coeffs[3] - coeffs[2])/2. / normalization / mb;
-   const auto CPp_bsmumu  = (coeffs[1] - coeffs[0])/2. / normalization / mb;
+   const auto CP_bsmumu   = (coeffs[3] - coeffs[2])/(2.*mb*normalization);
+   const auto CPp_bsmumu  = (coeffs[1] - coeffs[0])/(2.*mb*normalization);
 
    // TODO(all): Where are sigma-sigma operators?
 

--- a/templates/observables/br_d_l_to_d_l.hpp.in
+++ b/templates/observables/br_d_l_to_d_l.hpp.in
@@ -1,0 +1,38 @@
+// ====================================================================
+// This file is part of FlexibleSUSY.
+//
+// FlexibleSUSY is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// FlexibleSUSY is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with FlexibleSUSY.  If not, see
+// <http://www.gnu.org/licenses/>.
+// ====================================================================
+
+/**
+ * @file @ModelName@_@filename@.hpp
+ *
+ * This file was generated at @DateAndTime@ with FlexibleSUSY
+ * @FlexibleSUSYVersion@ and SARAH @SARAHVersion@ .
+ */
+
+#ifndef @ModelName@_@include_guard@_H
+#define @ModelName@_@include_guard@_H
+#include "lowe.h"
+
+namespace flexiblesusy {
+namespace @namespace@ {
+
+@calculate_prototypes@
+
+} // namespace @namespace@
+} // namespace flexiblesusy
+
+#endif


### PR DESCRIPTION
Enable by default calculation of b-physics Wilson coefficients in CKM models.

Output
```
Block FWCOEF Q= 1.00000000E+03
     0305     4322   99   2     1.60628823E-11   # D_L
     0305     4422   99   2     7.44375247E-10   # D_R
 03051313     3131   99   2    -6.46478433E-23   # S_LL
 03051313     3132   99   2     6.30559932E-19   # S_LR
 03051313     3231   99   2     2.90620327E-17   # S_RL
 03051313     3232   99   2    -2.97938275E-21   # S_RR
 03051313     4141   99   2    -1.65011849E-12   # V_LL
 03051313     4142   99   2    -1.62133753E-12   # V_LR
 03051313     4241   99   2    -6.83908395E-13   # V_RL
 03051313     4242   99   2    -6.83914060E-13   # V_RR
 03051313     4343   99   2    -1.61626345E-23   # T_LL
 03051313     4444   99   2    -7.44876574E-22   # T_RR
```
follows the [Flavour Les Houches Accord](https://arxiv.org/abs/1008.0762). Additionaly, we create a json input to [flavio](https://arxiv.org/abs/1810.08132) (named `WC_<model>.json`).