### PR TITLE
fix p-value calculation

### DIFF
--- a/meta/FSMathLink.m
+++ b/meta/FSMathLink.m
@@ -346,7 +346,7 @@ FillDecaysSLHAData[] :=
        "if (flexibledecay_settings.get(FlexibleDecay_settings::call_higgstools)) {\n" <>
           TextFormatting`IndentText[
              "const SignalResult& hs = get_higgssignals_output();\n" <>
-             "slha_io.set_hs_or_lilith(\"HIGGSSIGNALS\", hs.ndof, hs.chi2BSM, hs.chi2SM, hs.mhRef, hs.pval);\n"
+             "slha_io.set_hs_or_lilith(\"HIGGSSIGNALS\", hs.ndof, hs.chi2BSM, hs.chi2SM, hs.mhRef, hs.pval1d, hs.pval2d);\n"
           ] <>
        "}\n" <>
        "if (flexibledecay_settings.get(FlexibleDecay_settings::call_lilith)) {\n" <>

--- a/meta/FlexibleSUSY.m
+++ b/meta/FlexibleSUSY.m
@@ -2828,7 +2828,7 @@ if (show_decays && flexibledecay_settings.get(FlexibleDecay_settings::calculate_
    if (flexibledecay_settings.get(FlexibleDecay_settings::call_higgstools)) {
       if (hs.has_value()) {
          SignalResult hs_ = hs.value();
-         slha_io.set_hs_or_lilith(\"HIGGSSIGNALS\", hs_.ndof, hs_.chi2BSM, hs_.chi2SM, hs_.mhRef, hs_.pval);
+         slha_io.set_hs_or_lilith(\"HIGGSSIGNALS\", hs_.ndof, hs_.chi2BSM, hs_.chi2SM, hs_.mhRef, hs_.pval1d, hs_.pval2d);
       }
       if (higgsbounds_v.size() > 0) {
          slha_io.set_higgsbounds(higgsbounds_v);
@@ -2837,7 +2837,7 @@ if (show_decays && flexibledecay_settings.get(FlexibleDecay_settings::calculate_
 #endif
 #ifdef ENABLE_LILITH
    if (flexibledecay_settings.get(FlexibleDecay_settings::call_lilith) && lilith.has_value()) {
-      slha_io.set_hs_or_lilith(\"LILITH\", lilith.value().ndof, lilith.value().chi2BSM, lilith.value().chi2SM, lilith.value().mhRef, lilith.value().pval);
+      slha_io.set_hs_or_lilith(\"LILITH\", lilith.value().ndof, lilith.value().chi2BSM, lilith.value().chi2SM, lilith.value().mhRef, lilith.value().pval1d, lilith.value().pval2d);
    }
 #endif
 }";

--- a/src/decays/experimental_constraints.cpp
+++ b/src/decays/experimental_constraints.cpp
@@ -233,8 +233,8 @@ void set_sm_lambda_to_match_bsm_mh(standard_model::Standard_model& sm, double ma
 }
 } // anonymous
 
-double chi2_to_pval(double chi2BSM, double chi2SM) {
-   boost::math::chi_squared dist(2);
+double chi2_to_pval(double chi2BSM, double chi2SM, int d) {
+   boost::math::chi_squared dist(d);
    const double pval = chi2BSM<=chi2SM ? 1 : boost::math::cdf(complement(dist, chi2BSM-chi2SM));
    return pval;
 }
@@ -394,8 +394,9 @@ std::tuple<std::optional<SignalResult>, std::vector<std::tuple<int, double, doub
       const double hs_chisq = signals(pred);
       const double mhSMref = physical_input.get(Physical_input::mh_pole);
       const double smChi2 = minChi2SM_hs(mhSMref, higgssignals_dataset);
-      const double pvalue = chi2_to_pval(hs_chisq, smChi2);
-      hs_return = {signals.observableCount(), mhSMref, hs_chisq, smChi2, pvalue};
+      const double pvalue1d = chi2_to_pval(hs_chisq, smChi2, 1);
+      const double pvalue2d = chi2_to_pval(hs_chisq, smChi2, 2);
+      hs_return = {signals.observableCount(), mhSMref, hs_chisq, smChi2, pvalue1d, pvalue2d};
    }
    else if (higgssignals_dataset.empty()) {
       WARNING("Warning: no HiggsSignals database provided");
@@ -499,8 +500,9 @@ std::optional<SignalResult> call_lilith(
 
     Py_Finalize();
 
-    const double pvalue = chi2_to_pval(my_likelihood, sm_likelihood);
-    const SignalResult res {exp_ndf, mhSMref, my_likelihood, sm_likelihood, pvalue};
+    const double pvalue1d = chi2_to_pval(my_likelihood, sm_likelihood, 2);
+    const double pvalue2d = chi2_to_pval(my_likelihood, sm_likelihood, 1);
+    const SignalResult res {exp_ndf, mhSMref, my_likelihood, sm_likelihood, pvalue1d, pvalue2d};
 
     return res;
 }

--- a/src/decays/experimental_constraints.hpp
+++ b/src/decays/experimental_constraints.hpp
@@ -55,10 +55,11 @@ struct SignalResult {
    double chi2BSM {};
    // SM chi2 for Physical_input::mh_pole
    double chi2SM {};
-   double pval {};
+   double pval1d {};
+   double pval2d {};
 };
 
-double chi2_to_pval(double /* chi2BSM */, double /* chi2SM */);
+double chi2_to_pval(double /* chi2BSM */, double /* chi2SM */, int /*dim*/);
 
 #ifdef ENABLE_HIGGSTOOLS
 std::tuple<std::optional<SignalResult>, std::vector<std::tuple<int, double, double, std::string>>> call_higgstools(

--- a/src/slha_io.cpp
+++ b/src/slha_io.cpp
@@ -1025,7 +1025,7 @@ void SLHA_io::set_matrix_imag(const std::string& name, const std::complex<double
    set_block(detail::format_matrix_imag(block_head(name, scale), a, symbol, rows, cols));
 }
 
-void SLHA_io::set_hs_or_lilith(std::string const& block_name, const std::size_t ndof, const double chi2, const double chi2SMmin, const double mhSM, const double pval)
+void SLHA_io::set_hs_or_lilith(std::string const& block_name, const std::size_t ndof, const double chi2, const double chi2SMmin, const double mhSM, const double pval1d, const double pval2d)
 {
    std::ostringstream ss;
 
@@ -1034,7 +1034,8 @@ void SLHA_io::set_hs_or_lilith(std::string const& block_name, const std::size_t 
    ss << FORMAT_ELEMENT(2, chi2, "𝜒²");
    ss << FORMAT_ELEMENT(3, chi2SMmin, "SM 𝜒² for mh = " + std::to_string(mhSM) + " GeV");
    // SLHA doesn't print nicely numbers with 3 digit exponent
-   ss << FORMAT_ELEMENT(4, pval > 1e-99 ? pval : 0., "p-value");
+   ss << FORMAT_ELEMENT(4, pval1d > 1e-99 ? pval1d : 0., "p-value (1d)");
+   ss << FORMAT_ELEMENT(5, pval2d > 1e-99 ? pval2d : 0., "p-value (2d)");
 
    set_block(ss);
 }

--- a/src/slha_io.hpp
+++ b/src/slha_io.hpp
@@ -148,7 +148,7 @@ public:
    void set_block(const std::string&, const Eigen::MatrixBase<Derived>&, const std::string&, double scale = 0.);
    template <class Derived>
    void set_block_imag(const std::string&, const Eigen::MatrixBase<Derived>&, const std::string&, double scale = 0.);
-   void set_hs_or_lilith(std::string const& /* block name */, std::size_t /* n.d.o.f. */, double /* chi2 */, double /* min chi2 in the SM */, double /* SM mh for which SM chi2 was calculated */, double /* p-value */);
+   void set_hs_or_lilith(std::string const& /* block name */, std::size_t /* n.d.o.f. */, double /* chi2 */, double /* min chi2 in the SM */, double /* SM mh for which SM chi2 was calculated */, double /* p-value 1d */, double /* p-value 2d */);
    void set_higgsbounds(std::vector<std::tuple<int, double, double, std::string>> const&);
    void set_effectivecouplings_block(const std::vector<std::tuple<int, int, int, double, std::string>>&);
    void set_normalized_effectivecouplings_block(EffectiveCoupling_list const&);

--- a/templates/librarylink.cpp.in
+++ b/templates/librarylink.cpp.in
@@ -784,7 +784,8 @@ void Model_data::put_higgstools_results(MLINK link, std::optional<SignalResult> 
       MLPutRuleTo(link, static_cast<int>(hs_.ndof), "ndof");
       MLPutRuleTo(link, hs_.chi2BSM, "chi2");
       MLPutRuleTo(link, hs_.chi2SM, "chi2SM");
-      MLPutRuleTo(link, hs_.pval, "pval");
+      MLPutRuleTo(link, hs_.pval1d, "pval1d");
+      MLPutRuleTo(link, hs_.pval2d, "pval2d");
    }
    else {
       MLPutFunction(link, "List", 0);

--- a/templates/slha_io.cpp.in
+++ b/templates/slha_io.cpp.in
@@ -494,9 +494,9 @@ void @ModelName@_slha_io::set_imnormalized_effectivecouplings_block(const Effect
 @setDecaysFunctions@
 @fillDecaysDataFunctions@
 
-void @ModelName@_slha_io::set_hs_or_lilith(std::string const& block_name, const int ndof, const double chi2, const double chi2SMmin, const double mhSM, const double pval)
+void @ModelName@_slha_io::set_hs_or_lilith(std::string const& block_name, const int ndof, const double chi2, const double chi2SMmin, const double mhSM, const double pval1d, const double pval2d)
 {
-   slha_io.set_hs_or_lilith(block_name, ndof, chi2, chi2SMmin, mhSM, pval);
+   slha_io.set_hs_or_lilith(block_name, ndof, chi2, chi2SMmin, mhSM, pval1d, pval2d);
 }
 
 void @ModelName@_slha_io::set_higgsbounds(std::vector<std::tuple<int, double, double, std::string>> const& hb)

--- a/templates/slha_io.hpp.in
+++ b/templates/slha_io.hpp.in
@@ -84,7 +84,7 @@ public:
    void set_dcinfo(const std::vector<std::string>&, const std::vector<std::string>&);
 @setDecaysPrototypes@
    void set_extra(const @ModelName@_slha&, const @ModelName@_scales&, const @ModelName@_observables&, const flexiblesusy::Spectrum_generator_settings&);
-   void set_hs_or_lilith(std::string const& /* block name */, int /* n.d.o.f. */, double /* chi2 */, double /* min SM chi2 */, double /* mh for which SM chi2 was calculated */, double);
+   void set_hs_or_lilith(std::string const& /* block name */, int /* n.d.o.f. */, double /* chi2 */, double /* min SM chi2 */, double /* mh for which SM chi2 was calculated */, double /*pval 1d*/, double /*pval 2d*/);
    void set_higgsbounds(std::vector<std::tuple<int, double, double, std::string>> const&);
    void set_effectivecouplings_block(const std::vector<std::tuple<int, int, int, double, std::string>>& effCouplings);
    void set_normalized_effectivecouplings_block(const EffectiveCoupling_list&);


### PR DESCRIPTION
This PR tweaks the calculation of the p-value from the $\chi^2$ reported by HiggsTools and Lilith in response to the referee's comment. We will now provide the p-value for 1 and 2d scans
```
Block HIGGSSIGNALS
     1     1.59000000E+02   # number of degrees of freedom
     2     2.38190045E+02   # 𝜒²
     3     1.52548868E+02   # SM 𝜒² for mh = 125.090000 GeV
     4     2.15735989E-20   # p-value (1d)
     5     2.53078234E-19   # p-value (2d)
```