### PR TITLE
fix SMHighScale model warning

### DIFF
--- a/sarah/SM2/particles.m
+++ b/sarah/SM2/particles.m
@@ -70,6 +70,7 @@ ParticleDefinitions[GaugeES] = {
                  PDG.IX ->{0},
                  Width -> {0}, 
                  Mass -> {0},
+                 ElectricCharge->1,
                  LaTeX -> {"H^+","H^-"},
                  OutputName -> {"Hp","Hm"}
                  }},                                                   


### PR DESCRIPTION
SARAH is confussed about the charge of `Hp`
```
Vertex::ChargeViolating: 
   Non-zero result for {Ah, Hp, conj[VWp]}
     vertex which violates charge. (This might just be a problem with
     simplifying the vertex, but could also point towards a mistake in the
     implementation.)

Vertex::ChargeViolating: 
   Non-zero result for {Ah, conj[Hp], VWp}
     vertex which violates charge. (This might just be a problem with
     simplifying the vertex, but could also point towards a mistake in the
     implementation.)

Vertex::ChargeViolating: 
   Non-zero result for {hh, Hp, conj[VWp]}
     vertex which violates charge. (This might just be a problem with
     simplifying the vertex, but could also point towards a mistake in the
     implementation.)

General::stop: Further output of Vertex::ChargeViolating
```