### PR TITLE
fix tests broken when FA/FC is disabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -280,35 +280,6 @@ jobs:
           FLEXIBLESUSY_LOOP_LIBRARY=3 make -j2 execute-compiled-tests execute-shell-tests
           make clean-test-log
 
-      - name: Testing pack-SM-src
-        if: ${{ matrix.PART == 2 }}
-        env:
-          CXXCOMPILER: ${{ matrix.CXXCOMPILER }}
-        run: |
-          make pack-SM-src
-          rm -rf models/SM
-          tar -xf SM.tar.gz
-          ./configure \
-            --with-cxx=$CXXCOMPILER \
-            --with-models=SM \
-            --with-loop-libraries=collier,looptools \
-            --with-looptools-incdir=$FS_DEPENDENCIES_DIR/LoopTools/include \
-            --with-looptools-libdir=$FS_DEPENDENCIES_DIR/LoopTools/lib64 \
-            --with-collier-incdir=/fs_dependencies/gcc/COLLIER/include \
-            --with-collier-libdir=/fs_dependencies/gcc/COLLIER/lib \
-            --disable-meta \
-            --enable-feynarts \
-            --enable-formcalc \
-            --with-optional-modules=test
-          make -j2
-          make -j2 execute-meta-tests
-          make -j2 alltest
-          for i in {0..3}
-          do
-            FLEXIBLESUSY_LOOP_LIBRARY=$i make -j2 execute-compiled-tests execute-shell-tests
-            make clean-test-log
-          done
-
       - name: Testing without FormCalc
         if: ${{ matrix.PART == 2 }}
         env:
@@ -378,6 +349,50 @@ jobs:
             --disable-feynarts \
             --disable-formcalc \
             --enable-librarylink
+          make -j2
+          make -j2 execute-meta-tests
+          make -j2 alltest
+          for i in {0..3}
+          do
+            FLEXIBLESUSY_LOOP_LIBRARY=$i make -j2 execute-compiled-tests execute-shell-tests
+            make clean-test-log
+          done
+
+      - name: Testing pack-SM-src
+        if: ${{ matrix.PART == 2 }}
+        env:
+          CXXCOMPILER: ${{ matrix.CXXCOMPILER }}
+        run: |
+          rm -rf models/SM
+          ./createmodel --name=SM
+          ./configure \
+            --with-cxx=$CXXCOMPILER \
+            --with-models=SM \
+            --with-loop-libraries=collier,looptools \
+            --with-looptools-incdir=$FS_DEPENDENCIES_DIR/LoopTools/include \
+            --with-looptools-libdir=$FS_DEPENDENCIES_DIR/LoopTools/lib64 \
+            --with-collier-incdir=/fs_dependencies/gcc/COLLIER/include \
+            --with-collier-libdir=/fs_dependencies/gcc/COLLIER/lib \
+            --with-optional-modules=test \
+            --enable-feynarts \
+            --enable-formcalc \
+            --disable-compile
+          make -j2
+          make pack-SM-src
+          rm -rf models/SM
+          tar -xf SM.tar.gz
+          ./configure \
+            --with-cxx=$CXXCOMPILER \
+            --with-models=SM \
+            --with-loop-libraries=collier,looptools \
+            --with-looptools-incdir=$FS_DEPENDENCIES_DIR/LoopTools/include \
+            --with-looptools-libdir=$FS_DEPENDENCIES_DIR/LoopTools/lib64 \
+            --with-collier-incdir=/fs_dependencies/gcc/COLLIER/include \
+            --with-collier-libdir=/fs_dependencies/gcc/COLLIER/lib \
+            --with-optional-modules=test \
+            --enable-feynarts \
+            --enable-formcalc \
+            --disable-meta
           make -j2
           make -j2 execute-meta-tests
           make -j2 alltest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,6 +220,8 @@ jobs:
             --with-tsil-incdir=$FS_DEPENDENCIES_DIR/tsil \
             --with-tsil-libdir=$FS_DEPENDENCIES_DIR/tsil \
             --with-optional-modules=test \
+            --enable-feynarts \
+            --enable-formcalc \
             --enable-librarylink
           make showbuild
 
@@ -295,7 +297,87 @@ jobs:
             --with-collier-incdir=/fs_dependencies/gcc/COLLIER/include \
             --with-collier-libdir=/fs_dependencies/gcc/COLLIER/lib \
             --disable-meta \
+            --enable-feynarts \
+            --enable-formcalc \
             --with-optional-modules=test
+          make -j2
+          make -j2 execute-meta-tests
+          make -j2 alltest
+          for i in {0..3}
+          do
+            FLEXIBLESUSY_LOOP_LIBRARY=$i make -j2 execute-compiled-tests execute-shell-tests
+            make clean-test-log
+          done
+
+      - name: Testing without FormCalc
+        if: ${{ matrix.PART == 2 }}
+        env:
+          CXXCOMPILER: ${{ matrix.CXXCOMPILER }}
+        run: |
+          ./configure \
+            --with-cxx=$CXXCOMPILER \
+            --with-models=SM,MRSSM2 \
+            --with-loop-libraries=collier,looptools \
+            --with-looptools-incdir=$FS_DEPENDENCIES_DIR/LoopTools/include \
+            --with-looptools-libdir=$FS_DEPENDENCIES_DIR/LoopTools/lib64 \
+            --with-collier-incdir=/fs_dependencies/gcc/COLLIER/include \
+            --with-collier-libdir=/fs_dependencies/gcc/COLLIER/lib \
+            --enable-higgstools \
+            --with-higgstools-incdir=$FS_DEPENDENCIES_DIR/HiggsTools/include \
+            --with-higgstools-libdir=$FS_DEPENDENCIES_DIR/HiggsTools/lib64 \
+            --enable-lilith \
+            --with-lilith=/fs_dependencies/Lilith \
+            --enable-himalaya \
+            --with-himalaya-incdir=$FS_DEPENDENCIES_DIR/Himalaya/include \
+            --with-himalaya-libdir=$FS_DEPENDENCIES_DIR/Himalaya/lib64 \
+            --enable-gm2calc \
+            --with-gm2calc-incdir=$FS_DEPENDENCIES_DIR/GM2Calc/include \
+            --with-gm2calc-libdir=$FS_DEPENDENCIES_DIR/GM2Calc/lib64 \
+            --with-tsil-incdir=$FS_DEPENDENCIES_DIR/tsil \
+            --with-tsil-libdir=$FS_DEPENDENCIES_DIR/tsil \
+            --with-optional-modules=test \
+            --enable-feynarts \
+            --disable-formcalc \
+            --enable-librarylink
+          make -j2
+          make -j2 execute-meta-tests
+          make -j2 alltest
+          for i in {0..3}
+          do
+            FLEXIBLESUSY_LOOP_LIBRARY=$i make -j2 execute-compiled-tests execute-shell-tests
+            make clean-test-log
+          done
+
+      - name: Testing without Feynarts and FormCalc
+        if: ${{ matrix.PART == 2 }}
+        env:
+          CXXCOMPILER: ${{ matrix.CXXCOMPILER }}
+        run: |
+          ./configure \
+            --with-cxx=$CXXCOMPILER \
+            --with-models=SM,MRSSM2 \
+            --with-loop-libraries=collier,looptools \
+            --with-looptools-incdir=$FS_DEPENDENCIES_DIR/LoopTools/include \
+            --with-looptools-libdir=$FS_DEPENDENCIES_DIR/LoopTools/lib64 \
+            --with-collier-incdir=/fs_dependencies/gcc/COLLIER/include \
+            --with-collier-libdir=/fs_dependencies/gcc/COLLIER/lib \
+            --enable-higgstools \
+            --with-higgstools-incdir=$FS_DEPENDENCIES_DIR/HiggsTools/include \
+            --with-higgstools-libdir=$FS_DEPENDENCIES_DIR/HiggsTools/lib64 \
+            --enable-lilith \
+            --with-lilith=/fs_dependencies/Lilith \
+            --enable-himalaya \
+            --with-himalaya-incdir=$FS_DEPENDENCIES_DIR/Himalaya/include \
+            --with-himalaya-libdir=$FS_DEPENDENCIES_DIR/Himalaya/lib64 \
+            --enable-gm2calc \
+            --with-gm2calc-incdir=$FS_DEPENDENCIES_DIR/GM2Calc/include \
+            --with-gm2calc-libdir=$FS_DEPENDENCIES_DIR/GM2Calc/lib64 \
+            --with-tsil-incdir=$FS_DEPENDENCIES_DIR/tsil \
+            --with-tsil-libdir=$FS_DEPENDENCIES_DIR/tsil \
+            --with-optional-modules=test \
+            --disable-feynarts \
+            --disable-formcalc \
+            --enable-librarylink
           make -j2
           make -j2 execute-meta-tests
           make -j2 alltest

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -134,4 +134,10 @@
 /* Enable statements for addons */
 @DEFINE_ENABLE_ADDONS@
 
+/* Enable FeynArts */
+@DEFINE_ENABLE_FEYNARTS@
+
+/* Enable FormCalc */
+@DEFINE_ENABLE_FORMCALC@
+
 #endif

--- a/configure
+++ b/configure
@@ -3974,6 +3974,8 @@ if test "x${enable_meta}" = "xyes"; then
     check_feynarts
     check_formcalc
 else
+    if [ ! "${enable_feynarts}" = "no" ]; then DEFINE_ENABLE_FEYNARTS="#define ENABLE_FEYNARTS 1"; fi
+    if [ ! "${enable_formcalc}" = "no" ]; then DEFINE_ENABLE_FORMCALC="#define ENABLE_FORMCALC 1"; fi
     enable_feynarts=no
     enable_formcalc=no
 fi

--- a/configure
+++ b/configure
@@ -168,6 +168,8 @@ DEFINE_ENABLE_LATTICE_SOLVER="#undef ENABLE_LATTICE_SOLVER"
 DEFINE_ENABLE_SEMI_ANALYTIC_SOLVER="#undef ENABLE_SEMI_ANALYTIC_SOLVER"
 DEFINE_ENABLE_SHOOTING_SOLVER="#undef ENABLE_SHOOTING_SOLVER"
 DEFINE_ENABLE_ADDONS=""
+DEFINE_ENABLE_FEYNARTS="#undef ENABLE_FEYNARTS"
+DEFINE_ENABLE_FORMCALC="#undef ENABLE_FORMCALC"
 
 boost_lib_dir=""
 boost_inc_dir=""
@@ -3047,6 +3049,7 @@ EOF
             if version_at_least $FEYNARTS_VERSION "${required_feynarts_version}"; then
                 enable_feynarts="yes"
                 result "ok (version ${FEYNARTS_VERSION})"
+                DEFINE_ENABLE_FEYNARTS="#define ENABLE_FEYNARTS 1"
             elif test "x$enable_feynarts" = "xautomatic"; then
                 enable_feynarts="no"
                 result "ok (version ${FEYNARTS_VERSION} too old -- support disabled)"
@@ -3123,6 +3126,7 @@ EOF
 
             if version_at_least $FORMCALC_VERSION "${required_formcalc_version}"; then
                 result "ok (version ${FORMCALC_VERSION})"
+                DEFINE_ENABLE_FORMCALC="#define ENABLE_FORMCALC 1"
             elif test "x$enable_formcalc" = "xautomatic"; then
                 enable_formcalc="no"
                 result "ok (version ${FORMCALC_VERSION} too old -- support disabled)"
@@ -4116,6 +4120,8 @@ sed -e "s|@FLEXIBLESUSY_VERSION@|$FLEXIBLESUSY_VERSION|" \
     -e "s|@DEFINE_ENABLE_SEMI_ANALYTIC_SOLVER@|$DEFINE_ENABLE_SEMI_ANALYTIC_SOLVER|" \
     -e "s|@DEFINE_ENABLE_SHOOTING_SOLVER@|$DEFINE_ENABLE_SHOOTING_SOLVER|" \
     -e "s|@DEFINE_ENABLE_ADDONS@|$DEFINE_ENABLE_ADDONS|"       \
+    -e "s|@DEFINE_ENABLE_FEYNARTS@|$DEFINE_ENABLE_FEYNARTS|"       \
+    -e "s|@DEFINE_ENABLE_FORMCALC@|$DEFINE_ENABLE_FORMCALC|"       \
     -e 's|@n@|\
 |g' \
     < $CONFIGHDR_TMPL > $CONFIGHDR

--- a/test/test_SM_observable_problems.cpp
+++ b/test/test_SM_observable_problems.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE( test_non_perturbative_running )
 
    setup_SM_const(sm, input);
 
-#if(defined ENABLE_FEYNARTS && defined ENABLE_FORMCALC)
+#if defined(ENABLE_FEYNARTS) && defined(ENABLE_FORMCALC)
    flexiblesusy::LToLConversion_settings ltolconversion_settings;
    const auto obs = flexiblesusy::calculate_observables(sm, qedqcd, ltolconversion_settings, physical_input, settings, scale);
 #else

--- a/test/test_SM_observable_problems.cpp
+++ b/test/test_SM_observable_problems.cpp
@@ -12,6 +12,7 @@
 #include "SM_input_parameters.hpp"
 #include "SM_observables.hpp"
 #include "observables/l_to_l_conversion/settings.hpp"
+#include "config.h"
 
 
 BOOST_AUTO_TEST_CASE( test_non_perturbative_running )
@@ -21,12 +22,17 @@ BOOST_AUTO_TEST_CASE( test_non_perturbative_running )
    flexiblesusy::SM_input_parameters input;
    flexiblesusy::SM_mass_eigenstates sm;
    flexiblesusy::Spectrum_generator_settings settings;
-   flexiblesusy::LToLConversion_settings ltolconversion_settings;
    const double scale = 0.0;
 
    setup_SM_const(sm, input);
 
+#if(defined ENABLE_FEYNARTS && defined ENABLE_FORMCALC)
+   flexiblesusy::LToLConversion_settings ltolconversion_settings;
    const auto obs = flexiblesusy::calculate_observables(sm, qedqcd, ltolconversion_settings, physical_input, settings, scale);
+#else
+   const auto obs = flexiblesusy::calculate_observables(sm, qedqcd, physical_input, settings, scale);
+#endif
+
    const auto op = obs.problems;
 
    // BOOST_CHECK(op.have_problem());


### PR DESCRIPTION
The signature of `calculate_observables` changes depending on whether FeynArts/FormCalc is enabled. There was a weird interplay between `--disable-meta` and FeynArts/FormCalc. I had to fix that too. I've also added tests with `--disable-feynars` and `--disable-formcalc`.